### PR TITLE
feat(attach): resolve attach endpoints per platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,6 +223,7 @@ src/attach/ring-buffer.js
 src/attach/protocol.js
 src/attach/send-input.js
 src/attach/socket-discovery.js
+src/attach/socket-endpoint.js
 src/attach/attach-client.js
 src/attach/attach-server.js
 src/attach/attach-server-types.js

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -460,6 +460,7 @@ export default [
       'src/attach/protocol.js',
       'src/attach/send-input.js',
       'src/attach/socket-discovery.js',
+      'src/attach/socket-endpoint.js',
       'src/attach/attach-client.js',
       'src/attach/attach-server.js',
       'src/attach/attach-server-types.js',

--- a/src/attach/attach-client.ts
+++ b/src/attach/attach-client.ts
@@ -1,9 +1,9 @@
 /** Terminal client for attaching to a running task or agent. */
 import crypto from 'node:crypto';
 import { EventEmitter } from 'node:events';
-import net from 'node:net';
 
 import protocol from './protocol';
+import { connectToEndpoint, type EndpointSocket } from './socket-endpoint';
 
 const CTRL_B = '\x02';
 const CTRL_C = '\x03';
@@ -60,7 +60,7 @@ class AttachClient extends EventEmitter {
   readonly stdin: AttachInput;
   readonly stdout: AttachOutput;
   readonly clientId: string;
-  socket: net.Socket | null = null;
+  socket: EndpointSocket | null = null;
   decoder = new protocol.MessageDecoder();
   connected = false;
   wasRawMode: boolean | undefined | null = null;
@@ -90,7 +90,7 @@ class AttachClient extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      const socket = net.createConnection(this.socketPath);
+      const socket = connectToEndpoint(this.socketPath);
       this.socket = socket;
 
       socket.on('connect', () => {

--- a/src/attach/attach-server-socket.ts
+++ b/src/attach/attach-server-socket.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import net from 'node:net';
 
+import { IS_WINDOWS, endpointFor, writeEndpointRecord } from './socket-endpoint';
 import type { AttachServerHost } from './attach-server-types';
 
 export function startSocketServer(host: AttachServerHost): Promise<void> {
@@ -8,7 +9,19 @@ export function startSocketServer(host: AttachServerHost): Promise<void> {
     const server = net.createServer((socket) => host._handleClientConnection(socket));
     host.server = server;
     server.on('error', host._onServerError);
-    server.listen(host.socketPath, () => {
+    server.listen(endpointFor(host.socketPath), () => {
+      if (IS_WINDOWS) {
+        // The pipe carries the connection, but discovery and cleanup only see
+        // the record, so a failure here leaves an unreachable server: reject.
+        try {
+          writeEndpointRecord(host.socketPath);
+        } catch (error: unknown) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+        resolve();
+        return;
+      }
       try {
         fs.chmodSync(host.socketPath, 0o600);
       } catch {

--- a/src/attach/send-input.ts
+++ b/src/attach/send-input.ts
@@ -6,9 +6,9 @@
  */
 
 import fs from 'node:fs';
-import net from 'node:net';
 
 import protocol from './protocol';
+import { connectToEndpoint } from './socket-endpoint';
 
 const DEFAULT_TIMEOUT_MS = 1500;
 
@@ -46,7 +46,7 @@ function sendInput(options: SendInputOptions = {}): Promise<SendInputResult> | S
   return new Promise((resolve) => {
     let settled = false;
     let timeout: NodeJS.Timeout | undefined;
-    const socket = net.createConnection(socketPath);
+    const socket = connectToEndpoint(socketPath);
 
     const finish = (result: SendInputResult): void => {
       if (settled) return;

--- a/src/attach/socket-discovery.ts
+++ b/src/attach/socket-discovery.ts
@@ -6,10 +6,10 @@
  */
 
 import fs from 'node:fs';
-import net from 'node:net';
 import path from 'node:path';
 
 import socketPaths from './socket-paths';
+import { connectToEndpoint } from './socket-endpoint';
 
 interface ClustersRegistryModule {
   readClustersFileSync(storageDir: string): unknown;
@@ -83,7 +83,7 @@ function isSocketAlive(socketPath: string): Promise<boolean> {
   }
 
   return new Promise((resolve) => {
-    const socket = net.createConnection(socketPath);
+    const socket = connectToEndpoint(socketPath);
     const timeout = setTimeout(() => {
       socket.destroy();
       resolve(false);

--- a/src/attach/socket-endpoint.ts
+++ b/src/attach/socket-endpoint.ts
@@ -1,0 +1,74 @@
+/**
+ * Attach endpoint resolution.
+ *
+ * On Unix a socket path plays two roles at once: it is the address `net` binds
+ * to, and it is the on-disk record that readdir-based discovery, staleness
+ * cleanup and cluster teardown operate on. The `.sock` node is both.
+ *
+ * Windows has no filesystem-visible Unix domain sockets. Named pipes live in a
+ * separate `\\.\pipe\` namespace that cannot be enumerated, stat-ed or unlinked
+ * through `fs`, so binding a pipe would silently break every discovery and
+ * cleanup path that assumes a file exists.
+ *
+ * So on Windows the two roles are split, and only the address changes:
+ *
+ *   record   - a regular file at the same `.sock` path. Discovery, staleness
+ *              cleanup and directory teardown keep working untouched.
+ *   endpoint - a named pipe derived deterministically from the record path, so
+ *              every process resolves the same name without reading the record
+ *              (no parse step, no read/write race on startup).
+ *
+ * Liveness keeps its existing shape on both platforms: the record says an
+ * endpoint was claimed, a connect attempt says whether anything still serves
+ * it. A dead process leaves a record that fails to connect, which is exactly
+ * the stale-socket case cleanup already handles.
+ */
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+
+const IS_WINDOWS = process.platform === 'win32';
+const PIPE_PREFIX = '\\\\.\\pipe\\';
+const RECORD_MODE = 0o600;
+
+/**
+ * Derive the pipe name for a record path. Windows paths are case-insensitive,
+ * so the key is lowercased to keep two spellings of one path on one pipe.
+ * The digest also keeps the name inside the pipe namespace length limit no
+ * matter how long the record path is.
+ */
+function pipeNameFor(recordPath: string): string {
+  const key = path.resolve(recordPath).toLowerCase();
+  const digest = crypto.createHash('sha256').update(key).digest('hex').slice(0, 32);
+  return `${PIPE_PREFIX}zeroshot-${digest}`;
+}
+
+/** Address to bind or connect for a given record path. */
+export function endpointFor(recordPath: string): string {
+  return IS_WINDOWS ? pipeNameFor(recordPath) : recordPath;
+}
+
+/**
+ * Create the discovery record. No-op on Unix, where binding the socket creates
+ * the node itself. Callers must treat failure as a startup failure: a served
+ * pipe with no record is invisible to `listAttachableTasks`.
+ */
+export function writeEndpointRecord(recordPath: string): void {
+  if (!IS_WINDOWS) return;
+  fs.writeFileSync(recordPath, `${pipeNameFor(recordPath)}\n`, { mode: RECORD_MODE });
+}
+
+export { IS_WINDOWS };
+
+/** Socket type for callers that no longer import `net` directly. */
+export type EndpointSocket = net.Socket;
+
+/**
+ * Connect to the endpoint backing a record path. Callers go through this rather
+ * than `net.createConnection` so an untranslated record path cannot reach the
+ * wire on Windows.
+ */
+export function connectToEndpoint(recordPath: string): EndpointSocket {
+  return net.createConnection(endpointFor(recordPath));
+}

--- a/tests/attach-socket-endpoint.test.js
+++ b/tests/attach-socket-endpoint.test.js
@@ -1,0 +1,115 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const MODULE_PATH = '../src/attach/socket-endpoint';
+
+/** Load socket-endpoint as if running on `platform`. */
+function loadFor(platform) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  delete require.cache[require.resolve(MODULE_PATH)];
+  try {
+    return require(MODULE_PATH);
+  } finally {
+    Object.defineProperty(process, 'platform', descriptor);
+    delete require.cache[require.resolve(MODULE_PATH)];
+  }
+}
+
+describe('attach socket endpoint', function () {
+  describe('on unix', function () {
+    it('binds and connects on the record path itself', function () {
+      const mod = loadFor('linux');
+      const record = '/tmp/zeroshot-1000-abc/steady-spire-84.sock';
+      assert.strictEqual(mod.endpointFor(record), record);
+      assert.strictEqual(mod.IS_WINDOWS, false);
+    });
+
+    it('writes no record, because binding creates the socket node', function () {
+      const mod = loadFor('linux');
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-endpoint-'));
+      const record = path.join(dir, 'task.sock');
+      try {
+        mod.writeEndpointRecord(record);
+        assert.strictEqual(fs.existsSync(record), false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('on windows, addressing', function () {
+    it('maps a record path to a named pipe in the pipe namespace', function () {
+      const mod = loadFor('win32');
+      const endpoint = mod.endpointFor('C:\\Users\\k\\.zeroshot\\sockets\\steady-spire-84.sock');
+      assert.match(endpoint, /^\\\\\.\\pipe\\zeroshot-[0-9a-f]{32}$/);
+      assert.strictEqual(mod.IS_WINDOWS, true);
+    });
+
+    it('resolves the same pipe from every process for one record', function () {
+      const mod = loadFor('win32');
+      const record = 'C:\\Users\\k\\.zeroshot\\sockets\\task.sock';
+      assert.strictEqual(mod.endpointFor(record), mod.endpointFor(record));
+    });
+
+    it('ignores case, so two spellings of one path share a pipe', function () {
+      const mod = loadFor('win32');
+      assert.strictEqual(
+        mod.endpointFor('C:\\Users\\K\\.zeroshot\\sockets\\Task.sock'),
+        mod.endpointFor('c:\\users\\k\\.zeroshot\\sockets\\task.sock')
+      );
+    });
+
+    it('separates distinct records', function () {
+      const mod = loadFor('win32');
+      assert.notStrictEqual(
+        mod.endpointFor('C:\\s\\alpha.sock'),
+        mod.endpointFor('C:\\s\\beta.sock')
+      );
+    });
+
+    it('keeps the pipe name inside the namespace length limit for long records', function () {
+      const mod = loadFor('win32');
+      const deep = `C:\\${'nested\\'.repeat(60)}task.sock`;
+      assert.ok(mod.endpointFor(deep).length < 256);
+    });
+  });
+
+  describe('on windows, discovery record', function () {
+    it('is a regular file that readdir-based listing still matches', function () {
+      const mod = loadFor('win32');
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-endpoint-'));
+      const record = path.join(dir, 'steady-spire-84.sock');
+      try {
+        mod.writeEndpointRecord(record);
+
+        // listAttachableTasks accepts entries that are files ending in .sock.
+        const entry = fs
+          .readdirSync(dir, { withFileTypes: true })
+          .find((candidate) => candidate.name === 'steady-spire-84.sock');
+        assert.ok(entry, 'record must appear in the socket directory');
+        assert.ok(entry.isFile(), 'record must be a regular file so discovery sees it');
+
+        // Cleanup paths unlink the record, so it has to be a removable file.
+        fs.unlinkSync(record);
+        assert.strictEqual(fs.existsSync(record), false);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('records the pipe the server bound, for debugging a live directory', function () {
+      const mod = loadFor('win32');
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeroshot-endpoint-'));
+      const record = path.join(dir, 'task.sock');
+      try {
+        mod.writeEndpointRecord(record);
+        assert.strictEqual(fs.readFileSync(record, 'utf8').trim(), mod.endpointFor(record));
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
Windows native support has been blocked since January by two independent problems (#70). This PR fixes the first one: attach IPC. It does **not** enable Windows — the preflight gate stays in place, because the second blocker is untouched. See *Scope* below.

## The problem

On Unix a socket path plays two roles at once:

- the address `net` binds to, and
- the on-disk record that `listAttachableTasks`, `cleanupStaleSocket`, `listAttachableClusters` and `cleanupClusterSockets` operate on via `readdir` / `existsSync` / `unlink`.

The `.sock` node is both, which is why nothing in discovery has ever needed to know about addressing.

Windows named pipes live in a `\\.\pipe\` namespace that `fs` cannot enumerate, stat or unlink. So the obvious fix — swap the path for a pipe name — silently breaks every discovery and cleanup path at once. That is the part #70's sketch doesn't cover, and it's the reason this isn't a three-line change.

## The approach

Split the two roles behind `src/attach/socket-endpoint.ts`:

| role | Unix | Windows |
| --- | --- | --- |
| record | the `.sock` socket node | a regular file at the same `.sock` path |
| endpoint | that same path | `\\.\pipe\zeroshot-<sha256(path)[0:32]>` |

Discovery, staleness cleanup and cluster teardown are untouched — they still see a file at the path they already look at. `listAttachableTasks` already accepted `entry.isFile()` alongside `entry.isSocket()`, so it matches the record as-is.

The pipe name is **derived** from the record path rather than read out of it, so every process resolves the same name with no parse step and no read/write race at startup. It's lowercased before hashing because Windows paths are case-insensitive, and the digest keeps the name inside the pipe-namespace length limit however deep the record path is.

Liveness keeps its existing shape: the record says an endpoint was claimed, a connect attempt says whether anything still serves it. A dead process leaves a record that fails to connect — exactly the stale-socket case `cleanupStaleSocket` already handles.

The seam also owns the transport. Connect sites call `connectToEndpoint()` rather than `net.createConnection()`, so an untranslated record path cannot reach the wire, and `attach-client` takes its socket type from the seam instead of importing `net` for it.

**Unix behaviour is unchanged by construction:** `endpointFor()` returns the path it was given and `writeEndpointRecord()` is a no-op.

## Scope — what this does not do

Executable resolution (#57, #457) is the other half and is **not** in this PR. `_resolveZeroshotPath()` returns a bare `'zeroshot'` string that is threaded through ~15 `spawn` / `runCommand` sites, and on Windows the npm global is `zeroshot.cmd`, which `spawn()` cannot resolve. `shell: true` is not a safe fix there because task prompts contain spaces and would be re-split into positional args. Doing it properly means a `{command, args}` refactor across `agent-task-executor.js` and `claude-task-runner.js`, which deserves its own review.

So `runPreflight()` still rejects `win32`. Nothing here changes what users can run today; it removes one of the two reasons they can't.

## Verification

- 2934 passing, 12 failing — the same 12 that fail on unmodified `main` in this environment (OMP SDK `darwin/arm64`, opcore-dependent suites). Failure set diffed byte-for-byte against a pristine `origin/main` worktree: identical.
- `tsc --noEmit` clean, `eslint` clean on changed files, opcore pre-commit gate green.
- 9 new unit tests covering both platforms: pipe-namespace shape, determinism, case-insensitivity, distinct records, long-path bounding, and that the record stays a readdir-visible, unlinkable regular file.

**Not verified on Windows.** Nobody on the team runs it, and that is the actual reason this has sat since January rather than any difficulty in the code. The unit tests pin the addressing contract on both platforms, but a real `zeroshot task run` on Windows has not happened. It cannot until #457 lands too. Reviewers should read this as a correct-by-construction seam, not as a tested port.

Refs #70, #63