### PR TITLE
fix(deps): bump better-sqlite3 to ^12.11.1 for Node 26 support

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
         "@oh-my-pi/pi-coding-agent": "17.2.1",
         "ajv": "^8.18.0",
         "ansi-to-html": "^0.7.2",
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.11.1",
         "bun": "1.3.14",
         "chalk": "^4.1.2",
         "commander": "^14.0.2",
@@ -5310,9 +5310,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5320,7 +5320,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@oh-my-pi/pi-coding-agent": "17.2.1",
         "ajv": "^8.18.0",
         "ansi-to-html": "^0.7.2",
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.11.1",
         "bun": "1.3.14",
         "chalk": "^4.1.2",
         "commander": "^14.0.2",
@@ -5310,9 +5310,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5320,7 +5320,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "@oh-my-pi/pi-coding-agent": "17.2.1",
     "ajv": "^8.18.0",
     "ansi-to-html": "^0.7.2",
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.11.1",
     "bun": "1.3.14",
     "chalk": "^4.1.2",
     "commander": "^14.0.2",


### PR DESCRIPTION
## Summary

- Bump `better-sqlite3` from `^12.6.2` to `^12.11.1` in `package.json`.
- Regenerate `npm-shrinkwrap.json`.

Fixes #1039.

## Why

`npm install -g @the-open-engine/zeroshot` fails on Node 26. The shipped `npm-shrinkwrap.json` pinned `better-sqlite3` to `12.6.2`, which has no Node 26 (`v147`) prebuild and whose source uses `v8::PropertyCallbackInfo<T>::This()`, removed in Node 26 V8. `prebuild-install` falls back to `node-gyp rebuild`, which fails.

Two upstream PRs fix this together:

- **WiseLibs/better-sqlite3#1459** — source fix (`HolderV2()`), released in `12.8.0`.
- **WiseLibs/better-sqlite3#1468** — Node 26 prebuilds and engines, released in `12.10.0`.

`^12.10.0` is the minimum. This PR uses `^12.11.1` to also pick up patch fixes.

## Verification

Direct dependency install on Node 26.2.0 (darwin arm64) with the new pin:

```
$ fnm use 26 && npm install better-sqlite3@12.11.1
added 38 packages in 3s
```

No local compile — the `v147` prebuild is used.

Repository install on this branch:

```
$ fnm use 26 && npm install --no-audit --no-fund
added 1102 packages in 28s
```

Before the change, the same command failed with three `no member named 'This'` errors from `node-gyp`.

## Diff

Two files: `package.json` and `npm-shrinkwrap.json`. No source code changes.