### PR TITLE
fix(rust): link ARM64 musl runtime statically

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -206,6 +206,7 @@ jobs:
           sudo apt-get install --yes musl-tools
           command -v "$C_COMPILER"
           echo "CC=$C_COMPILER" >> "$GITHUB_ENV"
+          echo "RUSTFLAGS=-C link-arg=-lgcc" >> "$GITHUB_ENV"
 
       - name: Verify bundled SQLite C toolchain
         if: runner.os == 'macOS'

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -571,7 +571,8 @@ function checkLinuxCToolchain(job) {
     linuxC.if !== "runner.os == 'Linux'" ||
     linuxC.env?.C_COMPILER !== '${{ matrix.c-compiler }}' ||
     !linuxC.run?.includes('sudo apt-get install --yes musl-tools') ||
-    !linuxC.run.includes('echo "CC=$C_COMPILER" >> "$GITHUB_ENV"')
+    !linuxC.run.includes('echo "CC=$C_COMPILER" >> "$GITHUB_ENV"') ||
+    !linuxC.run.includes('echo "RUSTFLAGS=-C link-arg=-lgcc" >> "$GITHUB_ENV"')
   ) {
     failIntegrity('Linux release build does not use the matrix-selected static C toolchain');
   }

--- a/tests/unit/rust-release-workflow-guards.test.js
+++ b/tests/unit/rust-release-workflow-guards.test.js
@@ -58,6 +58,11 @@ describe('Rust release workflow causal guards', function () {
         /statically portable/,
       ],
       [
+        'echo "RUSTFLAGS=-C link-arg=-lgcc" >> "$GITHUB_ENV"',
+        'echo skip-static-gcc-runtime',
+        /static C toolchain/,
+      ],
+      [
         'run: node scripts/rust-distribution.js publish-assets --tag "$RELEASE_TAG" --dir rust-release',
         'run: gh release upload "$RELEASE_TAG" rust-release/* --clobber',
         /assets are not verified/,


### PR DESCRIPTION
## Summary

- link the static GCC runtime in Linux musl release jobs
- guard the release contract against losing the linker flag
- cover the guard with a mutation test

## Why

The first 0.1.1 release attempt exposed an ARM64-only link failure from bundled C code using outline atomics (__aarch64_ldadd4_sync). Rust musl links with -nodefaultlibs, so the static GCC runtime must be explicit.

## Validation

- repository distribution contract check
- targeted workflow guard tests
- formatting, hooks, typecheck, Opcore introduced-change and Opcore Zero gates
- full optimized aarch64-unknown-linux-musl build in an ARM64 container under QEMU
- verified no ELF interpreter and executed the resulting binary successfully