### PR TITLE
docs: add zeroshot task spec and review skills

### DIFF
--- a/skills/zeroshot-task-review/SKILL.md
+++ b/skills/zeroshot-task-review/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: zeroshot-task-review
+description: Use when a Zeroshot task or plan file has been drafted and needs checking before `zeroshot run`, when reviewing someone else's Zeroshot spec, or when deciding whether a task file is ready to hand to Zeroshot.
+license: MIT
+metadata:
+  author: the-open-engine
+  version: '1.0'
+---
+
+# Reviewing Zeroshot Task Specs
+
+## Overview
+
+A Zeroshot spec fails in ways that only show up an hour into a run: a criterion
+nothing can check, an unstated risk that bought the cheap workflow, a deferred
+clause the executor echoes into the code. All of them are visible in the file
+beforehand.
+
+**Core principle: audit for what a verifier cannot check, not for what reads well.**
+Fluent prose is the common failure mode — a spec can be well written and still
+give the verifier nothing to run.
+
+For the authoring rules and the mechanics behind each check, use the
+`zeroshot-task-spec` skill.
+
+## Your Output
+
+A review is three parts, in this order:
+
+1. **Verdict** — `READY` or `NOT READY`, on the first line, with the count of blocking issues.
+2. **Blocking issues** — one line each: the location, what is wrong, and the concrete replacement text. No issue without a replacement.
+3. **Rewritten acceptance criteria table** — the full corrected table, ready to paste.
+
+Skip parts 2 and 3 when the verdict is `READY`. Do not restate the spec, do not
+summarize what the task does, and do not list what the spec got right.
+
+## Blocking Checks
+
+Each of these makes a run measurably worse. Any one of them means `NOT READY`.
+
+**Acceptance criteria**
+
+- Fewer than three criteria.
+- No criterion marked `MUST`.
+- Any criterion whose verification is not a runnable command, a URL, or a named test. "Verify it works", "confirm the behavior", "manual check", "inspect the diff", and "review the code" all qualify as unrunnable. A source-content check becomes runnable as a `grep`.
+- Criteria written as `- [ ]` checkboxes rather than a table with id, criterion, verification, and priority columns.
+- A criterion that restates the title instead of naming an observable outcome.
+
+**Classification**
+
+- No sentence stating file count, whether behavior changes, and whether the change contacts authentication logic, billing calculations, secrets, destructive database operations, production deployment, or PII.
+- The change modifies one of those six but the spec does not say so. This is the highest-cost defect: the conductor's tie-break runs toward the cheaper workflow, so the risky change gets routine verification.
+- A bug fix whose title and opening describe a proposed solution rather than the observed failure, which routes it away from the debug workflow.
+
+**Language**
+
+- Contains `TODO`, `FIXME`, placeholder, "phase 2", "future work", "will add tests later", or "deferred". Validators reject these on sight, and the executor tends to echo them into the code.
+- Steps that wait, deploy, monitor over time, or observe production. Nothing in a single session can complete them.
+
+**Mechanics**
+
+- Filename is not `.md` or `.markdown`. The path string becomes the task body instead of the file.
+- No `# H1`, or more than one plausible title heading. The first H1 becomes the cluster and PR title.
+- The document is wrapped in a ` ```markdown ` fence.
+- A `zeroshot-command-proofs` block whose JSON does not parse, or whose entries are missing `id`, `profile`, or `command`. Malformed JSON aborts the run before any agent starts.
+
+**Verification**
+
+- No named test or build command from the repo. Validators discover commands from repo context files; naming them removes the guess.
+- Backwards compatibility is implied by the requirements but never stated as an explicit exception. Validators reject compatibility shims by default.
+
+## Advisory Checks
+
+Worth raising, not worth blocking on: a criterion that constrains implementation
+rather than outcome; pasted ticket discussion carrying reversals or dead ends; a
+"notes for the verifier" section that only restates the criteria table; an
+expensive command run by several agents with no command proof declared.
+
+## Worked Example
+
+Draft criterion:
+
+> - [ ] Rotation handling works correctly
+
+Review output:
+
+```
+NOT READY — 3 blocking issues
+
+- Acceptance criteria: checkbox list, no id/verification/priority columns. Replace with the table below.
+- AC "rotation handling works correctly": no runnable verification and restates the title. Split into rename-rotation and truncate-rotation criteria, each naming its test.
+- Scope line missing: add "Touches 2 files in the follow code path, changes user-visible behavior, does not modify authentication logic, billing math, secrets, destructive database operations, production deployment, or PII."
+
+| ID | Criterion | Verification | Priority |
+|----|-----------|--------------|----------|
+| AC1 | After `mv app.log app.log.1` and recreating `app.log`, new lines appear in output | `pytest tests/test_follow.py::test_reopen_on_rename` passes | MUST |
+| AC2 | After in-place truncation, reading resumes from offset 0 with no re-emitted lines | `pytest tests/test_follow.py::test_resume_on_truncate` passes | MUST |
+| AC3 | Lines written immediately before rotation are emitted before reopening | `pytest tests/test_follow.py::test_no_tail_loss` passes | MUST |
+| AC4 | Handle count does not grow across ten rotations | `pytest tests/test_follow.py::test_no_fd_leak` passes | SHOULD |
+```
+
+## Common Mistakes in Reviews
+
+**Approving fluent prose.** Long, well-organized specs fail these checks as
+often as terse ones. Read the verification column, not the paragraphs.
+
+**Flagging an issue without a replacement.** "AC2 is vague" sends the work back
+without moving it. Write the corrected criterion.
+
+**Rewriting the whole spec.** The author chose the scope and approach. Fix what
+blocks verification and leave the rest.
+
+**Missing the unstated risk.** Read the required behavior and ask what it
+actually modifies, then check whether the spec says so. A spec can be internally
+consistent and still under-declare its risk.

--- a/skills/zeroshot-task-spec/SKILL.md
+++ b/skills/zeroshot-task-spec/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: zeroshot-task-spec
+description: Use when writing a task or plan file for Zeroshot to execute, converting an issue, ticket, or idea into work for `zeroshot run`, or when a previous Zeroshot run produced incomplete work, was rejected by its validators, or picked the wrong workflow size for the change.
+license: MIT
+metadata:
+  author: the-open-engine
+  version: '1.0'
+---
+
+# Writing Zeroshot Task Specs
+
+## Overview
+
+Zeroshot runs an executor–verifier loop: an executor implements the change, and
+an **independent** verifier that never saw the executor's reasoning decides
+whether it holds. A spec is good when that verifier can reach a verdict without
+asking anyone a question.
+
+**Core principle: every claim in the spec must be checkable by running something.**
+The verifier cannot ask you what you meant. Prose it cannot execute is prose it
+must guess at, and a guessing verifier either rubber-stamps or rejects at random.
+
+## What Zeroshot Actually Parses
+
+Most of the file is read by a language model, not a parser. Three things are
+mechanical, and getting them wrong fails before any agent runs:
+
+| Mechanic       | Rule                                                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------- |
+| File extension | Only `.md` and `.markdown` are read as files. `task.txt` or `task` makes the **literal path string** the task body. |
+| Title          | The first `# H1` anywhere in the file becomes the cluster title and the PR title. No H1 → the filename is used.     |
+| Command proofs | A fenced ` ```zeroshot-command-proofs ` block is parsed as JSON. It is the only structured hook in the document.    |
+
+Everything else — headings, ordering, emphasis — exists to steer the model.
+There is no schema, no front matter, and no required section. The entire file
+arrives as one blob, so structure earns its place by being legible, not by being
+recognized.
+
+Never wrap the document in a ` ```markdown ` fence. The file _is_ markdown.
+
+## The Recipe
+
+A Zeroshot spec is these seven parts, in this order:
+
+1. **`# H1` title** — imperative, specific, PR-title quality. `# Add --json output to logtail status`, not `# JSON support`.
+2. **Scope line** — one sentence naming file count, whether behavior changes, and whether the change touches a high-risk category. This is the classification anchor; see below.
+3. **Context** — what exists today and why it is wrong. Two to five sentences. Point at the subsystem; do not paste code.
+4. **Required behavior** — numbered, observable statements. Each one is something a verifier can trigger and watch.
+5. **Acceptance criteria table** — the contract. Format below.
+6. **Verification** — the repo's own commands, by name, plus a command-proofs block when the commands are expensive.
+7. **Out of scope** — what the executor must not touch, phrased as present-tense boundaries.
+
+Copy `assets/task-template.md` and fill it in.
+
+## The Classification Anchor
+
+Zeroshot's conductor sizes the workflow from the task text before any work
+starts: how many validators run, which model tier, whether the debug workflow
+loads. Its rubric keys on the _shape of the diff_, and it explicitly discounts
+topic keywords — "refactor the auth module" reads as routine, while "change the
+password comparison" reads as high-risk.
+
+Write one sentence that states the three things it looks for:
+
+> Touches 2 files in the `follow` code path, changes user-visible behavior, and does not modify authentication logic, billing math, secrets, destructive database operations, production deployment, or PII handling.
+
+Also name the work type in the title verb, because a fix routes to a different
+agent graph than an addition:
+
+- **Fix / debug / diagnose** → investigator → fixer → tester
+- **Add / implement / build** → planner → worker → validators
+- **Explain / audit / find** → read-only exploration
+
+When the change genuinely does modify one of those six high-risk categories, say
+so in plain words. The conductor's tie-break bias runs _downward_ toward the
+cheaper workflow, so an unstated risk is an under-verified one.
+
+Full rubric and routing table: `references/classification.md`.
+
+## The Acceptance Criteria Contract
+
+Zeroshot's planner must emit at least three criteria, each carrying an id, the
+criterion, an exact verification step, and a priority. The requirements
+validator then verifies _those_ — so criteria written in that shape survive the
+handoff intact, while a `- [ ]` checklist gets paraphrased first.
+
+Write them as a table:
+
+| ID  | Criterion                                                                     | Verification                                                                         | Priority |
+| --- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | -------- |
+| AC1 | `logtail status --json` emits a single JSON object on stdout and nothing else | `logtail status --json \| python -c "import json,sys; json.load(sys.stdin)"` exits 0 | MUST     |
+| AC2 | Numeric fields are JSON numbers, absent values are `null`                     | `pytest tests/test_status.py::test_json_types` passes                                | MUST     |
+| AC3 | Default `logtail status` output is byte-identical to before                   | `pytest tests/test_status.py::test_table_unchanged` passes                           | MUST     |
+| AC4 | `--json` appears in `logtail status --help`                                   | `logtail status --help \| grep -q -- --json`                                         | SHOULD   |
+
+Rules that make a criterion hold up:
+
+- **Verification is a command, a URL, or a named test.** "Verify it works" is not a verification step; `pytest tests/test_rotation.py::test_reopen_on_rename` is. "Inspect the diff" and "review the code" are not steps either — a human reading is not something the validator can run. When the check really is about source content, make it a search: `grep -rn "timingSafeEqual" src/` returns a hit.
+- **At least one MUST.** `MUST` blocks completion; `SHOULD` and `NICE` do not.
+- **Three minimum.** Fewer and the planner invents the rest, and invented criteria are the ones that get rubber-stamped.
+- **Name tests that do not exist yet.** Writing `AC2 → tests/test_status.py::test_json_types passes` commissions that test and gives the verifier something exact to run.
+- **State the observable, not the implementation.** "Returns 400 with `{error: 'Invalid email format'}`" beats "validates the email properly."
+
+## Making Verification Cheap and Trustworthy
+
+Name the repo's real entry points — `npm test`, `pytest`, `cargo test`, `make check`, whatever the project actually uses. Zeroshot's validators begin by reading the repo's context files to discover these, and reject when they fail.
+
+For commands expensive enough that you do not want each agent paying for them,
+declare a command proof. Each entry becomes a **required handoff gate**: on
+`--pr` and `--ship`, the git-pusher refuses to push until that gate has fresh
+passing evidence.
+
+````
+```zeroshot-command-proofs
+[
+  { "id": "unit-tests", "profile": "node-test", "command": "npm test", "scope": "repo", "description": "Full unit suite" },
+  { "id": "typecheck", "profile": "node-test", "command": "npm run typecheck", "scope": "repo" }
+]
+```
+````
+
+`id`, `profile`, and `command` are all mandatory. Only the first such block in
+the file is read, and malformed JSON aborts the run before any agent starts — so
+if you include one, check that it parses.
+
+Details on gates and evidence: `references/verification.md`.
+
+## Two Defaults Worth Knowing
+
+**Backwards compatibility is rejected unless requested.** Zeroshot's validators
+reject deprecation shims, re-exports, legacy fallbacks, `_unused` parameter
+renames, and feature flags that toggle old versus new behavior. When you want
+the old path kept, say so explicitly and say why:
+
+> The existing `compareTokens` helper stays exported and unchanged; four other modules still call it and migrating them is a separate change.
+
+**Scope is one session.** The executor implements, verifies, and stops. Steps
+that wait, deploy, monitor over time, or observe production are outside what any
+agent can complete, and a spec containing them ends with unfinished work. End at
+"ready to deploy."
+
+## Phrases That Cause Rejection
+
+Zeroshot's validators reject on sight: `TODO`, `FIXME`, placeholder, "phase 2",
+"future work", "will add tests later", "deferred". Writing them into the spec
+invites the executor to echo them back into the code, where they become the
+rejection.
+
+Say the same thing as a boundary instead. Not "phase 2: migrate the other
+callers" but:
+
+> Out of scope: the other four call sites of `compareTokens`. Leave them untouched.
+
+## Quick Reference
+
+| Symptom of a weak spec                            | Fix                                                          |
+| ------------------------------------------------- | ------------------------------------------------------------ |
+| Verifier approved work that does not function     | Acceptance criteria had no runnable verification column      |
+| Run used 2 validators on a security change        | No classification anchor; the risk category was never stated |
+| Executor stopped at 60% with "remaining work"     | Spec contained phased or deferred language                   |
+| Verifier rejected a deliberate compatibility shim | Compatibility was wanted but never stated as an exception    |
+| Task body came out as a file path                 | File was not named `.md`                                     |
+| PR title was `my-task`                            | No `# H1` in the file                                        |
+| Run aborted before any agent started              | Malformed JSON in the command-proofs block                   |
+
+## Common Mistakes
+
+**Pasting the whole ticket.** Issue trackers carry discussion, reversals, and
+dead ends. The executor cannot tell a rejected proposal from the decision. State
+the decision.
+
+**Describing implementation instead of outcome.** "Use a `Map` keyed by inode"
+constrains the executor without giving the verifier anything to check. "Detects
+rotation and resumes within one poll interval" does both.
+
+**Acceptance criteria that restate the title.** `AC1: the --json flag works` is
+the request, not a criterion. What does working look like from outside?
+
+**Silence about the risky part.** The conductor sizes the workflow from what you
+wrote. An unmentioned auth change gets a routine workflow.
+
+**Assuming the verifier read the executor's notes.** It did not. Anything the
+verifier must know belongs in the spec.

--- a/skills/zeroshot-task-spec/assets/task-template.md
+++ b/skills/zeroshot-task-spec/assets/task-template.md
@@ -1,0 +1,60 @@
+# <Imperative title, PR-quality: "Add --json output to logtail status">
+
+<Scope line: file count, behavior change yes/no, and whether the change modifies
+authentication logic, billing calculations, secrets, destructive database
+operations, production deployment, or PII. One sentence.>
+
+## Context
+
+<What exists today and why it is wrong. Two to five sentences. Name the
+subsystem and the entry point; do not paste code. For a bug, lead with the
+observed failure and its trigger, then the expected behavior.>
+
+## Required behavior
+
+1. <Observable statement a verifier can trigger and watch.>
+2. <Another. State outcomes, not implementation choices.>
+3. <Include the edge case that makes this non-trivial.>
+
+## Acceptance criteria
+
+| ID  | Criterion            | Verification                               | Priority |
+| --- | -------------------- | ------------------------------------------ | -------- |
+| AC1 | <Observable outcome> | <Exact command, URL, or `path::test_name`> | MUST     |
+| AC2 | <Observable outcome> | <Exact command>                            | MUST     |
+| AC3 | <Observable outcome> | <Exact command>                            | SHOULD   |
+
+<Minimum three. At least one MUST. Naming a test that does not exist yet
+commissions it.>
+
+## Verification
+
+Run and pass:
+
+```bash
+<the repo's real commands: pytest / npm test / cargo test / make check>
+<the repo's real lint or typecheck command>
+```
+
+```zeroshot-command-proofs
+[
+  { "id": "unit-tests", "profile": "<profile>", "command": "<expensive command>", "scope": "repo", "description": "<what it proves>" }
+]
+```
+
+<Delete the proofs block if no command is expensive enough to cache. If kept,
+verify the JSON parses — malformed JSON aborts the run. Each entry becomes a
+required handoff gate under --pr and --ship.>
+
+## Out of scope
+
+- <Boundary, present tense: "The other four call sites stay untouched.">
+- <Another boundary.>
+
+<If backwards compatibility is wanted, state it here as an explicit exception
+and give the reason — validators reject compatibility shims by default.>
+
+## Notes for the verifier
+
+<Checks beyond the criteria table: what to confirm independently, what a passing
+test suite would not catch. Delete if there is nothing to add.>

--- a/skills/zeroshot-task-spec/references/classification.md
+++ b/skills/zeroshot-task-spec/references/classification.md
@@ -1,0 +1,91 @@
+# How Zeroshot Sizes a Task
+
+Before any work begins, a conductor agent reads the task text and classifies it
+on two dimensions. The result decides which agents load, how many validators
+run, and which model tier they use. Nothing else in the run reconsiders it.
+
+## Complexity
+
+| Value       | Definition in the rubric                                            | Validators         |
+| ----------- | ------------------------------------------------------------------- | ------------------ |
+| `TRIVIAL`   | One file, mechanical change, no behavior change                     | 0                  |
+| `SIMPLE`    | Small change, 1-2 files, low risk                                   | 1                  |
+| `STANDARD`  | Multi-file work or user-visible behavior. **The declared default.** | 2                  |
+| `CRITICAL`  | Directly modifies one of the six categories below                   | Two-stage pipeline |
+| `UNCERTAIN` | Escalates to a stronger conductor                                   | —                  |
+
+The six `CRITICAL` categories, as written in the rubric:
+
+1. Authentication / authorization **logic**
+2. Payment processing / billing **calculations**
+3. Secrets / credentials handling
+4. Destructive database operations (`DROP`, `DELETE`)
+5. Production deployment or live infrastructure
+6. PII processing (not merely displaying it)
+
+The rubric carries an explicit downward bias: when torn between `STANDARD` and
+`CRITICAL`, it picks `STANDARD`, on cost grounds. It also lists false positives
+that stay `STANDARD` — refactoring code that _mentions_ auth or billing, adding
+types to existing structures, cleanup in infra-adjacent files, read-only queries
+against production, tests for auth or billing code, extracting modules, and
+config reorganization.
+
+The distinction is **modifying the logic versus living near it**. A spec that
+says "refactor the auth service into smaller modules" classifies as `STANDARD`.
+A spec that says "change how the session token is compared" classifies as
+`CRITICAL`. If the change really does alter one of the six, name the specific
+operation rather than the subsystem.
+
+## Task Type
+
+| Value     | Meaning                           |
+| --------- | --------------------------------- |
+| `INQUIRY` | Questions, exploration, read-only |
+| `TASK`    | Implement something new           |
+| `DEBUG`   | Fix something broken              |
+
+`DEBUG` at anything above `TRIVIAL` loads a different agent graph entirely —
+investigator, then fixer, then tester — instead of the planner/worker/validator
+shape. Lead a bug report with the failure, not with the proposed fix, so it
+classifies as `DEBUG` rather than as a feature request.
+
+## Routing
+
+| Classification                       | Workflow           |
+| ------------------------------------ | ------------------ |
+| `DEBUG` and not `TRIVIAL`            | `debug-workflow`   |
+| `TRIVIAL`, in PR mode, not `INQUIRY` | `worker-validator` |
+| `TRIVIAL`                            | `single-worker`    |
+| `SIMPLE`                             | `worker-validator` |
+| `STANDARD` or `CRITICAL`             | `full-workflow`    |
+
+Model tier follows complexity: `level1` for `TRIVIAL`, `level3` for the planner
+on `CRITICAL`, `level2` otherwise. Context budget per agent runs 50k tokens at
+`TRIVIAL`, 100k at `SIMPLE` and `STANDARD`, 150k at `CRITICAL`.
+
+## Writing the Anchor
+
+State the three signals the rubric keys on — file count, behavior change, and
+high-risk contact — in one sentence near the top:
+
+> Touches 2 files in the `follow` code path, changes user-visible behavior, and does not modify authentication logic, billing math, secrets, destructive database operations, production deployment, or PII handling.
+
+For a change that does contact a category:
+
+> Modifies the session token comparison in the auth middleware — this is authentication logic, and the change is to the comparison itself, not to surrounding code.
+
+For a small mechanical change, saying so buys a cheaper, faster run:
+
+> Single file, mechanical rename of an internal helper, no behavior change.
+
+## Aiming Deliberately
+
+**To get more verification:** name the specific high-risk operation being
+changed. Vague risk language does not raise the classification; the rubric was
+written to discount it.
+
+**To get less ceremony:** state the file count and that behavior does not
+change. Both are explicit rubric conditions for `TRIVIAL` and `SIMPLE`.
+
+**To reach the debug workflow:** describe the observed failure — the symptom,
+the trigger, the expected behavior — before any hypothesis about the cause.

--- a/skills/zeroshot-task-spec/references/verification.md
+++ b/skills/zeroshot-task-spec/references/verification.md
@@ -1,0 +1,134 @@
+# What Zeroshot's Verifiers Demand
+
+Validators run read-only, in their own sessions, without the executor's
+reasoning. They are instructed to search before claiming something is missing,
+to run commands rather than read them, and to record evidence. A spec earns a
+trustworthy verdict by telling them exactly what to run.
+
+## The Evidence Standard
+
+Every validator returns structured output, and the requirements validator
+records one result per acceptance criterion:
+
+```json
+{
+  "approved": false,
+  "summary": "AC2 fails: numeric fields serialized as strings",
+  "errors": ["AC2: size emitted as \"1024\" not 1024"],
+  "criteriaResults": [
+    {
+      "id": "AC1",
+      "status": "PASS",
+      "evidence": { "command": "logtail status --json | jq .", "exitCode": 0, "output": "{...}" }
+    }
+  ]
+}
+```
+
+`evidence` is required for every `PASS` and `FAIL`, and it must be actual
+command output. `CANNOT_VALIDATE` is reserved for a missing tool, absent
+network, or denied permission — and it is treated as a pass with a warning. A
+criterion whose verification step names no command is a criterion that lands in
+`CANNOT_VALIDATE` and quietly passes.
+
+That is the mechanism behind the core rule: **an acceptance criterion without a
+runnable verification step is an acceptance criterion that cannot fail.**
+
+## What Each Validator Checks
+
+| Validator    | Focus                                           | What satisfies it                                        |
+| ------------ | ----------------------------------------------- | -------------------------------------------------------- |
+| requirements | Every acceptance criterion                      | Per-criterion command output; any failing `MUST` rejects |
+| code         | Logic errors, leaks, duplication, god functions | Reading the diff; grep for repeated patterns             |
+| tester       | Tests actually execute                          | Real test output, not test source                        |
+| security     | Injection, authz, secrets, OWASP                | Repo validation script plus review                       |
+
+The tester validator is explicitly told that reading test code is not
+verification, and that "tests look correct" is unacceptable where "15/15
+passing" is. It discovers the test command from the repo's own context files
+rather than assuming one. Naming the command in the spec removes the guess.
+
+Skipped tests — missing env vars, absent services, no credentials — are recorded
+as warnings, not failures. If a criterion can only be checked with credentials
+the run will not have, it will not actually be checked.
+
+## Generalization and Root Cause
+
+Several validators apply the same two tests to any fix:
+
+- **Generalization.** If the executor fixed one instance of a pattern, they grep
+  for the pattern. More instances left unfixed means rejection.
+- **Root cause.** Workarounds that mask the underlying bug are rejected, as are
+  "restart the service", "clear the cache", "works on my machine", and blaming
+  the test without proof.
+
+For a bug fix, state explicitly whether other instances exist and whether they
+are in scope:
+
+> The same unchecked-rotation pattern appears only in `follow`. `cat` mode reads once and exits, so it is unaffected.
+
+## Command Proofs
+
+A command proof puts a signed, content-addressed cache in front of an expensive
+command so the agents in a run pay for it once instead of each. Declare proofs
+in the spec with a fenced block:
+
+````
+```zeroshot-command-proofs
+[
+  {
+    "id": "unit-tests",
+    "profile": "node-test",
+    "command": "npm test",
+    "scope": "repo",
+    "description": "Full unit suite"
+  }
+]
+```
+````
+
+`id`, `profile`, and `command` are mandatory; entries missing any of them are
+dropped. `scope` and `description` are optional. Only the first block in the
+document is read. Malformed JSON aborts the run before any agent starts.
+
+Agents are then instructed to run `zeroshot cmdproof check <id>` in place of the
+raw command and to treat its exit code as the command's exit code.
+
+Proofs can also live in `<gitRoot>/.zeroshot/settings.json` under
+`ship.commandProofs`. Spec-declared proofs merge on top of configured ones
+rather than replacing them, so a spec can add a gate without disturbing repo
+defaults.
+
+## Required Handoff Gates
+
+Every declared command proof becomes a required quality gate. Under `--pr` and
+`--ship`, the git-pusher refuses to push until each gate has evidence that is
+present, passing, and fresh. It blocks when:
+
+| Condition                                         | Result  |
+| ------------------------------------------------- | ------- |
+| No matching gate reported                         | blocked |
+| `status` is not `PASS`                            | blocked |
+| `evidence.command` missing or empty               | blocked |
+| `evidence.exitCode` is not `0`                    | blocked |
+| `evidence.output` is not a string                 | blocked |
+| Marked `stale: true`                              | blocked |
+| No completion timestamp                           | blocked |
+| Evidence predates the last implementation handoff | blocked |
+
+Gates match on exact `id`, and on `scope` when the requirement declares one. A
+validator that cannot run a gate must report `UNAVAILABLE` and withhold
+approval — an unavailable gate blocks rather than passing.
+
+With no validators and no gates configured, the pusher proceeds unconditionally.
+That combination is worth avoiding on anything headed for a PR.
+
+## Writing for the Verifier
+
+The full spec text reaches every validator, so a section addressed to them
+lands. Use it for the checks that matter beyond the criteria table:
+
+> Independently confirm that `--json` did not leak onto other subcommands, and that the diff touches only the status code path and its tests.
+
+Keep it to genuine verification instructions. Restating the acceptance criteria
+here costs context without adding a check.


### PR DESCRIPTION
Add two Agent Skills (agentskills.io format) that teach coding agents how to write task files Zeroshot can execute and independently verify.

zeroshot-task-spec covers the mechanics that are not documented elsewhere and that silently degrade a run when missed:

- only .md/.markdown are read as files; any other extension makes the literal path string the task body
- the first H1 becomes the cluster title and the PR title
- the zeroshot-command-proofs fenced block is the only machine-parsed hook in a task file, and each entry becomes a fail-closed handoff gate under --pr/--ship
- acceptance criteria shaped {id, criterion, verification, priority} survive the planner handoff intact, while checkbox lists get paraphrased first
- a criterion whose verification is not runnable lands in CANNOT_VALIDATE, which is treated as a pass, so it cannot fail
- the conductor's tie-break bias runs downward, so an unstated risk category buys a cheaper workflow than the change warrants

zeroshot-task-review audits a draft before the run and emits a verdict, blocking issues each paired with replacement text, and a corrected criteria table.

Content is derived from cluster-templates/conductor-bootstrap.json, cluster-templates/base-templates/, src/command-proofs.ts, src/config-router.ts, src/input-helpers.ts and src/agents/git-pusher-template.js rather than from prose docs.

Developed against baseline runs: three agents wrote specs without the skill and produced three different structures, none declaring command proofs, none anchoring classification, and none using the criteria contract. The same scenarios with the skill produced all three consistently.

## Summary

Brief description of changes.

## Related Issues

Fixes #

## Changes Made

-

## Testing

How was this tested?

## Checklist

- [ ] Tests pass (`npm test`)
- [ ] Documentation updated (if needed)
- [ ] Follows commit guidelines
