### PR TITLE
fix(rust): publish portable native distributions

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -148,14 +148,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             executable: zeroshot-rust
-            c-compiler: cc
-          - target: aarch64-unknown-linux-gnu
+            c-compiler: musl-gcc
+          - target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
             executable: zeroshot-rust
-            c-compiler: cc
+            c-compiler: musl-gcc
           - target: x86_64-apple-darwin
             runner: macos-15-intel
             executable: zeroshot-rust
@@ -196,8 +196,19 @@ jobs:
           toolchain: 1.97.0
           targets: ${{ matrix.target }}
 
+      - name: Install static Linux C toolchain
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          C_COMPILER: ${{ matrix.c-compiler }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes musl-tools
+          command -v "$C_COMPILER"
+          echo "CC=$C_COMPILER" >> "$GITHUB_ENV"
+
       - name: Verify bundled SQLite C toolchain
-        if: runner.os != 'Windows'
+        if: runner.os == 'macOS'
         shell: bash
         env:
           C_COMPILER: ${{ matrix.c-compiler }}
@@ -225,6 +236,15 @@ jobs:
 
       - name: Build standalone Rust release binary
         run: cargo build --release --locked -p zeroshot-rust --bin zeroshot-rust --target ${{ matrix.target }}
+
+      - name: Verify static Linux release binary
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          if readelf --program-headers "$BINARY_PATH" | grep -q INTERP; then
+            echo "::error::Linux release binary has a dynamic interpreter"
+            exit 1
+          fi
 
       - name: Run standalone Rust release binary
         run: node scripts/rust-distribution.js smoke --binary "$BINARY_PATH"
@@ -604,7 +624,7 @@ jobs:
         run: |
           set -euo pipefail
           install_root="$RUNNER_TEMP/zeroshot-rust-shim-install"
-          tarballs=(shim-release/*.tgz)
+          tarballs=(./shim-release/*.tgz)
           [[ "${#tarballs[@]}" -eq 1 ]]
           npm install --ignore-scripts --prefix "$install_root" "${tarballs[0]}"
           package_root="$install_root/node_modules/@the-open-engine/zeroshot-rust"
@@ -633,7 +653,7 @@ jobs:
         if: inputs.action == 'dry-run'
         shell: bash
         run: |
-          npm publish --dry-run --access public shim-release/*.tgz
+          npm publish --dry-run --access public ./shim-release/*.tgz
 
       - name: Upload exact npm shim publication input
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -670,7 +690,7 @@ jobs:
         run: |
           set -euo pipefail
           package="@the-open-engine/zeroshot-rust@$RELEASE_VERSION"
-          tarballs=(shim-release/*.tgz)
+          tarballs=(./shim-release/*.tgz)
           [[ "${#tarballs[@]}" -eq 1 ]]
           local_integrity="$(
             node - "${tarballs[0]}" <<'NODE'
@@ -695,5 +715,5 @@ jobs:
             }
             echo "$package is already published; recovery is complete"
           else
-            npm publish --provenance --access public shim-release/*.tgz
+            npm publish --provenance --access public ./shim-release/*.tgz
           fi

--- a/distribution/zeroshot-rust-targets.json
+++ b/distribution/zeroshot-rust-targets.json
@@ -1,19 +1,19 @@
 [
   {
-    "target": "x86_64-unknown-linux-gnu",
+    "target": "x86_64-unknown-linux-musl",
     "runner": "ubuntu-latest",
     "platform": "linux",
     "arch": "x64",
     "executable": "zeroshot-rust",
-    "cCompiler": "cc"
+    "cCompiler": "musl-gcc"
   },
   {
-    "target": "aarch64-unknown-linux-gnu",
+    "target": "aarch64-unknown-linux-musl",
     "runner": "ubuntu-24.04-arm",
     "platform": "linux",
     "arch": "arm64",
     "executable": "zeroshot-rust",
-    "cCompiler": "cc"
+    "cCompiler": "musl-gcc"
   },
   {
     "target": "x86_64-apple-darwin",

--- a/npm/zeroshot-rust/targets.json
+++ b/npm/zeroshot-rust/targets.json
@@ -2,13 +2,13 @@
   {
     "platform": "linux",
     "arch": "x64",
-    "target": "x86_64-unknown-linux-gnu",
+    "target": "x86_64-unknown-linux-musl",
     "executable": "zeroshot-rust"
   },
   {
     "platform": "linux",
     "arch": "arm64",
-    "target": "aarch64-unknown-linux-gnu",
+    "target": "aarch64-unknown-linux-musl",
     "executable": "zeroshot-rust"
   },
   {

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -565,6 +565,56 @@ function checkScriptInstalls(jobs) {
   }
 }
 
+function checkLinuxCToolchain(job) {
+  const linuxC = findStep(job, 'Install static Linux C toolchain');
+  if (
+    linuxC.if !== "runner.os == 'Linux'" ||
+    linuxC.env?.C_COMPILER !== '${{ matrix.c-compiler }}' ||
+    !linuxC.run?.includes('sudo apt-get install --yes musl-tools') ||
+    !linuxC.run.includes('echo "CC=$C_COMPILER" >> "$GITHUB_ENV"')
+  ) {
+    failIntegrity('Linux release build does not use the matrix-selected static C toolchain');
+  }
+}
+
+function checkMacCToolchain(job) {
+  const macC = findStep(job, 'Verify bundled SQLite C toolchain');
+  if (
+    macC.if !== "runner.os == 'macOS'" ||
+    macC.env?.C_COMPILER !== '${{ matrix.c-compiler }}' ||
+    macC.run?.trim() !== 'command -v "$C_COMPILER"'
+  ) {
+    failIntegrity('macOS bundled-SQLite C compiler setup does not use the matrix mapping');
+  }
+}
+
+function checkWindowsCToolchain(job) {
+  const windowsC = findStep(job, 'Verify bundled SQLite MSVC toolchain');
+  if (
+    windowsC.if !== "runner.os == 'Windows'" ||
+    !windowsC.run?.includes('Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
+  ) {
+    failIntegrity('Windows bundled-SQLite MSVC setup is missing');
+  }
+}
+
+function checkNativeCToolchains(job) {
+  checkLinuxCToolchain(job);
+  checkMacCToolchain(job);
+  checkWindowsCToolchain(job);
+}
+
+function checkStaticLinuxBinary(job) {
+  const step = findStep(job, 'Verify static Linux release binary');
+  if (
+    step.if !== "runner.os == 'Linux'" ||
+    !step.run?.includes('readelf --program-headers "$BINARY_PATH"') ||
+    !step.run.includes('Linux release binary has a dynamic interpreter')
+  ) {
+    failIntegrity('Linux release binary is not verified as statically portable');
+  }
+}
+
 function checkBuildJob(jobs) {
   const job = jobs['rust-binaries'];
   if (!job) failIntegrity('release workflow has no rust-binaries job');
@@ -585,21 +635,7 @@ function checkBuildJob(jobs) {
   ) {
     failIntegrity('Rust target toolchain setup does not install the declared matrix target');
   }
-  const unixC = findStep(job, 'Verify bundled SQLite C toolchain');
-  if (
-    unixC.if !== "runner.os != 'Windows'" ||
-    unixC.env?.C_COMPILER !== '${{ matrix.c-compiler }}' ||
-    unixC.run?.trim() !== 'command -v "$C_COMPILER"'
-  ) {
-    failIntegrity('Unix bundled-SQLite C compiler setup does not use the matrix mapping');
-  }
-  const windowsC = findStep(job, 'Verify bundled SQLite MSVC toolchain');
-  if (
-    windowsC.if !== "runner.os == 'Windows'" ||
-    !windowsC.run?.includes('Microsoft.VisualStudio.Component.VC.Tools.x86.x64')
-  ) {
-    failIntegrity('Windows bundled-SQLite MSVC setup is missing');
-  }
+  checkNativeCToolchains(job);
 
   const stage = findStep(job, 'Stage explicit Rust package version');
   if (
@@ -627,6 +663,7 @@ function checkBuildJob(jobs) {
   ) {
     failIntegrity(`rust-binaries build step must execute exactly: ${exactBuild}`);
   }
+  checkStaticLinuxBinary(job);
   const nativeSmoke = findStep(job, 'Run standalone Rust release binary');
   if (
     nativeSmoke.if !== undefined ||
@@ -805,6 +842,7 @@ function checkPublicationJobs(jobs) {
   ).run;
   if (
     !shimInstall?.includes('npm install --ignore-scripts --prefix "$install_root"') ||
+    !shimInstall.includes('tarballs=(./shim-release/*.tgz)') ||
     !shimInstall.includes('$install_root/node_modules/.bin/zeroshot-rust')
   ) {
     failIntegrity('npm shim input is not installed and invoked from the exact packed tarball');
@@ -812,6 +850,9 @@ function checkPublicationJobs(jobs) {
   const shimDryRun = findStep(shimInput, 'Dry-run npm shim publication');
   if (shimDryRun.if !== "inputs.action == 'dry-run'") {
     failIntegrity('npm shim dry-run must not gate recoverable publication');
+  }
+  if (!shimDryRun.run?.includes('npm publish --dry-run --access public ./shim-release/*.tgz')) {
+    failIntegrity('npm shim dry-run must publish the exact local tarball');
   }
   findStep(shimInput, 'Upload exact npm shim publication input');
 
@@ -826,7 +867,7 @@ function checkPublicationJobs(jobs) {
   if (
     !npmPublish?.includes('npm view "$package" version') ||
     !npmPublish.includes('npm view "$package" dist.integrity') ||
-    !npmPublish.includes('npm publish')
+    !npmPublish.includes('npm publish --provenance --access public ./shim-release/*.tgz')
   ) {
     failIntegrity('npm shim publication is not idempotently recoverable');
   }

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -841,7 +841,9 @@ function checkPublicationJobs(jobs) {
     'Install exact shim tarball against verified release inputs'
   ).run;
   if (
-    !shimInstall?.includes('npm install --ignore-scripts --prefix "$install_root"') ||
+    !shimInstall?.includes(
+      'npm install --ignore-scripts --prefix "$install_root" "${tarballs[0]}"'
+    ) ||
     !shimInstall.includes('tarballs=(./shim-release/*.tgz)') ||
     !shimInstall.includes('$install_root/node_modules/.bin/zeroshot-rust')
   ) {

--- a/tests/unit/rust-distribution.test.js
+++ b/tests/unit/rust-distribution.test.js
@@ -14,8 +14,8 @@ describe('Rust product distribution', function () {
     assert.strictEqual(distribution.rustReleaseTag('1.2.3'), 'zeroshot-rust-v1.2.3');
     assert.strictEqual(distribution.normalizeVersion('zeroshot-rust-v1.2.3'), '1.2.3');
     assert.strictEqual(
-      distribution.archiveName('zeroshot-rust-v1.2.3', 'x86_64-unknown-linux-gnu'),
-      'zeroshot-rust-v1.2.3-x86_64-unknown-linux-gnu.tar.gz'
+      distribution.archiveName('zeroshot-rust-v1.2.3', 'x86_64-unknown-linux-musl'),
+      'zeroshot-rust-v1.2.3-x86_64-unknown-linux-musl.tar.gz'
     );
   });
 
@@ -23,8 +23,8 @@ describe('Rust product distribution', function () {
     assert.deepStrictEqual(
       distribution.targets.map(({ target }) => target),
       [
-        'x86_64-unknown-linux-gnu',
-        'aarch64-unknown-linux-gnu',
+        'x86_64-unknown-linux-musl',
+        'aarch64-unknown-linux-musl',
         'x86_64-apple-darwin',
         'aarch64-apple-darwin',
         'x86_64-pc-windows-msvc',
@@ -93,7 +93,7 @@ describe('Rust product distribution', function () {
 
   it('rejects corrupt archives before extraction', function () {
     const archive = distribution.createArchive(Buffer.from('binary'), 'zeroshot-rust');
-    const filename = distribution.archiveName('1.2.3', 'x86_64-unknown-linux-gnu');
+    const filename = distribution.archiveName('1.2.3', 'x86_64-unknown-linux-musl');
     const manifest = `${'0'.repeat(64)}  ${filename}\n`;
     assert.throws(() => shim.verifyArchive(filename, archive, manifest), /CHECKSUM_MISMATCH/);
   });

--- a/tests/unit/rust-npm-shim.test.js
+++ b/tests/unit/rust-npm-shim.test.js
@@ -14,7 +14,7 @@ function registerShimInstallTests() {
   it('installs only a checksum-verified archive selected for the host', async function () {
     const packageRoot = temporaryDirectory();
     const binary = Buffer.from('standalone native fixture');
-    const target = 'x86_64-unknown-linux-gnu';
+    const target = 'x86_64-unknown-linux-musl';
     const filename = distribution.archiveName('1.2.3', target);
     const archive = distribution.createArchive(binary, 'zeroshot-rust');
     const manifest = Buffer.from(`${distribution.sha256(archive)}  ${filename}\n`);
@@ -53,7 +53,7 @@ function registerShimInstallTests() {
             Promise.resolve(
               url.endsWith('/SHA256SUMS')
                 ? Buffer.from(
-                    `${'0'.repeat(64)}  zeroshot-rust-v1.2.3-x86_64-unknown-linux-gnu.tar.gz\n`
+                    `${'0'.repeat(64)}  zeroshot-rust-v1.2.3-x86_64-unknown-linux-musl.tar.gz\n`
                   )
                 : distribution.createArchive(Buffer.from('untrusted'), 'zeroshot-rust')
             ),

--- a/tests/unit/rust-release-workflow-guards.test.js
+++ b/tests/unit/rust-release-workflow-guards.test.js
@@ -53,6 +53,11 @@ describe('Rust release workflow causal guards', function () {
         /canonical image guard/,
       ],
       [
+        'readelf --program-headers "$BINARY_PATH"',
+        'echo skip-static-linux-check',
+        /statically portable/,
+      ],
+      [
         'run: node scripts/rust-distribution.js publish-assets --tag "$RELEASE_TAG" --dir rust-release',
         'run: gh release upload "$RELEASE_TAG" rust-release/* --clobber',
         /assets are not verified/,
@@ -85,8 +90,25 @@ describe('Rust release workflow causal guards', function () {
       '$install_root/bin/zeroshot-rust',
       /exact packed tarball/
     );
+    rejectsRustMutation(
+      'tarballs=(./shim-release/*.tgz)',
+      'tarballs=(shim-release/*.tgz)',
+      /exact packed tarball/
+    );
+    rejectsRustMutation(
+      'npm publish --dry-run --access public ./shim-release/*.tgz',
+      'npm publish --dry-run --access public shim-release/*.tgz',
+      /exact local tarball/
+    );
+    rejectsRustMutation(
+      'npm publish --provenance --access public ./shim-release/*.tgz',
+      'npm publish --provenance --access public shim-release/*.tgz',
+      /idempotently recoverable/
+    );
   });
+});
 
+describe('Rust and Node release isolation', function () {
   it('keeps the Node semantic-release train free of Rust dependencies', function () {
     const coupled = mutation(
       nodeReleaseWorkflow(),

--- a/tests/unit/rust-release-workflow-guards.test.js
+++ b/tests/unit/rust-release-workflow-guards.test.js
@@ -67,7 +67,9 @@ describe('Rust release workflow causal guards', function () {
       rejectsRustMutation(before, after, error);
     }
   });
+});
 
+describe('Rust npm shim release guards', function () {
   it('keeps dry-run inputs non-publishing and the npm shim independently recoverable', function () {
     rejectsRustMutation('          - dry-run\n', '', /Rust release actions/);
     rejectsRustMutation(
@@ -93,6 +95,11 @@ describe('Rust release workflow causal guards', function () {
     rejectsRustMutation(
       'tarballs=(./shim-release/*.tgz)',
       'tarballs=(shim-release/*.tgz)',
+      /exact packed tarball/
+    );
+    rejectsRustMutation(
+      'npm install --ignore-scripts --prefix "$install_root" "${tarballs[0]}"',
+      'npm install --ignore-scripts --prefix "$install_root" ./npm/zeroshot-rust',
       /exact packed tarball/
     );
     rejectsRustMutation(


### PR DESCRIPTION
Fixes two blockers found by the live 0.1.0 publication journey:

- treat packed npm shim tarballs as local paths
- publish static musl Linux binaries instead of host-glibc-linked binaries
- enforce both properties in the distribution contract

Verified with targeted release tests, repository distribution checks, Opcore/Opcore Zero, and an x86_64 musl release build executed successfully on the glibc 2.34 AWS host where the original archive failed.