### PR TITLE
test: wait for resume daemon before cleanup

### DIFF
--- a/tests/e2e/resume-detach-daemon.test.js
+++ b/tests/e2e/resume-detach-daemon.test.js
@@ -489,6 +489,11 @@ describe('e2e: resume --detach daemon handoff', function () {
       return cluster?.state === 'stopped' || cluster?.state === 'killed' ? cluster : null;
     }, 30000);
 
+    const winnerPidMatch = /Daemon PID: (\d+)/.exec(winners[0].stdout);
+    assert.ok(winnerPidMatch, `winner should report its daemon PID, got:\n${winners[0].stdout}`);
+    const winnerPid = Number(winnerPidMatch[1]);
+    await pollUntil(() => !isPidAlive(winnerPid), 10000, 50);
+
     fs.rmSync(issueDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

- wait for the winning `resume --detach` daemon PID to exit after durable cluster completion
- keep E2E teardown from deleting the isolated home while that daemon can still write under `.zeroshot`
- preserve the existing assertion that exactly one daemon wins the concurrent resume claim

## Root cause

PR #863 exposed an `ENOTEMPTY` failure in the test's `afterEach` cleanup. The test waited for `clusters.json` to reach `stopped`, but that is a durable cluster-state boundary, not proof that the detached daemon process has finished its shutdown writes. Teardown could therefore race the daemon inside `.zeroshot`.

This change waits on the daemon PID already reported by the winning resume command, so teardown starts only after the process boundary is terminal.

## Verification

- exact race case: 5 consecutive post-fix passes
- `mocha tests/e2e/resume-detach-daemon.test.js`: 4 passing
- ESLint: no errors (one pre-existing max-lines warning)
- Prettier and TypeScript checks pass