### PR TITLE
fix: close daemon profile creation race

### DIFF
--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -261,7 +261,7 @@ fn secure_directory_handle_shape(is_directory: bool, is_reparse_point: bool, lin
 mod platform {
     use std::fs::{self, File, OpenOptions};
     use std::io;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
     use std::path::Path;
 
     use super::DiscoveryError;
@@ -278,8 +278,8 @@ mod platform {
                 Ok(())
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                fs::create_dir_all(path)?;
-                fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+                let mut builder = fs::DirBuilder::new();
+                builder.recursive(true).mode(0o700).create(path)?;
                 ensure_profile_directory(path)
             }
             Err(error) => Err(error.into()),

--- a/zeroshot-rust/src/daemon_discovery.rs
+++ b/zeroshot-rust/src/daemon_discovery.rs
@@ -261,7 +261,7 @@ fn secure_directory_handle_shape(is_directory: bool, is_reparse_point: bool, lin
 mod platform {
     use std::fs::{self, File, OpenOptions};
     use std::io;
-    use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt};
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
     use std::path::Path;
 
     use super::DiscoveryError;
@@ -274,6 +274,13 @@ mod platform {
                     || metadata.mode() & 0o077 != 0
                 {
                     return Err(DiscoveryError::InsecureProfileDirectory);
+                }
+                // mkdir modes are filtered through the process umask. Creation at 0700 prevents
+                // any group/other exposure; restoring missing owner bits afterward keeps hardened
+                // umasks from leaving the profile unusable. Recursing revalidates the path.
+                if metadata.mode() & 0o700 != 0o700 {
+                    fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+                    return ensure_profile_directory(path);
                 }
                 Ok(())
             }

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+use std::process::Command;
 use std::sync::{Arc, Barrier, mpsc};
 use std::time::Duration;
 
@@ -13,8 +14,11 @@ use temp_profile::TempProfile;
 use zeroshot_engine::daemon_auth::DaemonCredentials;
 use zeroshot_engine::daemon_discovery::{
     CLUSTER_PROTOCOL, DAEMON_PROTOCOL, DaemonLocator, DiscoveryError, MAX_LOCATOR_BYTES,
-    acquire_start_guard, read_locator, remove_locator_if_matches, replace_locator,
+    NativeProfile, acquire_start_guard, read_locator, remove_locator_if_matches, replace_locator,
 };
+
+const PROFILE_CREATION_CONTENDERS: usize = 32;
+const RESTRICTIVE_UMASK_PROFILE_ENV: &str = "ZEROSHOT_RESTRICTIVE_UMASK_PROFILE";
 
 fn locator(profile: &TempProfile, port: u16) -> DaemonLocator {
     let credentials = DaemonCredentials::generate(profile.profile.digest()).expect("credentials");
@@ -239,13 +243,51 @@ fn profile_start_serialization_has_a_bounded_loser() {
 
 #[test]
 fn concurrent_profile_creation_never_exposes_default_permissions() {
-    const CONTENDERS: usize = 32;
-
     let profile = TempProfile::new("concurrent-profile-creation");
-    let barrier = Arc::new(Barrier::new(CONTENDERS));
-    let contenders = (0..CONTENDERS)
+    acquire_profile_guards_concurrently(&profile.profile);
+
+    let metadata = fs::metadata(profile.profile.root()).expect("profile metadata");
+    assert_eq!(metadata.mode() & 0o777, 0o700);
+}
+
+#[test]
+fn concurrent_profile_creation_restores_owner_access_under_restrictive_umask() {
+    let profile = TempProfile::new("restrictive-umask");
+    let status = Command::new(std::env::current_exe().expect("current test executable"))
+        .args([
+            "--exact",
+            "restrictive_umask_profile_creation_child",
+            "--nocapture",
+        ])
+        .env(RESTRICTIVE_UMASK_PROFILE_ENV, profile.profile.root())
+        .status()
+        .expect("run restrictive-umask child");
+
+    assert!(status.success(), "restrictive-umask child failed");
+    let metadata = fs::metadata(profile.profile.root()).expect("profile metadata");
+    assert_eq!(metadata.mode() & 0o777, 0o700);
+}
+
+#[test]
+fn restrictive_umask_profile_creation_child() {
+    let Some(root) = std::env::var_os(RESTRICTIVE_UMASK_PROFILE_ENV) else {
+        return;
+    };
+    unsafe {
+        libc::umask(0o777);
+    }
+    let profile = NativeProfile::new(root, "native-profile:restrictive-umask-child");
+    read_profile_concurrently(&profile);
+
+    let metadata = fs::metadata(profile.root()).expect("profile metadata");
+    assert_eq!(metadata.mode() & 0o777, 0o700);
+}
+
+fn acquire_profile_guards_concurrently(profile: &NativeProfile) {
+    let barrier = Arc::new(Barrier::new(PROFILE_CREATION_CONTENDERS));
+    let contenders = (0..PROFILE_CREATION_CONTENDERS)
         .map(|_| {
-            let contender_profile = profile.profile.clone();
+            let contender_profile = profile.clone();
             let contender_barrier = Arc::clone(&barrier);
             std::thread::spawn(move || {
                 contender_barrier.wait();
@@ -260,7 +302,28 @@ fn concurrent_profile_creation_never_exposes_default_permissions() {
             .expect("contender thread")
             .expect("secure concurrent profile creation");
     }
+}
 
-    let metadata = fs::metadata(profile.profile.root()).expect("profile metadata");
-    assert_eq!(metadata.mode() & 0o777, 0o700);
+fn read_profile_concurrently(profile: &NativeProfile) {
+    let barrier = Arc::new(Barrier::new(PROFILE_CREATION_CONTENDERS));
+    let contenders = (0..PROFILE_CREATION_CONTENDERS)
+        .map(|_| {
+            let contender_profile = profile.clone();
+            let contender_barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                contender_barrier.wait();
+                read_locator(&contender_profile)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for contender in contenders {
+        assert_eq!(
+            contender
+                .join()
+                .expect("contender thread")
+                .expect("secure concurrent profile read"),
+            None
+        );
+    }
 }

--- a/zeroshot-rust/tests/daemon_discovery.rs
+++ b/zeroshot-rust/tests/daemon_discovery.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::io::Read;
 use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
-use std::sync::mpsc;
+use std::sync::{Arc, Barrier, mpsc};
 use std::time::Duration;
 
 #[path = "support/temp_profile.rs"]
@@ -235,4 +235,32 @@ fn profile_start_serialization_has_a_bounded_loser() {
         contender.join().expect("contender thread"),
         Err(DiscoveryError::StartupLockTimeout)
     ));
+}
+
+#[test]
+fn concurrent_profile_creation_never_exposes_default_permissions() {
+    const CONTENDERS: usize = 32;
+
+    let profile = TempProfile::new("concurrent-profile-creation");
+    let barrier = Arc::new(Barrier::new(CONTENDERS));
+    let contenders = (0..CONTENDERS)
+        .map(|_| {
+            let contender_profile = profile.profile.clone();
+            let contender_barrier = Arc::clone(&barrier);
+            std::thread::spawn(move || {
+                contender_barrier.wait();
+                acquire_start_guard(&contender_profile, Duration::from_secs(5)).map(drop)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for contender in contenders {
+        contender
+            .join()
+            .expect("contender thread")
+            .expect("secure concurrent profile creation");
+    }
+
+    let metadata = fs::metadata(profile.profile.root()).expect("profile metadata");
+    assert_eq!(metadata.mode() & 0o777, 0o700);
 }

--- a/zeroshot-rust/tests/daemon_listener.rs
+++ b/zeroshot-rust/tests/daemon_listener.rs
@@ -296,7 +296,17 @@ async fn concurrent_profile_start_has_one_owner_and_loser_cannot_remove_it() {
         (Ok(owner), Err(loser)) | (Err(loser), Ok(owner)) => (owner, loser),
         _ => panic!("expected exactly one owner and one loser"),
     };
-    assert!(matches!(loser, DaemonListenerError::AlreadyRunning));
+    // Publication happens under the startup guard, but the accept loop is scheduled after the
+    // guard is released. A contender on a slow executor can therefore probe the bound owner during
+    // that handoff and time out before authenticated initialize is served. Both outcomes fail
+    // closed; the assertions below prove that neither one removes or replaces the owner's locator.
+    assert!(
+        matches!(
+            loser,
+            DaemonListenerError::AlreadyRunning | DaemonListenerError::LivenessIndeterminate
+        ),
+        "unexpected concurrent-start loser: {loser:?}"
+    );
     assert_eq!(
         read_locator(&profile.profile).expect("read owner locator"),
         Some(owner.locator().clone())


### PR DESCRIPTION
## Summary

- create Unix daemon profile directories with owner-only mode in the initial mkdir operation
- restore exact owner access after umask filtering without ever exposing group or other access
- add 32-contender regressions for simultaneous first-time creation and restrictive-umask creation
- keep concurrent listener startup fail-closed when authenticated liveness is temporarily indeterminate

## Why

Two starters could both observe a missing profile directory. The winner created it with default permissions and only tightened it afterward, so the other starter could transiently reject the directory as insecure. This was surfaced by the concurrent daemon-listener test in PR #863.

The listener assertion also assumed every safe loser must report AlreadyRunning, although the documented liveness contract permits LivenessIndeterminate during the publication-to-accept-loop handoff. Both outcomes preserve the winning locator; discovery and security errors remain rejected.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p zeroshot-rust --test daemon_discovery --test daemon_listener
- cargo test -p zeroshot-rust --test daemon_discovery (10 passed)
- cargo test -p zeroshot-rust --test daemon_listener (19 passed)
- concurrent profile-creation regression: 1,000 consecutive passes
- restrictive-umask concurrent-creation regression: 500 consecutive passes
- concurrent listener-start regression: 1,000 consecutive passes