### PR TITLE
fix(sdks/python): resolve native wheel path portably

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -231,7 +231,13 @@ jobs:
             echo "::error::$ARCHIVE contains unexpected version $reported_version"
             exit 1
           }
-          echo "ZEROSHOT_RUST_BINARY=$PWD/native/${{ matrix.executable }}" >> "$GITHUB_ENV"
+          binary_path="$(python - <<'PY'
+          from pathlib import Path
+
+          print(Path('native/${{ matrix.executable }}').resolve(strict=True))
+          PY
+          )"
+          echo "ZEROSHOT_RUST_BINARY=$binary_path" >> "$GITHUB_ENV"
 
       - name: Build platform wheel containing the exact Rust executable
         working-directory: sdks/python


### PR DESCRIPTION
Fix the Windows SDK wheel build by resolving the bundled Rust executable with the native Python interpreter before exporting `ZEROSHOT_RUST_BINARY`.

This is the one-file recovery needed after `zeroshot-rust-v0.4.0` published successfully but the automatic Python revision 1 build stopped before tagging or publishing.

Validation:
- `actionlint .github/workflows/release-python.yml`
- `npx mocha tests/unit/ci-path-classifier.test.js`
- `opcore-zero check --tree HEAD --base origin/main`