### PR TITLE
fix(rust): publish shim after skipped build jobs

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -665,7 +665,10 @@ jobs:
 
   rust-shim-publish:
     needs: [plan, rust-shim-input]
-    if: inputs.action == 'publish-npm-shim' && needs.rust-shim-input.result == 'success'
+    if: |
+      always() &&
+      inputs.action == 'publish-npm-shim' &&
+      needs.rust-shim-input.result == 'success'
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -861,6 +861,7 @@ function checkPublicationJobs(jobs) {
 
   const shimPublish = jobs['rust-shim-publish'];
   if (
+    !shimPublish.if?.trim().startsWith('always() &&') ||
     !shimPublish.if?.includes("inputs.action == 'publish-npm-shim'") ||
     shimPublish.permissions?.['id-token'] !== 'write'
   ) {

--- a/tests/unit/rust-release-workflow-guards.test.js
+++ b/tests/unit/rust-release-workflow-guards.test.js
@@ -78,8 +78,8 @@ describe('Rust npm shim release guards', function () {
   it('keeps dry-run inputs non-publishing and the npm shim independently recoverable', function () {
     rejectsRustMutation('          - dry-run\n', '', /Rust release actions/);
     rejectsRustMutation(
-      "if: inputs.action == 'publish-npm-shim' && needs.rust-shim-input.result == 'success'",
-      "if: inputs.action == 'release'",
+      '  rust-shim-publish:\n    needs: [plan, rust-shim-input]\n    if: |\n      always() &&\n',
+      '  rust-shim-publish:\n    needs: [plan, rust-shim-input]\n    if: |\n      !always() &&\n',
       /separate OIDC-authorized action/
     );
     rejectsRustMutation(


### PR DESCRIPTION
## Summary

- allow the explicit npm-shim publish job to run after intentionally skipped Rust build jobs
- guard the required GitHub Actions always predicate
- cover the causal gate with a mutation test

## Validation

- reproduced the skipped publish in workflow run 32417882119
- release distribution repository contract
- targeted npm shim workflow guard tests
- formatting, lint, typecheck, Opcore introduced-change and Opcore Zero gates