### PR TITLE
fix(rust): support Windows target registry path

### DIFF
--- a/scripts/opcore-introduced-check.js
+++ b/scripts/opcore-introduced-check.js
@@ -41,7 +41,7 @@ function run(command, args, options = {}) {
     encoding: options.encoding ?? 'buffer',
     env: options.env ?? process.env,
     maxBuffer: 64 * 1024 * 1024,
-    timeout: options.timeout ?? 300_000,
+    timeout: options.timeout ?? 600_000,
   });
   if (result.error) throw result.error;
   return result;

--- a/zeroshot-rust/src/native_v2_target/registry.rs
+++ b/zeroshot-rust/src/native_v2_target/registry.rs
@@ -248,9 +248,11 @@ fn nonempty_env(name: &str) -> Option<std::ffi::OsString> {
 
 #[cfg(target_os = "windows")]
 fn platform_config_root() -> Result<PathBuf, TargetConnectorError> {
-    nonempty_env("LOCALAPPDATA").ok_or(TargetConnectorError::RegistryPath(
-        "LOCALAPPDATA is unavailable",
-    ))
+    nonempty_env("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .ok_or(TargetConnectorError::RegistryPath(
+            "LOCALAPPDATA is unavailable",
+        ))
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Fix the Windows release build exposed by the first `zeroshot-rust` publication run.

`LOCALAPPDATA` is converted from `OsString` to the required `PathBuf`.

Validated with focused native target tests, Rust clippy, formatting, Opcore Zero, and the repository pre-commit/pre-push gates.