### PR TITLE
fix(rust): clarify runtime config help

### DIFF
--- a/docs/zeroshot-rust-cli.html
+++ b/docs/zeroshot-rust-cli.html
@@ -247,7 +247,7 @@ Options:
           Load the graph&#39;s initial input from this JSON file
 
       --runtime-config &lt;FILE&gt;
-          Load provider, harness, model-size, and node bindings from this JSON file
+          Load the secret-free runtime plan from this JSON file
 
       --target &lt;NAME&gt;
           Run on this named target; if omitted, run locally. Named targets receive GH_TOKEN when set.
@@ -270,7 +270,39 @@ Options:
           Materialize merge delivery for the software-change template
 
   -h, --help
-          Print help (see a summary with &#39;-h&#39;)</code></pre></section>
+          Print help (see a summary with &#39;-h&#39;)
+
+RUNTIME CONFIGURATION
+    The file is secret-free JSON. For example:
+
+      {
+        &quot;harness&quot;: &quot;codex&quot;,
+        &quot;provider&quot;: &quot;openrouter&quot;,
+        &quot;size&quot;: &quot;standard&quot;,
+        &quot;nodes&quot;: {
+          &quot;worker&quot;: {
+            &quot;kind&quot;: &quot;agent&quot;,
+            &quot;model&quot;: &quot;gpt-5.6-sol&quot;,
+            &quot;env&quot;: [&quot;OPENROUTER_API_KEY&quot;]
+          }
+        }
+      }
+
+    Harness/provider pairs:
+      codex: openai or openrouter
+      claude: anthropic or openrouter
+
+    Sizes are tiny, small, standard, and large. Codex models are gpt-5.6, gpt-5.6-sol,
+    gpt-5.6-terra, and gpt-5.6-luna. Claude models are claude-haiku-4-5, claude-sonnet-5,
+    claude-opus-5, and claude-fable-5.
+
+    Every executable graph node needs a same-named binding. Agent bindings require kind and model.
+    Optional fields are effort (low, medium, high, xhigh, or max when supported), sessionScope
+    (execution or node_instance), and env. env lists variable names copied from the submitting
+    process; never put values in this file.
+
+    Use `zeroshot-rust template show TEMPLATE` to inspect node names. With --pr or --ship, omit the
+    template-owned delivery binding.</code></pre></section>
 <section id="zeroshot-rust-list"><h3><code>zeroshot-rust list</code></h3>
 <pre><code>List runs as JSON
 

--- a/docs/zeroshot-rust-cli.md
+++ b/docs/zeroshot-rust-cli.md
@@ -255,7 +255,7 @@ Options:
           Load the graph's initial input from this JSON file
 
       --runtime-config <FILE>
-          Load provider, harness, model-size, and node bindings from this JSON file
+          Load the secret-free runtime plan from this JSON file
 
       --target <NAME>
           Run on this named target; if omitted, run locally. Named targets receive GH_TOKEN when set.
@@ -279,6 +279,38 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
+
+RUNTIME CONFIGURATION
+    The file is secret-free JSON. For example:
+
+      {
+        "harness": "codex",
+        "provider": "openrouter",
+        "size": "standard",
+        "nodes": {
+          "worker": {
+            "kind": "agent",
+            "model": "gpt-5.6-sol",
+            "env": ["OPENROUTER_API_KEY"]
+          }
+        }
+      }
+
+    Harness/provider pairs:
+      codex: openai or openrouter
+      claude: anthropic or openrouter
+
+    Sizes are tiny, small, standard, and large. Codex models are gpt-5.6, gpt-5.6-sol,
+    gpt-5.6-terra, and gpt-5.6-luna. Claude models are claude-haiku-4-5, claude-sonnet-5,
+    claude-opus-5, and claude-fable-5.
+
+    Every executable graph node needs a same-named binding. Agent bindings require kind and model.
+    Optional fields are effort (low, medium, high, xhigh, or max when supported), sessionScope
+    (execution or node_instance), and env. env lists variable names copied from the submitting
+    process; never put values in this file.
+
+    Use `zeroshot-rust template show TEMPLATE` to inspect node names. With --pr or --ship, omit the
+    template-owned delivery binding.
 ```
 
 ### `zeroshot-rust list`

--- a/zeroshot-rust/src/native_v2_cli/parser.rs
+++ b/zeroshot-rust/src/native_v2_cli/parser.rs
@@ -193,6 +193,37 @@ struct TemplateShowArgs {
 #[derive(Debug, Args)]
 #[command(group = ArgGroup::new("graph_source").args(["graph", "template"]).required(true).multiple(false))]
 #[command(group = ArgGroup::new("delivery").args(["pr", "ship"]).multiple(false))]
+#[command(after_long_help = r#"RUNTIME CONFIGURATION
+    The file is secret-free JSON. For example:
+
+      {
+        "harness": "codex",
+        "provider": "openrouter",
+        "size": "standard",
+        "nodes": {
+          "worker": {
+            "kind": "agent",
+            "model": "gpt-5.6-sol",
+            "env": ["OPENROUTER_API_KEY"]
+          }
+        }
+      }
+
+    Harness/provider pairs:
+      codex: openai or openrouter
+      claude: anthropic or openrouter
+
+    Sizes are tiny, small, standard, and large. Codex models are gpt-5.6, gpt-5.6-sol,
+    gpt-5.6-terra, and gpt-5.6-luna. Claude models are claude-haiku-4-5, claude-sonnet-5,
+    claude-opus-5, and claude-fable-5.
+
+    Every executable graph node needs a same-named binding. Agent bindings require kind and model.
+    Optional fields are effort (low, medium, high, xhigh, or max when supported), sessionScope
+    (execution or node_instance), and env. env lists variable names copied from the submitting
+    process; never put values in this file.
+
+    Use `zeroshot-rust template show TEMPLATE` to inspect node names. With --pr or --ship, omit the
+    template-owned delivery binding."#)]
 struct RunArgs {
     /// Human-readable title recorded with the run.
     #[arg(long, value_name = "TITLE")]
@@ -210,7 +241,7 @@ struct RunArgs {
     #[arg(long, value_name = "FILE")]
     input: PathBuf,
 
-    /// Load provider, harness, model-size, and node bindings from this JSON file.
+    /// Load the secret-free runtime plan from this JSON file.
     #[arg(long, value_name = "FILE")]
     runtime_config: PathBuf,
 

--- a/zeroshot-rust/tests/native_v2_cli_help.rs
+++ b/zeroshot-rust/tests/native_v2_cli_help.rs
@@ -1,6 +1,23 @@
 use std::process::{Command, Output};
 
 use openengine_cluster_testkit::assertions::AssertValue;
+use zeroshot_engine::native_v2_admission::{CLAUDE_MODELS, CODEX_MODELS};
+use zeroshot_engine::native_v2_contract::{
+    ClaudeProvider, CodexProvider, ReasoningEffort, RunSize, SessionScope,
+};
+
+macro_rules! exhaustive_values {
+    ($type:ty => [$($variant:path),+ $(,)?]) => {{
+        let values = [$($variant),+];
+        let exhaustive = |value: $type| match value {
+            $($variant => ()),+
+        };
+        for value in values {
+            exhaustive(value);
+        }
+        values
+    }};
+}
 
 const HELP_PATHS: &[&[&str]] = &[
     &[],
@@ -39,6 +56,71 @@ fn help_subcommand_reaches_every_group_and_operational_command() {
             .chain(path.iter().copied())
             .collect::<Vec<_>>();
         assert_help(&arguments, path);
+    }
+}
+
+#[test]
+fn help_explains_runtime_configuration() {
+    let run = successful_stdout(&["run", "--help"]);
+    assert_prose(
+        &run,
+        &[
+            "runtime configuration",
+            r#""harness": "codex""#,
+            r#""provider": "openrouter""#,
+            r#""env": ["openrouter_api_key"]"#,
+            "env lists variable names copied from the submitting process",
+            "never put values in this file",
+            "zeroshot-rust template show template",
+            "omit the template-owned delivery binding",
+        ],
+    );
+
+    let codex_providers = serialized_names(&exhaustive_values!(CodexProvider => [
+        CodexProvider::OpenAi,
+        CodexProvider::OpenRouter,
+    ]));
+    let claude_providers = serialized_names(&exhaustive_values!(ClaudeProvider => [
+        ClaudeProvider::Anthropic,
+        ClaudeProvider::OpenRouter,
+    ]));
+    let sizes = serialized_names(&exhaustive_values!(RunSize => [
+        RunSize::Tiny,
+        RunSize::Small,
+        RunSize::Standard,
+        RunSize::Large,
+    ]));
+    let efforts = serialized_names(&exhaustive_values!(ReasoningEffort => [
+        ReasoningEffort::Low,
+        ReasoningEffort::Medium,
+        ReasoningEffort::High,
+        ReasoningEffort::Xhigh,
+        ReasoningEffort::Max,
+    ]));
+    let session_scopes = serialized_names(&exhaustive_values!(SessionScope => [
+        SessionScope::Execution,
+        SessionScope::NodeInstance,
+    ]));
+    let contract_prose = [
+        format!(
+            "harness/provider pairs: codex: {} claude: {} sizes are {}.",
+            prose_list(codex_providers, "or"),
+            prose_list(claude_providers, "or"),
+            prose_list(sizes, "and")
+        ),
+        format!(
+            "codex models are {}. claude models are {}.",
+            prose_list(CODEX_MODELS.iter().map(|model| model.id.to_owned()), "and"),
+            prose_list(CLAUDE_MODELS.iter().map(|model| model.id.to_owned()), "and")
+        ),
+        format!(
+            "optional fields are effort ({} when supported), sessionscope ({}), and env.",
+            prose_list(efforts, "or"),
+            prose_list(session_scopes, "or")
+        ),
+    ];
+    for expected in &contract_prose {
+        assert_prose(&run, &[expected]);
     }
 }
 
@@ -243,4 +325,27 @@ fn normalized(value: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
         .to_ascii_lowercase()
+}
+
+fn serialized_names<T: serde::Serialize>(values: &[T]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| {
+            serde_json::to_value(value)
+                .assert_value()
+                .as_str()
+                .assert_value()
+                .to_owned()
+        })
+        .collect()
+}
+
+fn prose_list(values: impl IntoIterator<Item = String>, conjunction: &str) -> String {
+    let mut values = values.into_iter().collect::<Vec<_>>();
+    let last = values.pop().assert_value();
+    match values.as_slice() {
+        [] => last,
+        [only] => format!("{only} {conjunction} {last}"),
+        _ => format!("{}, {conjunction} {last}", values.join(", ")),
+    }
 }


### PR DESCRIPTION
## Summary
- document the secret-free runtime configuration shape in `zeroshot-rust run --help`
- explain provider/model choices, environment-name forwarding, executable-node bindings, and template-owned delivery
- keep generated CLI references and contract-linked help coverage current

## Validation
- `cargo test -p zeroshot-rust`
- `cargo clippy -p zeroshot-rust --all-targets -- -D warnings`
- generated CLI reference check
- Opcore Zero changed and staged gates