### PR TITLE
fix(rust): publish complete distribution in one release

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -4,14 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: Build without publishing, release Rust artifacts and image, or publish the optional npm shim.
+        description: Build without publishing or release the complete Rust distribution.
         required: true
         default: dry-run
         type: choice
         options:
           - dry-run
           - release
-          - publish-npm-shim
       version:
         description: Explicit Rust release version in X.Y.Z form.
         required: true
@@ -96,13 +95,6 @@ jobs:
               exit 1
             }
             tag_exists=true
-          fi
-          if [[ "$RELEASE_ACTION" == "publish-npm-shim" ]]; then
-            [[ "$tag_exists" == "true" ]] || {
-              echo "::error::$release_tag must exist before publishing the npm shim"
-              exit 1
-            }
-            gh release view "$release_tag" >/dev/null
           fi
           if [[ "$tag_exists" == "false" ]]; then
             green_required="$(
@@ -559,13 +551,14 @@ jobs:
         run: node scripts/rust-distribution.js publish-assets --tag "$RELEASE_TAG" --dir rust-release
 
   rust-shim-input:
-    needs: [plan, rust-manifest]
+    needs: [plan, rust-manifest, rust-publish]
     if: |
       always() &&
       needs.plan.result == 'success' &&
+      needs.rust-manifest.result == 'success' &&
       (
-        (inputs.action == 'dry-run' && needs.rust-manifest.result == 'success') ||
-        inputs.action == 'publish-npm-shim'
+        inputs.action == 'dry-run' ||
+        (inputs.action == 'release' && needs.rust-publish.result == 'success')
       )
     runs-on: ubuntu-latest
     permissions:
@@ -598,7 +591,7 @@ jobs:
           path: rust-release
 
       - name: Download published Rust distribution
-        if: inputs.action == 'publish-npm-shim'
+        if: inputs.action == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -664,10 +657,11 @@ jobs:
           if-no-files-found: error
 
   rust-shim-publish:
-    needs: [plan, rust-shim-input]
+    needs: [plan, rust-image-publish, rust-shim-input]
     if: |
       always() &&
-      inputs.action == 'publish-npm-shim' &&
+      inputs.action == 'release' &&
+      needs.rust-image-publish.result == 'success' &&
       needs.rust-shim-input.result == 'success'
     runs-on: ubuntu-latest
     environment: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,9 +206,9 @@ Node and Rust CI lanes are selected by `.github/ci-path-classifier.js`; shared o
 both. Keep the aggregate `required` check stable. Node release analysis and notes must filter every
 Rust-only commit since the last Node tag, not just the triggering commit. Rust releases are manual,
 use an exact `main` commit and explicit version, and publish `zeroshot-rust-vX.Y.Z`, five native
-archives with `SHA256SUMS`, and the Linux AMD64 `zeroshot-rust-target` image. The optional npm shim
-is published separately only after those GitHub assets exist. Rust GitHub Releases are never marked
-repository-wide latest.
+archives with `SHA256SUMS`, and the Linux AMD64 `zeroshot-rust-target` image. The npm shim
+is published by the same release only after the GitHub assets exist and the image passes anonymous
+installation. Rust GitHub Releases are never marked repository-wide latest.
 The published Node bindings are the standalone `@the-open-engine/zeroshot/cluster` and
 `@the-open-engine/zeroshot/hosted-session` subpaths. Hosted-session owns only short-lived access
 renewal and authenticated reconnect over the public cluster client; provider capsule APIs remain
@@ -1274,7 +1274,7 @@ Multiple CI jobs fail → Diagnose each independently.
   Conventional squash titles select patch/minor/major, and Rust-only history is excluded.
 - Zeroshot Rust releases only by explicit `release-rust.yml` dispatch with a version and exact
   `main` commit. Its canonical outputs are GitHub archives/checksums and the Linux AMD64 GHCR image;
-  the npm downloader shim is optional and separately published.
+  the same release finishes by publishing the npm downloader shim.
 - Checked-in versions are deliberately non-authoritative and are staged only in release workspaces.
 - There is no release-promotion PR and no `dev -> main` synchronization step.
 

--- a/docs/zeroshot-rust-distribution.md
+++ b/docs/zeroshot-rust-distribution.md
@@ -3,7 +3,7 @@
 Zeroshot Rust is released independently from the Node product. Its release is an explicit manual
 operation in `release-rust.yml`: the operator supplies an `X.Y.Z` version and an exact commit on
 `main`. `dry-run` builds the same publication inputs without publish authority; `release` publishes
-them. The initial release is `0.1.0`.
+the complete distribution. The initial release is `0.1.0`.
 
 The canonical release consists of:
 
@@ -11,19 +11,20 @@ The canonical release consists of:
 - one native archive per target declared by `distribution/zeroshot-rust-targets.json`, plus a
   complete `SHA256SUMS`;
 - the Linux AMD64 image `ghcr.io/the-open-engine/zeroshot-rust-target`, tagged with the version,
-  full commit SHA, and `latest`.
+  full commit SHA, and `latest`;
+- the `@the-open-engine/zeroshot-rust` npm downloader shim.
 
-The optional `@the-open-engine/zeroshot-rust` npm package is only a downloader shim. Its separate
-`publish-npm-shim` action verifies the already-published checksums and archives, packs the shim, and
-publishes that exact Rust version. Installation selects the host archive and verifies its SHA-256
-before extraction. Unsupported hosts fail instead of building from source or falling back to Node.
+The npm package contains only a downloader shim. The release verifies the published checksums and
+archives, packs the shim, and publishes that exact Rust version after the image passes anonymous
+installation. Installation selects the host archive and verifies its SHA-256 before extraction.
+Unsupported hosts fail instead of building from source or falling back to Node.
 
 Release staging writes the requested version into the temporary Cargo and npm workspaces; it never
-commits versions to `main`. Rerunning the same action with the same version and commit is the
+commits versions to `main`. Rerunning the release with the same version and commit is the
 recovery path. Existing Git tags, release assets, and npm versions fail closed on conflicting
 content. Existing version/SHA images are source-verified and reused as the canonical recovery image;
 missing tags are filled from that image. Historical combined releases remain unchanged. Publishing
-the optional shim requires npm trusted publishing for `release-rust.yml`.
+the shim requires npm trusted publishing for `release-rust.yml`.
 
 GHCR creates a new container package as private. After the first image push, an organization owner
 must set `zeroshot-rust-target` to public. That first workflow run may stop at its anonymous-pull

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -471,6 +471,13 @@ function requireFragments(label, value, fragments) {
   }
 }
 
+function exactCondition(label, expected, actual) {
+  const normalize = (value) => String(value).replace(/\s+/g, ' ').trim();
+  if (normalize(actual) !== normalize(expected)) {
+    failIntegrity(`${label} has changed`);
+  }
+}
+
 function findStep(job, name) {
   const step = job.steps?.find((candidate) => candidate.name === name);
   if (!step) failIntegrity(`job is missing enabled step ${name}`);
@@ -842,15 +849,16 @@ function checkShimInputJob(jobs) {
     ['plan', 'rust-manifest', 'rust-publish'],
     [...(shimInput?.needs || [])].sort()
   );
-  requireFragments(
+  exactCondition(
     'npm shim input is not exercised by dry-run and complete release',
-    shimInput.if,
-    [
-      "inputs.action == 'dry-run'",
-      "inputs.action == 'release'",
-      "needs.rust-manifest.result == 'success'",
-      "needs.rust-publish.result == 'success'",
-    ]
+    `always() &&
+      needs.plan.result == 'success' &&
+      needs.rust-manifest.result == 'success' &&
+      (
+        inputs.action == 'dry-run' ||
+        (inputs.action == 'release' && needs.rust-publish.result == 'success')
+      )`,
+    shimInput.if
   );
   const publishedShimInput = findStep(shimInput, 'Download published Rust distribution');
   if (publishedShimInput.if !== "inputs.action == 'release'") {
@@ -888,14 +896,13 @@ function checkShimPublishJob(jobs) {
     ['plan', 'rust-image-publish', 'rust-shim-input'],
     [...(shimPublish?.needs || [])].sort()
   );
-  requireFragments(
+  exactCondition(
     'npm shim publication is not the final OIDC-authorized release step',
-    shimPublish.if,
-    [
-      "inputs.action == 'release'",
-      "needs.rust-image-publish.result == 'success'",
-      "needs.rust-shim-input.result == 'success'",
-    ]
+    `always() &&
+      inputs.action == 'release' &&
+      needs.rust-image-publish.result == 'success' &&
+      needs.rust-shim-input.result == 'success'`,
+    shimPublish.if
   );
   if (
     !shimPublish.if?.trim().startsWith('always() &&') ||

--- a/scripts/rust-distribution.js
+++ b/scripts/rust-distribution.js
@@ -464,6 +464,13 @@ function exactJson(label, expected, actual) {
   }
 }
 
+function requireFragments(label, value, fragments) {
+  const missing = fragments.filter((fragment) => !value?.includes(fragment));
+  if (missing.length > 0) {
+    failIntegrity(`${label} is missing: ${missing.join(', ')}`);
+  }
+}
+
 function findStep(job, name) {
   const step = job.steps?.find((candidate) => candidate.name === name);
   if (!step) failIntegrity(`job is missing enabled step ${name}`);
@@ -716,11 +723,10 @@ function checkManifestJob(jobs) {
 
 function checkManualInputs(document, jobs) {
   const dispatch = document.on?.workflow_dispatch;
-  exactJson(
-    'Rust release actions',
-    ['dry-run', 'release', 'publish-npm-shim'],
-    dispatch?.inputs?.action?.options
-  );
+  exactJson('Rust release actions', ['dry-run', 'release'], dispatch?.inputs?.action?.options);
+  if (JSON.stringify(document).includes('publish-npm-shim')) {
+    failIntegrity('Rust release retains the removed standalone npm shim action');
+  }
   if (!dispatch.inputs.version?.required || !dispatch.inputs.release_commit?.required) {
     failIntegrity('manual Rust release requires explicit version and commit inputs');
   }
@@ -827,13 +833,28 @@ function checkPublicationJobs(jobs) {
   ) {
     failIntegrity('GitHub Release assets are not verified and uploaded without overwrite');
   }
+}
 
+function checkShimInputJob(jobs) {
   const shimInput = jobs['rust-shim-input'];
-  if (
-    !shimInput.if?.includes("inputs.action == 'dry-run'") ||
-    !shimInput.if.includes("inputs.action == 'publish-npm-shim'")
-  ) {
-    failIntegrity('npm shim input is not exercised by dry-run and explicit shim publication');
+  exactJson(
+    'rust-shim-input dependencies',
+    ['plan', 'rust-manifest', 'rust-publish'],
+    [...(shimInput?.needs || [])].sort()
+  );
+  requireFragments(
+    'npm shim input is not exercised by dry-run and complete release',
+    shimInput.if,
+    [
+      "inputs.action == 'dry-run'",
+      "inputs.action == 'release'",
+      "needs.rust-manifest.result == 'success'",
+      "needs.rust-publish.result == 'success'",
+    ]
+  );
+  const publishedShimInput = findStep(shimInput, 'Download published Rust distribution');
+  if (publishedShimInput.if !== "inputs.action == 'release'") {
+    failIntegrity('release shim input does not come from published GitHub assets');
   }
   findStep(shimInput, 'Verify exact shim distribution inputs');
   findStep(shimInput, 'Pack exact npm shim publication input');
@@ -841,15 +862,15 @@ function checkPublicationJobs(jobs) {
     shimInput,
     'Install exact shim tarball against verified release inputs'
   ).run;
-  if (
-    !shimInstall?.includes(
-      'npm install --ignore-scripts --prefix "$install_root" "${tarballs[0]}"'
-    ) ||
-    !shimInstall.includes('tarballs=(./shim-release/*.tgz)') ||
-    !shimInstall.includes('$install_root/node_modules/.bin/zeroshot-rust')
-  ) {
-    failIntegrity('npm shim input is not installed and invoked from the exact packed tarball');
-  }
+  requireFragments(
+    'npm shim input is not installed and invoked from the exact packed tarball',
+    shimInstall,
+    [
+      'npm install --ignore-scripts --prefix "$install_root" "${tarballs[0]}"',
+      'tarballs=(./shim-release/*.tgz)',
+      '$install_root/node_modules/.bin/zeroshot-rust',
+    ]
+  );
   const shimDryRun = findStep(shimInput, 'Dry-run npm shim publication');
   if (shimDryRun.if !== "inputs.action == 'dry-run'") {
     failIntegrity('npm shim dry-run must not gate recoverable publication');
@@ -858,23 +879,36 @@ function checkPublicationJobs(jobs) {
     failIntegrity('npm shim dry-run must publish the exact local tarball');
   }
   findStep(shimInput, 'Upload exact npm shim publication input');
+}
 
+function checkShimPublishJob(jobs) {
   const shimPublish = jobs['rust-shim-publish'];
+  exactJson(
+    'rust-shim-publish dependencies',
+    ['plan', 'rust-image-publish', 'rust-shim-input'],
+    [...(shimPublish?.needs || [])].sort()
+  );
+  requireFragments(
+    'npm shim publication is not the final OIDC-authorized release step',
+    shimPublish.if,
+    [
+      "inputs.action == 'release'",
+      "needs.rust-image-publish.result == 'success'",
+      "needs.rust-shim-input.result == 'success'",
+    ]
+  );
   if (
     !shimPublish.if?.trim().startsWith('always() &&') ||
-    !shimPublish.if?.includes("inputs.action == 'publish-npm-shim'") ||
     shimPublish.permissions?.['id-token'] !== 'write'
   ) {
-    failIntegrity('npm shim publication is not a separate OIDC-authorized action');
+    failIntegrity('npm shim publication is not the final OIDC-authorized release step');
   }
   const npmPublish = findStep(shimPublish, 'Idempotently publish standalone Rust shim package').run;
-  if (
-    !npmPublish?.includes('npm view "$package" version') ||
-    !npmPublish.includes('npm view "$package" dist.integrity') ||
-    !npmPublish.includes('npm publish --provenance --access public ./shim-release/*.tgz')
-  ) {
-    failIntegrity('npm shim publication is not idempotently recoverable');
-  }
+  requireFragments('npm shim publication is not idempotently recoverable', npmPublish, [
+    'npm view "$package" version',
+    'npm view "$package" dist.integrity',
+    'npm publish --provenance --access public ./shim-release/*.tgz',
+  ]);
 }
 
 function checkNodeReleaseIndependence(document) {
@@ -979,6 +1013,8 @@ function checkRepository(
   checkManualInputs(document, document.jobs);
   checkImageJobs(document.jobs);
   checkPublicationJobs(document.jobs);
+  checkShimInputJob(document.jobs);
+  checkShimPublishJob(document.jobs);
   checkNodeReleaseIndependence(nodeDocument);
   checkShimTargets(shimTargets);
   checkScriptDependencies(packageManifest, packageLock);

--- a/tests/unit/rust-release-workflow-guards.test.js
+++ b/tests/unit/rust-release-workflow-guards.test.js
@@ -75,12 +75,32 @@ describe('Rust release workflow causal guards', function () {
 });
 
 describe('Rust npm shim release guards', function () {
-  it('keeps dry-run inputs non-publishing and the npm shim independently recoverable', function () {
+  it('keeps dry-run non-publishing and finishes releases with a recoverable npm shim', function () {
     rejectsRustMutation('          - dry-run\n', '', /Rust release actions/);
     rejectsRustMutation(
-      '  rust-shim-publish:\n    needs: [plan, rust-shim-input]\n    if: |\n      always() &&\n',
-      '  rust-shim-publish:\n    needs: [plan, rust-shim-input]\n    if: |\n      !always() &&\n',
-      /separate OIDC-authorized action/
+      '  rust-shim-publish:\n    needs: [plan, rust-image-publish, rust-shim-input]\n    if: |\n      always() &&\n',
+      '  rust-shim-publish:\n    needs: [plan, rust-image-publish, rust-shim-input]\n    if: |\n      !always() &&\n',
+      /final OIDC-authorized release step/
+    );
+    rejectsRustMutation(
+      "      needs.rust-image-publish.result == 'success' &&\n",
+      '',
+      /final OIDC-authorized release step/
+    );
+    rejectsRustMutation(
+      "      needs.rust-shim-input.result == 'success'\n",
+      "      needs.rust-shim-input.result == 'failure'\n",
+      /final OIDC-authorized release step/
+    );
+    rejectsRustMutation(
+      "      needs.rust-manifest.result == 'success' &&\n",
+      '',
+      /dry-run and complete release/
+    );
+    rejectsRustMutation(
+      "        if: inputs.action == 'release'\n        env:\n          GH_TOKEN: ${{ github.token }}",
+      "        if: inputs.action == 'dry-run'\n        env:\n          GH_TOKEN: ${{ github.token }}",
+      /published GitHub assets/
     );
     rejectsRustMutation(
       '      contents: read\n    env:\n      RELEASE_COMMIT: ${{ needs.plan.outputs.commit }}',

--- a/tests/unit/rust-release-workflow-guards.test.js
+++ b/tests/unit/rust-release-workflow-guards.test.js
@@ -84,7 +84,7 @@ describe('Rust npm shim release guards', function () {
     );
     rejectsRustMutation(
       "      needs.rust-image-publish.result == 'success' &&\n",
-      '',
+      "      needs.rust-image-publish.result == 'success' ||\n",
       /final OIDC-authorized release step/
     );
     rejectsRustMutation(
@@ -94,7 +94,7 @@ describe('Rust npm shim release guards', function () {
     );
     rejectsRustMutation(
       "      needs.rust-manifest.result == 'success' &&\n",
-      '',
+      "      needs.rust-manifest.result == 'success' ||\n",
       /dry-run and complete release/
     );
     rejectsRustMutation(


### PR DESCRIPTION
## Summary
- replace the standalone npm-shim action with one complete Rust release action
- publish npm only after verified GitHub assets and anonymous image installation
- keep dry-run non-publishing and the release recoverable

## Validation
- full Node suite: 2949 passing, 17 pending; 3 ENOSPC cases rerun serially: 11 passing
- Rust distribution and release isolation suites: 23 passing
- actionlint, typecheck, lint (0 errors), Opcore introduced-change and dependency gates

A branch dry-run of the complete publishing journey will be monitored before merge.