### PR TITLE
fix(rust): persist target credentials on headless Linux

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,13 @@ graph first.
 Native release metadata and npm installer code stay outside the Rust-only `zeroshot-rust/`
 package. `distribution/zeroshot-rust-targets.json` is the authoritative release target list;
 the workflow matrix and checksum coverage must match it exactly.
+Linux hosted-target login must hold the per-target refresh-family lock while it selects and
+persists its credential backend, requests a device code, and stores the resulting token. Existing
+system-keyring credentials remain authoritative during migration; otherwise
+desktop sessions prefer Secret Service and headless sessions use the private-file backend. Private
+credential files must stay owner-only, reject symlinks and unsafe ownership or modes, and rotate via
+fsynced atomic replacement. `ZEROSHOT_RUST_CREDENTIAL_STORE=system|file|auto` may override automatic
+selection, and file mode must always disclose that Zeroshot does not encrypt the refresh token.
 The Python SDK is one typed async sidecar client for local and auth-less direct targets. Platform
 wheels bundle the exact released `zeroshot-rust` executable; Python must not project built-in graph
 catalogs or validation rules. Built-in discovery, uniform runtime expansion, and fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +87,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +252,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +302,15 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -195,6 +343,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -244,6 +402,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,7 +493,15 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
  "zeroize",
 ]
 
@@ -341,6 +522,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -370,6 +552,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +592,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -401,6 +636,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -468,6 +709,25 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -565,12 +825,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -578,6 +844,36 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -780,6 +1076,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1157,7 @@ dependencies = [
  "byteorder",
  "dbus-secret-service",
  "log",
+ "secret-service",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
@@ -881,6 +1198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1254,19 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1114,10 +1459,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1165,10 +1526,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1192,6 +1578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1282,11 +1677,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1303,12 +1709,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1481,6 +1906,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +2018,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.8",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +2127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +2216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +2273,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1944,6 +2431,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,7 +2512,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2037,6 +2566,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -2267,6 +2807,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -2413,6 +2962,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2981,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "yasna"
@@ -2454,6 +3022,62 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.8",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -2585,3 +3209,40 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]

--- a/docs/zeroshot-rust-cli.html
+++ b/docs/zeroshot-rust-cli.html
@@ -102,7 +102,9 @@ Options:
   -h, --help
           Print help</code></pre></section>
 <section id="zeroshot-rust-target-login"><h4><code>zeroshot-rust target login</code></h4>
-<pre><code>Authenticate with a hosted named target
+<pre><code>Authenticate with a hosted named target.
+
+On Linux, desktop sessions prefer Secret Service and headless sessions use a durable private file. Set ZEROSHOT_RUST_CREDENTIAL_STORE to auto, system, or file to override automatic selection.
 
 Usage: zeroshot-rust target login &lt;NAME&gt;
 
@@ -112,7 +114,7 @@ Arguments:
 
 Options:
   -h, --help
-          Print help</code></pre></section>
+          Print help (see a summary with &#39;-h&#39;)</code></pre></section>
 <section id="zeroshot-rust-target-setup"><h4><code>zeroshot-rust target setup</code></h4>
 <pre><code>Configure the local profile for a named target.
 

--- a/docs/zeroshot-rust-cli.md
+++ b/docs/zeroshot-rust-cli.md
@@ -78,7 +78,9 @@ Options:
 #### `zeroshot-rust target login`
 
 ```text
-Authenticate with a hosted named target
+Authenticate with a hosted named target.
+
+On Linux, desktop sessions prefer Secret Service and headless sessions use a durable private file. Set ZEROSHOT_RUST_CREDENTIAL_STORE to auto, system, or file to override automatic selection.
 
 Usage: zeroshot-rust target login <NAME>
 
@@ -88,7 +90,7 @@ Arguments:
 
 Options:
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 
 #### `zeroshot-rust target setup`

--- a/zeroshot-rust/Cargo.toml
+++ b/zeroshot-rust/Cargo.toml
@@ -21,7 +21,12 @@ fs2.workspace = true
 getrandom.workspace = true
 httparse.workspace = true
 libc.workspace = true
-keyring = { workspace = true, features = ["apple-native", "sync-secret-service", "windows-native"] }
+keyring = { workspace = true, features = [
+  "apple-native",
+  "crypto-rust",
+  "sync-secret-service",
+  "windows-native",
+] }
 openengine-cluster-protocol.workspace = true
 openengine_cluster_client.workspace = true
 openengine-cluster-server.workspace = true

--- a/zeroshot-rust/src/native_v2_cli/parser.rs
+++ b/zeroshot-rust/src/native_v2_cli/parser.rs
@@ -80,6 +80,10 @@ enum TargetCommand {
     Add(TargetAddArgs),
 
     /// Authenticate with a hosted named target.
+    ///
+    /// On Linux, desktop sessions prefer Secret Service and headless sessions use a durable
+    /// private file. Set ZEROSHOT_RUST_CREDENTIAL_STORE to auto, system, or file to override
+    /// automatic selection.
     Login(TargetNameArgs),
 
     /// Configure the local profile for a named target.

--- a/zeroshot-rust/src/native_v2_target/controller_authority.rs
+++ b/zeroshot-rust/src/native_v2_target/controller_authority.rs
@@ -19,8 +19,8 @@ use self::contract::{
     require_response_route, validate_device_code, validate_secret, validate_token,
 };
 use self::credentials::{
-    DeviceCodeNotifier, KeyringTargetCredentialStore, StderrDeviceCodeNotifier, TargetRefreshGuard,
-    credential_service, open_refresh_lock,
+    CredentialStorePreparation, DeviceCodeNotifier, StderrDeviceCodeNotifier, TargetRefreshGuard,
+    credential_service, open_refresh_lock, production_target_credential_store,
 };
 use super::registry::default_target_registry_path;
 use super::{TargetAccess, TargetAuthorityError, TargetRecord};
@@ -55,6 +55,8 @@ impl TargetHttpControlAuthority {
             .parent()
             .ok_or_else(|| authority_error("target refresh lock path is unavailable"))?
             .to_owned();
+        let credentials =
+            production_target_credential_store(refresh_lock_directory.join("credentials"))?;
         let client = Client::builder()
             .connect_timeout(Duration::from_secs(10))
             .timeout(Duration::from_secs(30))
@@ -71,7 +73,7 @@ impl TargetHttpControlAuthority {
         Ok(Self {
             client,
             stream_client,
-            credentials: Arc::new(KeyringTargetCredentialStore),
+            credentials,
             notifier: Arc::new(StderrDeviceCodeNotifier),
             refresh_lock_directory,
         })
@@ -147,6 +149,20 @@ impl TargetHttpControlAuthority {
     }
 
     async fn login_inner(&self, request: HostedLogin<'_>) -> Result<(), TargetAuthorityError> {
+        if let CredentialStorePreparation::PrivateFile(path) = self
+            .credentials
+            .prepare_for_login(request.target_id)
+            .await?
+        {
+            eprintln!(
+                concat!(
+                    "\nWarning: the refresh token will be stored unencrypted in this private ",
+                    "file:\n  {}\nSet ZEROSHOT_RUST_CREDENTIAL_STORE=system to require Secret ",
+                    "Service.\n"
+                ),
+                path.display()
+            );
+        }
         let code: DeviceCodeWire = self
             .post_form_json(
                 &request.auth.device_authorization_endpoint,

--- a/zeroshot-rust/src/native_v2_target/controller_authority/control.rs
+++ b/zeroshot-rust/src/native_v2_target/controller_authority/control.rs
@@ -33,6 +33,7 @@ impl TargetControlAuthority for TargetHttpControlAuthority {
             .device_token()
             .ok_or_else(|| authority_error("direct target does not use login"))?;
         let (auth, controller) = self.descriptors(target).await?;
+        let _refresh_guard = self.lock_refresh_family(&target.id).await?;
         self.login_inner(HostedLogin {
             target_id: &target.id,
             device_token,

--- a/zeroshot-rust/src/native_v2_target/controller_authority/credentials.rs
+++ b/zeroshot-rust/src/native_v2_target/controller_authority/credentials.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
@@ -7,10 +8,45 @@ use super::authority_error;
 use crate::native_v2_target::registry::{create_private_directory, lock_registry, open_lock};
 use crate::native_v2_target::TargetAuthorityError;
 
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+mod private_file;
+#[cfg(all(test, target_os = "linux"))]
+mod tests;
+
 #[async_trait]
 pub(crate) trait TargetCredentialStore: Send + Sync {
+    async fn prepare_for_login(
+        &self,
+        _target_id: &str,
+    ) -> Result<CredentialStorePreparation, TargetAuthorityError> {
+        Ok(CredentialStorePreparation::Managed)
+    }
+
     async fn get(&self, target_id: &str) -> Result<Option<String>, TargetAuthorityError>;
     async fn set(&self, target_id: &str, refresh_token: &str) -> Result<(), TargetAuthorityError>;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CredentialStorePreparation {
+    Managed,
+    PrivateFile(PathBuf),
+}
+
+pub(super) fn production_target_credential_store(
+    directory: PathBuf,
+) -> Result<Arc<dyn TargetCredentialStore>, TargetAuthorityError> {
+    #[cfg(target_os = "linux")]
+    {
+        linux::LinuxTargetCredentialStore::from_environment(directory)
+            .map(|store| Arc::new(store) as Arc<dyn TargetCredentialStore>)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = directory;
+        Ok(Arc::new(KeyringTargetCredentialStore))
+    }
 }
 
 pub(crate) trait DeviceCodeNotifier: Send + Sync {
@@ -33,6 +69,14 @@ pub(super) struct KeyringTargetCredentialStore;
 
 #[async_trait]
 impl TargetCredentialStore for KeyringTargetCredentialStore {
+    async fn prepare_for_login(
+        &self,
+        target_id: &str,
+    ) -> Result<CredentialStorePreparation, TargetAuthorityError> {
+        self.get(target_id).await?;
+        Ok(CredentialStorePreparation::Managed)
+    }
+
     async fn get(&self, target_id: &str) -> Result<Option<String>, TargetAuthorityError> {
         let service = credential_service(target_id)?;
         tokio::task::spawn_blocking(move || {
@@ -98,6 +142,25 @@ pub(super) fn open_refresh_lock(
 }
 
 #[cfg(test)]
+pub(crate) fn refresh_lock_is_held(
+    directory: &Path,
+    path: &Path,
+) -> Result<bool, TargetAuthorityError> {
+    create_private_directory(directory)
+        .map_err(|_| authority_error("target refresh lock directory is unavailable"))?;
+    let lock =
+        open_lock(path).map_err(|_| authority_error("target refresh lock is unavailable"))?;
+    match fs2::FileExt::try_lock_exclusive(&lock) {
+        Ok(()) => {
+            drop(TargetRefreshGuard(lock));
+            Ok(false)
+        }
+        Err(error) if error.kind() == fs2::lock_contended_error().kind() => Ok(true),
+        Err(_) => Err(authority_error("target refresh lock could not be acquired")),
+    }
+}
+
+#[cfg(test)]
 pub(crate) mod test_support {
     use std::collections::BTreeMap;
     use std::sync::Mutex;
@@ -108,6 +171,8 @@ pub(crate) mod test_support {
     pub struct MemoryCredentialStore {
         values: Mutex<BTreeMap<String, String>>,
     }
+
+    pub struct UnavailableCredentialStore;
 
     #[derive(Default)]
     pub struct MemoryDeviceCodeNotifier {
@@ -129,6 +194,28 @@ pub(crate) mod test_support {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .push((verification_uri.to_owned(), user_code.to_owned()));
+        }
+    }
+
+    #[async_trait]
+    impl TargetCredentialStore for UnavailableCredentialStore {
+        async fn prepare_for_login(
+            &self,
+            _target_id: &str,
+        ) -> Result<CredentialStorePreparation, TargetAuthorityError> {
+            Err(authority_error("test credential store unavailable"))
+        }
+
+        async fn get(&self, _target_id: &str) -> Result<Option<String>, TargetAuthorityError> {
+            Err(authority_error("test credential store unavailable"))
+        }
+
+        async fn set(
+            &self,
+            _target_id: &str,
+            _refresh_token: &str,
+        ) -> Result<(), TargetAuthorityError> {
+            Err(authority_error("test credential store unavailable"))
         }
     }
 

--- a/zeroshot-rust/src/native_v2_target/controller_authority/credentials/linux.rs
+++ b/zeroshot-rust/src/native_v2_target/controller_authority/credentials/linux.rs
@@ -1,0 +1,189 @@
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::private_file::PrivateFileTargetCredentialStore;
+use super::{CredentialStorePreparation, KeyringTargetCredentialStore, TargetCredentialStore};
+use crate::native_v2_target::controller_authority::contract::authority_error;
+use crate::native_v2_target::TargetAuthorityError;
+
+const CREDENTIAL_STORE_ENV: &str = "ZEROSHOT_RUST_CREDENTIAL_STORE";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Backend {
+    System,
+    File,
+}
+
+pub(super) struct LinuxTargetCredentialStore {
+    system: Arc<dyn TargetCredentialStore>,
+    file: PrivateFileTargetCredentialStore,
+    forced: Option<Backend>,
+    desktop_session: bool,
+}
+
+impl LinuxTargetCredentialStore {
+    pub(super) fn from_environment(directory: PathBuf) -> Result<Self, TargetAuthorityError> {
+        Ok(Self {
+            system: Arc::new(KeyringTargetCredentialStore),
+            file: PrivateFileTargetCredentialStore::new(directory),
+            forced: parse_preference(std::env::var_os(CREDENTIAL_STORE_ENV).as_deref())?,
+            desktop_session: has_desktop_session(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_dependencies(
+        directory: PathBuf,
+        system: Arc<dyn TargetCredentialStore>,
+        forced: Option<&str>,
+        desktop_session: bool,
+    ) -> Result<Self, TargetAuthorityError> {
+        Ok(Self {
+            system,
+            file: PrivateFileTargetCredentialStore::new(directory),
+            forced: parse_preference(forced.map(OsStr::new))?,
+            desktop_session,
+        })
+    }
+
+    async fn stored_backend(
+        &self,
+        target_id: &str,
+    ) -> Result<Option<Backend>, TargetAuthorityError> {
+        self.file
+            .read_backend(target_id)
+            .await?
+            .map(|value| match value.as_str() {
+                "system\n" => Ok(Backend::System),
+                "file\n" => Ok(Backend::File),
+                _ => Err(authority_error(
+                    "target credential store selection is malformed",
+                )),
+            })
+            .transpose()
+    }
+
+    async fn remember_backend(
+        &self,
+        target_id: &str,
+        backend: Backend,
+    ) -> Result<(), TargetAuthorityError> {
+        let value = match backend {
+            Backend::System => "system\n",
+            Backend::File => "file\n",
+        };
+        self.file.write_backend(target_id, value).await
+    }
+
+    async fn prepare_backend(
+        &self,
+        backend: Backend,
+        target_id: &str,
+    ) -> Result<CredentialStorePreparation, TargetAuthorityError> {
+        self.backend(backend).prepare_for_login(target_id).await
+    }
+
+    fn backend(&self, backend: Backend) -> &dyn TargetCredentialStore {
+        match backend {
+            Backend::System => self.system.as_ref(),
+            Backend::File => &self.file,
+        }
+    }
+
+    async fn initial_backend(&self, target_id: &str) -> Backend {
+        match self.system.get(target_id).await {
+            Ok(Some(_)) => Backend::System,
+            Ok(None) if self.desktop_session => Backend::System,
+            Ok(None) | Err(_) => Backend::File,
+        }
+    }
+
+    async fn login_backend(&self, target_id: &str) -> Result<Backend, TargetAuthorityError> {
+        if let Some(forced) = self.forced {
+            return Ok(forced);
+        }
+        Ok(match self.stored_backend(target_id).await? {
+            Some(stored) => stored,
+            None => self.initial_backend(target_id).await,
+        })
+    }
+
+    async fn prepare_with_fallback(
+        &self,
+        target_id: &str,
+        desired: Backend,
+    ) -> Result<(Backend, CredentialStorePreparation), TargetAuthorityError> {
+        match self.prepare_backend(desired, target_id).await {
+            Ok(preparation) => Ok((desired, preparation)),
+            Err(_) if self.forced.is_none() && desired == Backend::System => self
+                .prepare_backend(Backend::File, target_id)
+                .await
+                .map(|preparation| (Backend::File, preparation)),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+#[async_trait]
+impl TargetCredentialStore for LinuxTargetCredentialStore {
+    async fn prepare_for_login(
+        &self,
+        target_id: &str,
+    ) -> Result<CredentialStorePreparation, TargetAuthorityError> {
+        let desired = self.login_backend(target_id).await?;
+        let (selected, preparation) = self.prepare_with_fallback(target_id, desired).await?;
+        self.remember_backend(target_id, selected).await?;
+        Ok(preparation)
+    }
+
+    async fn get(&self, target_id: &str) -> Result<Option<String>, TargetAuthorityError> {
+        if let Some(selected) = self.forced.or(self.stored_backend(target_id).await?) {
+            return self.backend(selected).get(target_id).await;
+        }
+        if let Ok(Some(token)) = self.system.get(target_id).await {
+            self.remember_backend(target_id, Backend::System).await?;
+            return Ok(Some(token));
+        }
+        let token = self.file.get(target_id).await?;
+        if token.is_some() {
+            self.remember_backend(target_id, Backend::File).await?;
+        }
+        Ok(token)
+    }
+
+    async fn set(&self, target_id: &str, refresh_token: &str) -> Result<(), TargetAuthorityError> {
+        let selected = match self.forced.or(self.stored_backend(target_id).await?) {
+            Some(selected) => selected,
+            None if self.desktop_session => Backend::System,
+            None => Backend::File,
+        };
+        self.backend(selected).set(target_id, refresh_token).await?;
+        if selected == Backend::System {
+            self.file.remove_credential(target_id).await?;
+        }
+        self.remember_backend(target_id, selected).await
+    }
+}
+
+fn parse_preference(value: Option<&OsStr>) -> Result<Option<Backend>, TargetAuthorityError> {
+    let Some(value) = value.filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    match value.to_str() {
+        Some("auto") => Ok(None),
+        Some("system") => Ok(Some(Backend::System)),
+        Some("file") => Ok(Some(Backend::File)),
+        _ => Err(authority_error(
+            "ZEROSHOT_RUST_CREDENTIAL_STORE must be auto, system, or file",
+        )),
+    }
+}
+
+fn has_desktop_session() -> bool {
+    ["DISPLAY", "WAYLAND_DISPLAY"]
+        .iter()
+        .any(|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()))
+}

--- a/zeroshot-rust/src/native_v2_target/controller_authority/credentials/private_file.rs
+++ b/zeroshot-rust/src/native_v2_target/controller_authority/credentials/private_file.rs
@@ -1,0 +1,273 @@
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use super::{CredentialStorePreparation, TargetCredentialStore, credential_service};
+use crate::native_v2_target::controller_authority::contract::authority_error;
+use crate::native_v2_target::registry::{create_private_directory, encode_hex};
+use crate::native_v2_target::TargetAuthorityError;
+
+const CREDENTIAL_FILE_VERSION: u32 = 1;
+const MAX_REFRESH_TOKEN_BYTES: usize = 16 * 1024;
+const MAX_CREDENTIAL_FILE_BYTES: usize = MAX_REFRESH_TOKEN_BYTES * 2 + 256;
+
+#[derive(Clone, Debug)]
+pub(super) struct PrivateFileTargetCredentialStore {
+    directory: PathBuf,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct CredentialFile {
+    version: u32,
+    refresh_token: String,
+}
+
+impl PrivateFileTargetCredentialStore {
+    pub(super) const fn new(directory: PathBuf) -> Self {
+        Self { directory }
+    }
+
+    pub(super) async fn read_backend(
+        &self,
+        target_id: &str,
+    ) -> Result<Option<String>, TargetAuthorityError> {
+        let path = self.backend_path(target_id)?;
+        tokio::task::spawn_blocking(move || {
+            read_private_file(&path).and_then(|value| {
+                value
+                    .map(String::from_utf8)
+                    .transpose()
+                    .map_err(|_| invalid_data())
+            })
+        })
+        .await
+        .map_err(|_| authority_error("target credential store task failed"))?
+        .map_err(|_| authority_error("target credential store metadata read failed"))
+    }
+
+    pub(super) async fn remove_credential(
+        &self,
+        target_id: &str,
+    ) -> Result<(), TargetAuthorityError> {
+        let path = self.credential_path(target_id)?;
+        tokio::task::spawn_blocking(move || remove_private_file(&path))
+            .await
+            .map_err(|_| authority_error("target credential store task failed"))?
+            .map_err(|_| authority_error("private target credential store cleanup failed"))
+    }
+
+    pub(super) async fn write_backend(
+        &self,
+        target_id: &str,
+        backend: &str,
+    ) -> Result<(), TargetAuthorityError> {
+        if !matches!(backend, "system\n" | "file\n") {
+            return Err(authority_error(
+                "target credential store selection is invalid",
+            ));
+        }
+        let path = self.backend_path(target_id)?;
+        let value = backend.as_bytes().to_vec();
+        tokio::task::spawn_blocking(move || write_private_file(&path, &value))
+            .await
+            .map_err(|_| authority_error("target credential store task failed"))?
+            .map_err(|_| authority_error("target credential store metadata write failed"))
+    }
+
+    fn credential_path(&self, target_id: &str) -> Result<PathBuf, TargetAuthorityError> {
+        credential_service(target_id)?;
+        Ok(self.directory.join(format!("{target_id}.json")))
+    }
+
+    fn backend_path(&self, target_id: &str) -> Result<PathBuf, TargetAuthorityError> {
+        credential_service(target_id)?;
+        Ok(self.directory.join(format!("{target_id}.store")))
+    }
+}
+
+#[async_trait]
+impl TargetCredentialStore for PrivateFileTargetCredentialStore {
+    async fn prepare_for_login(
+        &self,
+        target_id: &str,
+    ) -> Result<CredentialStorePreparation, TargetAuthorityError> {
+        let path = self.credential_path(target_id)?;
+        let prepared_path = path.clone();
+        tokio::task::spawn_blocking(move || {
+            let directory = path.parent().ok_or_else(invalid_data)?;
+            prepare_private_directory(directory)?;
+            read_credential(&path).map(|_| ())
+        })
+        .await
+        .map_err(|_| authority_error("target credential store task failed"))?
+        .map_err(|_| authority_error("private target credential store is unavailable"))?;
+        Ok(CredentialStorePreparation::PrivateFile(prepared_path))
+    }
+
+    async fn get(&self, target_id: &str) -> Result<Option<String>, TargetAuthorityError> {
+        let path = self.credential_path(target_id)?;
+        tokio::task::spawn_blocking(move || read_credential(&path))
+            .await
+            .map_err(|_| authority_error("target credential store task failed"))?
+            .map_err(|_| authority_error("private target credential store read failed"))
+    }
+
+    async fn set(&self, target_id: &str, refresh_token: &str) -> Result<(), TargetAuthorityError> {
+        if !valid_refresh_token(refresh_token) {
+            return Err(authority_error("refresh token is malformed"));
+        }
+        let path = self.credential_path(target_id)?;
+        let bytes = serde_json::to_vec(&CredentialFile {
+            version: CREDENTIAL_FILE_VERSION,
+            refresh_token: refresh_token.to_owned(),
+        })
+        .map_err(|_| authority_error("private target credential could not be encoded"))?;
+        tokio::task::spawn_blocking(move || write_private_file(&path, &bytes))
+            .await
+            .map_err(|_| authority_error("target credential store task failed"))?
+            .map_err(|_| authority_error("private target credential store write failed"))
+    }
+}
+
+fn read_credential(path: &Path) -> io::Result<Option<String>> {
+    let Some(bytes) = read_private_file(path)? else {
+        return Ok(None);
+    };
+    let credential: CredentialFile = serde_json::from_slice(&bytes).map_err(|_| invalid_data())?;
+    if credential.version != CREDENTIAL_FILE_VERSION
+        || !valid_refresh_token(&credential.refresh_token)
+    {
+        return Err(invalid_data());
+    }
+    Ok(Some(credential.refresh_token))
+}
+
+fn valid_refresh_token(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= MAX_REFRESH_TOKEN_BYTES
+        && !value.bytes().any(|byte| byte.is_ascii_control())
+}
+
+fn read_private_file(path: &Path) -> io::Result<Option<Vec<u8>>> {
+    let Some(file) = open_private_file(path)? else {
+        return Ok(None);
+    };
+    read_bounded_file(file).map(Some)
+}
+
+fn open_private_file(path: &Path) -> io::Result<Option<File>> {
+    let directory = path.parent().ok_or_else(invalid_data)?;
+    prepare_private_directory(directory)?;
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    match options.open(path) {
+        Ok(file) => Ok(Some(file)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_bounded_file(file: File) -> io::Result<Vec<u8>> {
+    let metadata = file.metadata()?;
+    let file_len = usize::try_from(metadata.len()).map_err(|_| invalid_data())?;
+    if !metadata.file_type().is_file()
+        || !private_owner_and_mode(&metadata)
+        || file_len > MAX_CREDENTIAL_FILE_BYTES
+    {
+        return Err(invalid_data());
+    }
+    let limit = u64::try_from(MAX_CREDENTIAL_FILE_BYTES)
+        .map_err(|_| invalid_data())?
+        .saturating_add(1);
+    let mut bytes = Vec::with_capacity(file_len);
+    file.take(limit).read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_CREDENTIAL_FILE_BYTES {
+        return Err(invalid_data());
+    }
+    Ok(bytes)
+}
+
+fn remove_private_file(path: &Path) -> io::Result<()> {
+    let Some(file) = open_private_file(path)? else {
+        return Ok(());
+    };
+    let metadata = file.metadata()?;
+    if !metadata.file_type().is_file() || !private_owner_and_mode(&metadata) {
+        return Err(invalid_data());
+    }
+    drop(file);
+    std::fs::remove_file(path)?;
+    sync_directory(path.parent().ok_or_else(invalid_data)?)
+}
+
+fn write_private_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if bytes.len() > MAX_CREDENTIAL_FILE_BYTES {
+        return Err(invalid_data());
+    }
+    let directory = path.parent().ok_or_else(invalid_data)?;
+    prepare_private_directory(directory)?;
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(invalid_data)?;
+    let mut suffix = [0_u8; 8];
+    getrandom::fill(&mut suffix).map_err(|_| invalid_data())?;
+    let temporary = directory.join(format!(".{file_name}.tmp-{}", encode_hex(&suffix)));
+    let mut options = OpenOptions::new();
+    options
+        .create_new(true)
+        .write(true)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    let result = (|| {
+        let mut file = options.open(&temporary)?;
+        let metadata = file.metadata()?;
+        if !metadata.file_type().is_file() || !private_owner_and_mode(&metadata) {
+            return Err(invalid_data());
+        }
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        std::fs::rename(&temporary, path)?;
+        sync_directory(directory)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn prepare_private_directory(path: &Path) -> io::Result<()> {
+    create_private_directory(path).map_err(|_| invalid_data())?;
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_dir() && private_owner_and_mode(&metadata) {
+        Ok(())
+    } else {
+        Err(invalid_data())
+    }
+}
+
+fn private_owner_and_mode(metadata: &std::fs::Metadata) -> bool {
+    metadata.uid() == unsafe { libc::geteuid() } && metadata.mode() & 0o077 == 0
+}
+
+fn sync_directory(path: &Path) -> io::Result<()> {
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW);
+    options.open(path)?.sync_all()
+}
+
+fn invalid_data() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        "invalid private credential storage",
+    )
+}

--- a/zeroshot-rust/src/native_v2_target/controller_authority/credentials/tests.rs
+++ b/zeroshot-rust/src/native_v2_target/controller_authority/credentials/tests.rs
@@ -1,0 +1,222 @@
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
+
+use super::linux::LinuxTargetCredentialStore;
+use super::private_file::PrivateFileTargetCredentialStore;
+use super::test_support::{MemoryCredentialStore, UnavailableCredentialStore};
+use super::{CredentialStorePreparation, TargetCredentialStore};
+
+const TARGET_ID: &str = "11111111-1111-4111-8111-111111111111";
+
+async fn prepare_and_store(store: &dyn TargetCredentialStore) {
+    assert!(matches!(
+        store.prepare_for_login(TARGET_ID).await.assert_value(),
+        CredentialStorePreparation::PrivateFile(_)
+    ));
+    store.set(TARGET_ID, "refresh-token").await.assert_value();
+}
+
+#[tokio::test]
+async fn private_file_credentials_persist_with_private_modes() {
+    let root =
+        openengine_cluster_testkit::TemporaryDirectory::for_test("zeroshot-private-credential");
+    let directory = root.path("credentials");
+    let first = PrivateFileTargetCredentialStore::new(directory.clone());
+    prepare_and_store(&first).await;
+
+    let second = PrivateFileTargetCredentialStore::new(directory.clone());
+    assert_eq!(
+        second.get(TARGET_ID).await.assert_value().as_deref(),
+        Some("refresh-token")
+    );
+    assert_eq!(
+        std::fs::metadata(&directory)
+            .assert_value()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    assert_eq!(
+        std::fs::metadata(directory.join(format!("{TARGET_ID}.json")))
+            .assert_value()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+}
+
+#[tokio::test]
+async fn private_file_credentials_reject_broad_permissions() {
+    let root = openengine_cluster_testkit::TemporaryDirectory::for_test(
+        "zeroshot-private-credential-mode",
+    );
+    let directory = root.path("credentials");
+    let store = PrivateFileTargetCredentialStore::new(directory.clone());
+    store.set(TARGET_ID, "refresh-token").await.assert_value();
+    let path = directory.join(format!("{TARGET_ID}.json"));
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).assert_value();
+
+    assert_eq!(
+        store.get(TARGET_ID).await.assert_error().to_string(),
+        "private target credential store read failed"
+    );
+}
+
+#[tokio::test]
+async fn private_file_credentials_reject_symlinks_and_special_files() {
+    let root = openengine_cluster_testkit::TemporaryDirectory::for_test(
+        "zeroshot-private-credential-special-file",
+    );
+    let directory = root.path("credentials");
+    let store = PrivateFileTargetCredentialStore::new(directory.clone());
+    store.prepare_for_login(TARGET_ID).await.assert_value();
+    let credential = directory.join(format!("{TARGET_ID}.json"));
+    let outside = root.path("outside.json");
+    std::fs::write(&outside, b"not-a-credential").assert_value();
+    std::os::unix::fs::symlink(&outside, &credential).assert_value();
+    assert_eq!(
+        store.get(TARGET_ID).await.assert_error().to_string(),
+        "private target credential store read failed"
+    );
+    std::fs::remove_file(&credential).assert_value();
+
+    let fifo_path = CString::new(credential.as_os_str().as_bytes()).assert_value();
+    // SAFETY: fifo_path is NUL-terminated and names a path in the temporary test directory.
+    assert_eq!(unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) }, 0);
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), store.get(TARGET_ID))
+            .await
+            .assert_value()
+            .assert_error()
+            .to_string(),
+        "private target credential store read failed"
+    );
+}
+
+#[tokio::test]
+async fn maximum_length_escaped_refresh_token_round_trips() {
+    let root = openengine_cluster_testkit::TemporaryDirectory::for_test(
+        "zeroshot-private-credential-max-token",
+    );
+    let store = PrivateFileTargetCredentialStore::new(root.path("credentials"));
+    let token = "\\".repeat(16 * 1024);
+    store.set(TARGET_ID, &token).await.assert_value();
+    assert_eq!(store.get(TARGET_ID).await.assert_value(), Some(token));
+}
+
+#[tokio::test]
+async fn linux_fallback_survives_a_new_store_instance() {
+    let root =
+        openengine_cluster_testkit::TemporaryDirectory::for_test("zeroshot-linux-credential");
+    let directory = root.path("credentials");
+    let first = LinuxTargetCredentialStore::with_dependencies(
+        directory.clone(),
+        Arc::new(UnavailableCredentialStore),
+        None,
+        false,
+    )
+    .assert_value();
+    prepare_and_store(&first).await;
+
+    let second = LinuxTargetCredentialStore::with_dependencies(
+        directory,
+        Arc::new(MemoryCredentialStore::default()),
+        None,
+        true,
+    )
+    .assert_value();
+    assert_eq!(
+        second.get(TARGET_ID).await.assert_value().as_deref(),
+        Some("refresh-token")
+    );
+}
+
+#[tokio::test]
+async fn switching_to_system_removes_the_private_file_after_storage() {
+    let root = openengine_cluster_testkit::TemporaryDirectory::for_test(
+        "zeroshot-system-credential-cleanup",
+    );
+    let directory = root.path("credentials");
+    let file_store = LinuxTargetCredentialStore::with_dependencies(
+        directory.clone(),
+        Arc::new(MemoryCredentialStore::default()),
+        Some("file"),
+        false,
+    )
+    .assert_value();
+    prepare_and_store(&file_store).await;
+    let credential = directory.join(format!("{TARGET_ID}.json"));
+    assert!(credential.exists());
+
+    let unavailable_system = LinuxTargetCredentialStore::with_dependencies(
+        directory.clone(),
+        Arc::new(UnavailableCredentialStore),
+        Some("system"),
+        false,
+    )
+    .assert_value();
+    assert_eq!(
+        unavailable_system
+            .set(TARGET_ID, "unpersisted-refresh-token")
+            .await
+            .assert_error()
+            .to_string(),
+        "test credential store unavailable"
+    );
+    assert!(credential.exists());
+
+    let system = Arc::new(MemoryCredentialStore::default());
+    let system_store = LinuxTargetCredentialStore::with_dependencies(
+        directory,
+        system.clone(),
+        Some("system"),
+        false,
+    )
+    .assert_value();
+    assert_eq!(
+        system_store
+            .prepare_for_login(TARGET_ID)
+            .await
+            .assert_value(),
+        CredentialStorePreparation::Managed
+    );
+    system_store
+        .set(TARGET_ID, "system-refresh-token")
+        .await
+        .assert_value();
+
+    assert_eq!(
+        system.get(TARGET_ID).await.assert_value().as_deref(),
+        Some("system-refresh-token")
+    );
+    assert!(!credential.exists());
+}
+
+#[tokio::test]
+async fn an_explicit_system_store_never_downgrades() {
+    let root =
+        openengine_cluster_testkit::TemporaryDirectory::for_test("zeroshot-system-credential");
+    let store = LinuxTargetCredentialStore::with_dependencies(
+        root.path("credentials"),
+        Arc::new(UnavailableCredentialStore),
+        Some("system"),
+        false,
+    )
+    .assert_value();
+
+    assert_eq!(
+        store
+            .prepare_for_login(TARGET_ID)
+            .await
+            .assert_error()
+            .to_string(),
+        "test credential store unavailable"
+    );
+}

--- a/zeroshot-rust/src/native_v2_target/tests.rs
+++ b/zeroshot-rust/src/native_v2_target/tests.rs
@@ -1,3 +1,5 @@
+#[path = "tests/authentication.rs"]
+mod authentication;
 #[path = "tests/contracts.rs"]
 mod contracts;
 #[path = "tests/fixtures.rs"]

--- a/zeroshot-rust/src/native_v2_target/tests/authentication.rs
+++ b/zeroshot-rust/src/native_v2_target/tests/authentication.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
+
+use super::super::controller_authority::credentials::{
+    refresh_lock_is_held,
+    test_support::{MemoryDeviceCodeNotifier, UnavailableCredentialStore},
+};
+use super::super::*;
+use super::fixtures::{hosted_target, temp_root};
+use super::hosted_authority::{LoginBlockingCredentialStore, spawn_target_authority};
+
+#[tokio::test]
+async fn login_preflights_credential_persistence_before_requesting_a_device_code() {
+    let root = temp_root();
+    let (origin, server) = spawn_target_authority(2).await;
+    let notifier = Arc::new(MemoryDeviceCodeNotifier::default());
+    let authority = TargetHttpControlAuthority::with_dependencies(
+        Arc::new(UnavailableCredentialStore),
+        notifier.clone(),
+        root.path("refresh-locks"),
+    );
+
+    assert_eq!(
+        authority
+            .login(&hosted_target("local", origin))
+            .await
+            .assert_error()
+            .to_string(),
+        "test credential store unavailable"
+    );
+    assert!(notifier.values().is_empty());
+    let requests = server.await.assert_value();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.path != "/oauth/device")
+    );
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn login_holds_the_target_refresh_family_lock_through_persistence() {
+    let root = temp_root();
+    let (origin, server) = spawn_target_authority(5).await;
+    let credentials = Arc::new(LoginBlockingCredentialStore::new("refresh-0"));
+    let lock_directory = root.path("refresh-locks");
+    let authority = TargetHttpControlAuthority::with_dependencies(
+        credentials.clone(),
+        Arc::new(MemoryDeviceCodeNotifier::default()),
+        lock_directory.clone(),
+    );
+    let target = hosted_target("local", origin);
+    let lock_path = lock_directory.join(format!("target-{}-refresh.lock", target.id));
+    let login = tokio::spawn(async move { authority.login(&target).await });
+    credentials.wait_until_prepared().await;
+
+    assert!(refresh_lock_is_held(&lock_directory, &lock_path).assert_value());
+    assert_eq!(credentials.reads(), 0);
+    credentials.release_login();
+
+    login.await.assert_value().assert_value();
+    assert!(!refresh_lock_is_held(&lock_directory, &lock_path).assert_value());
+    assert_eq!(credentials.reads(), 0);
+    assert_eq!(credentials.value(), "refresh-1");
+    assert_eq!(server.await.assert_value().len(), 5);
+}

--- a/zeroshot-rust/src/native_v2_target/tests/hosted_authority.rs
+++ b/zeroshot-rust/src/native_v2_target/tests/hosted_authority.rs
@@ -1,14 +1,24 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use serde_json::json;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::sync::Notify;
 
+use super::super::controller_authority::credentials::CredentialStorePreparation;
 use super::super::controller_authority::TargetCredentialStore;
 use super::super::*;
 
 pub(super) struct RotatingCredentialStore {
     state: Mutex<RotatingCredentialState>,
+}
+
+pub(super) struct LoginBlockingCredentialStore {
+    value: Mutex<String>,
+    prepare_started: Notify,
+    prepare_release: Notify,
+    reads: AtomicUsize,
 }
 
 struct RotatingCredentialState {
@@ -360,6 +370,55 @@ async fn read_http_body(stream: &mut tokio::net::TcpStream, bytes: &mut Vec<u8>,
         let count = stream.read(&mut chunk).await.assert_value();
         assert!(count > 0, "HTTP request ended before body");
         bytes.extend_from_slice(chunk.get(..count).assert_value());
+    }
+}
+
+impl LoginBlockingCredentialStore {
+    pub(super) fn new(value: &str) -> Self {
+        Self {
+            value: Mutex::new(value.to_owned()),
+            prepare_started: Notify::new(),
+            prepare_release: Notify::new(),
+            reads: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) async fn wait_until_prepared(&self) {
+        self.prepare_started.notified().await;
+    }
+
+    pub(super) fn release_login(&self) {
+        self.prepare_release.notify_one();
+    }
+
+    pub(super) fn reads(&self) -> usize {
+        self.reads.load(Ordering::SeqCst)
+    }
+
+    pub(super) fn value(&self) -> String {
+        self.value.lock().assert_value().clone()
+    }
+}
+
+#[async_trait]
+impl TargetCredentialStore for LoginBlockingCredentialStore {
+    async fn prepare_for_login(
+        &self,
+        _target_id: &str,
+    ) -> Result<CredentialStorePreparation, TargetAuthorityError> {
+        self.prepare_started.notify_one();
+        self.prepare_release.notified().await;
+        Ok(CredentialStorePreparation::Managed)
+    }
+
+    async fn get(&self, _target_id: &str) -> Result<Option<String>, TargetAuthorityError> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(self.value()))
+    }
+
+    async fn set(&self, _target_id: &str, refresh_token: &str) -> Result<(), TargetAuthorityError> {
+        *self.value.lock().assert_value() = refresh_token.to_owned();
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- select a persistent private-file credential backend on headless Linux before device authorization
- retain native keyring storage on desktop Linux, macOS, and Windows, with an explicit backend override
- harden private credential files and serialize login with refresh-token rotation
- document storage behavior and add security, migration, persistence, and concurrency coverage

## Validation
- fresh independent code-quality/security review: GREEN
- cargo test -p zeroshot-rust
- cargo clippy -p zeroshot-rust --all-targets --all-features -- -D warnings
- generated CLI documentation check
- Opcore introduced-change check
- Opcore Zero staged Verify and Sense
- live login/refresh validation against dev.theopenengine.com from headless Linux