### PR TITLE
fix(parser): improve extractDirectJson to handle conversational filler

### DIFF
--- a/src/agent/output-extraction-json.ts
+++ b/src/agent/output-extraction-json.ts
@@ -182,6 +182,19 @@ function extractDirectJson(text: unknown): JsonRecord | null {
     if (!isObjectRecord(parsed) || isCliMetadata(parsed)) return null;
     return parsed;
   } catch {
+    const firstBrace = trimmed.indexOf('{');
+    const lastBrace = trimmed.lastIndexOf('}');
+    if (firstBrace !== -1 && lastBrace > firstBrace) {
+      try {
+        const substring = trimmed.slice(firstBrace, lastBrace + 1);
+        const parsedSubstring: unknown = JSON.parse(substring);
+        if (isObjectRecord(parsedSubstring) && !isCliMetadata(parsedSubstring)) {
+          return parsedSubstring;
+        }
+      } catch {
+        // Fallthrough to null
+      }
+    }
     return null;
   }
 }

--- a/src/agent/output-extraction-json.ts
+++ b/src/agent/output-extraction-json.ts
@@ -179,24 +179,55 @@ function extractDirectJson(text: unknown): JsonRecord | null {
 
   try {
     const parsed: unknown = JSON.parse(trimmed);
-    if (!isObjectRecord(parsed) || isCliMetadata(parsed)) return null;
-    return parsed;
+    if (isObjectRecord(parsed) && !isCliMetadata(parsed)) return parsed;
   } catch {
-    const firstBrace = trimmed.indexOf('{');
-    const lastBrace = trimmed.lastIndexOf('}');
-    if (firstBrace !== -1 && lastBrace > firstBrace) {
-      try {
-        const substring = trimmed.slice(firstBrace, lastBrace + 1);
-        const parsedSubstring: unknown = JSON.parse(substring);
-        if (isObjectRecord(parsedSubstring) && !isCliMetadata(parsedSubstring)) {
-          return parsedSubstring;
+    // Proceed to scanning embedded objects
+  }
+
+  // Scan for balanced JSON object candidates in surrounding text
+  for (let i = 0; i < trimmed.length; i++) {
+    if (trimmed[i] !== '{') continue;
+
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+
+    for (let j = i; j < trimmed.length; j++) {
+      const ch = trimmed[j];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === '\\' && inString) {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (!inString) {
+        if (ch === '{') {
+          depth++;
+        } else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            try {
+              const candidate = trimmed.slice(i, j + 1);
+              const parsed: unknown = JSON.parse(candidate);
+              if (isObjectRecord(parsed) && !isCliMetadata(parsed)) {
+                return parsed;
+              }
+            } catch {
+              // Not a valid JSON object, continue search
+            }
+          }
         }
-      } catch {
-        // Fallthrough to null
       }
     }
-    return null;
   }
+
+  return null;
 }
 
 function hasFatalStandaloneOutput(output: unknown): boolean {

--- a/src/agent/output-extraction-json.ts
+++ b/src/agent/output-extraction-json.ts
@@ -182,18 +182,6 @@ function isCliMetadata(value: JsonRecord): boolean {
   return metadataFieldCount >= 2;
 }
 
-function parseBalancedCandidate(text: string, start: number, end: number): JsonRecord | null {
-  try {
-    const parsed: unknown = JSON.parse(text.slice(start, end));
-    if (isObjectRecord(parsed) && !isCliMetadata(parsed)) {
-      return parsed;
-    }
-  } catch {
-    // Not a valid JSON object
-  }
-  return null;
-}
-
 function braceDepthDelta(ch: string | undefined): number {
   if (ch === '{') return 1;
   if (ch === '}') return -1;
@@ -233,10 +221,22 @@ function scanBalancedJsonObject(text: string): JsonRecord | null {
   for (let i = 0; i < text.length; i++) {
     if (text[i] !== '{') continue;
     const end = findBalancedCandidateEnd(text, i);
-    if (end !== -1) {
-      const candidate = parseBalancedCandidate(text, i, end);
-      if (candidate) return candidate;
+    if (end === -1) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text.slice(i, end));
+    } catch {
+      // Not valid JSON; keep scanning for an embedded candidate.
+      continue;
     }
+    if (!isObjectRecord(parsed)) continue;
+    if (isCliMetadata(parsed)) {
+      // Rejected metadata envelope: skip its interior so nested objects
+      // (e.g. usage) are not misclassified as agent output.
+      i = end - 1;
+      continue;
+    }
+    return parsed;
   }
   return null;
 }

--- a/src/agent/output-extraction-json.ts
+++ b/src/agent/output-extraction-json.ts
@@ -162,13 +162,83 @@ const CLI_METADATA_FIELDS: ReadonlySet<string> = new Set([
 ]);
 
 function isCliMetadata(value: JsonRecord): boolean {
-  if (value.type === 'result') return true;
+  if (typeof value.type === 'string') {
+    if (
+      value.type === 'result' ||
+      value.type.startsWith('item.') ||
+      value.type.startsWith('turn.') ||
+      value.type.startsWith('thread.') ||
+      value.type.startsWith('assistant.') ||
+      value.type.startsWith('tool.')
+    ) {
+      return true;
+    }
+  }
 
   let metadataFieldCount = 0;
   for (const key of Object.keys(value)) {
     if (CLI_METADATA_FIELDS.has(key)) metadataFieldCount++;
   }
   return metadataFieldCount >= 2;
+}
+
+function parseBalancedCandidate(text: string, start: number, end: number): JsonRecord | null {
+  try {
+    const parsed: unknown = JSON.parse(text.slice(start, end));
+    if (isObjectRecord(parsed) && !isCliMetadata(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Not a valid JSON object
+  }
+  return null;
+}
+
+function braceDepthDelta(ch: string | undefined): number {
+  if (ch === '{') return 1;
+  if (ch === '}') return -1;
+  return 0;
+}
+
+function findBalancedCandidateEnd(text: string, start: number): number {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let j = start; j < text.length; j++) {
+    const ch = text[j];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else {
+      depth += braceDepthDelta(ch);
+      if (depth === 0) return j + 1;
+    }
+  }
+  return -1;
+}
+
+function scanBalancedJsonObject(text: string): JsonRecord | null {
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== '{') continue;
+    const end = findBalancedCandidateEnd(text, i);
+    if (end !== -1) {
+      const candidate = parseBalancedCandidate(text, i, end);
+      if (candidate) return candidate;
+    }
+  }
+  return null;
 }
 
 function extractDirectJson(text: unknown): JsonRecord | null {
@@ -179,55 +249,11 @@ function extractDirectJson(text: unknown): JsonRecord | null {
 
   try {
     const parsed: unknown = JSON.parse(trimmed);
-    if (isObjectRecord(parsed) && !isCliMetadata(parsed)) return parsed;
+    if (!isObjectRecord(parsed) || isCliMetadata(parsed)) return null;
+    return parsed;
   } catch {
-    // Proceed to scanning embedded objects
+    return scanBalancedJsonObject(trimmed);
   }
-
-  // Scan for balanced JSON object candidates in surrounding text
-  for (let i = 0; i < trimmed.length; i++) {
-    if (trimmed[i] !== '{') continue;
-
-    let depth = 0;
-    let inString = false;
-    let escape = false;
-
-    for (let j = i; j < trimmed.length; j++) {
-      const ch = trimmed[j];
-      if (escape) {
-        escape = false;
-        continue;
-      }
-      if (ch === '\\' && inString) {
-        escape = true;
-        continue;
-      }
-      if (ch === '"') {
-        inString = !inString;
-        continue;
-      }
-      if (!inString) {
-        if (ch === '{') {
-          depth++;
-        } else if (ch === '}') {
-          depth--;
-          if (depth === 0) {
-            try {
-              const candidate = trimmed.slice(i, j + 1);
-              const parsed: unknown = JSON.parse(candidate);
-              if (isObjectRecord(parsed) && !isCliMetadata(parsed)) {
-                return parsed;
-              }
-            } catch {
-              // Not a valid JSON object, continue search
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return null;
 }
 
 function hasFatalStandaloneOutput(output: unknown): boolean {

--- a/tests/output-extraction.test.js
+++ b/tests/output-extraction.test.js
@@ -259,6 +259,12 @@ function defineDirectJsonExtractionTests() {
       assert.deepStrictEqual(result, { foo: 'bar' });
     });
 
+    it('should extract JSON embedded in conversational filler', function () {
+      const text = 'Here is the JSON you requested:\n{"foo":"bar"}\nHope this helps!';
+      const result = extractDirectJson(text);
+      assert.deepStrictEqual(result, { foo: 'bar' });
+    });
+
     it('should return null for arrays', function () {
       const text = '[1, 2, 3]';
       const result = extractDirectJson(text);

--- a/tests/output-extraction.test.js
+++ b/tests/output-extraction.test.js
@@ -349,6 +349,19 @@ function defineDirectJsonExtractionTests() {
       const result = extractDirectJson(text);
       assert.strictEqual(result, null);
     });
+
+    it('should reject filler-wrapped CLI metadata without returning nested objects', function () {
+      const text =
+        'Here is output: {"duration_ms":100,"session_id":"test","usage":{"input_tokens":50}} done.';
+      const result = extractDirectJson(text);
+      assert.strictEqual(result, null);
+    });
+
+    it('should reject filler-wrapped protocol events without returning nested payload', function () {
+      const text = 'Result: {"type":"item.completed","index":0,"payload":{"foo":1}} end.';
+      const result = extractDirectJson(text);
+      assert.strictEqual(result, null);
+    });
   });
 }
 

--- a/tests/output-extraction.test.js
+++ b/tests/output-extraction.test.js
@@ -337,6 +337,18 @@ function defineDirectJsonExtractionTests() {
       const result = extractDirectJson(text);
       assert.deepStrictEqual(result, { summary: 'Fixed bugs', errors: [] });
     });
+
+    it('should reject CLI metadata and not fall through to nested usage object', function () {
+      const text = '{"duration_ms":100,"session_id":"test","usage":{"input_tokens":50}}';
+      const result = extractDirectJson(text);
+      assert.strictEqual(result, null);
+    });
+
+    it('should reject provider protocol event records', function () {
+      const text = '{"type":"item.completed","index":0,"payload":"data"}';
+      const result = extractDirectJson(text);
+      assert.strictEqual(result, null);
+    });
   });
 }
 

--- a/tests/output-extraction.test.js
+++ b/tests/output-extraction.test.js
@@ -265,6 +265,18 @@ function defineDirectJsonExtractionTests() {
       assert.deepStrictEqual(result, { foo: 'bar' });
     });
 
+    it('should extract JSON embedded in conversational filler containing additional braces', function () {
+      const text = 'Note: {var_placeholder} was replaced. Result: {"foo":"bar"} and {extra_unrelated}.';
+      const result = extractDirectJson(text);
+      assert.deepStrictEqual(result, { foo: 'bar' });
+    });
+
+    it('should extract JSON containing string with nested braces', function () {
+      const text = 'Result: {"template":"Hello {name}, welcome {home}"} complete.';
+      const result = extractDirectJson(text);
+      assert.deepStrictEqual(result, { template: 'Hello {name}, welcome {home}' });
+    });
+
     it('should return null for arrays', function () {
       const text = '[1, 2, 3]';
       const result = extractDirectJson(text);


### PR DESCRIPTION
This PR improves the test result JSON parser (`extractDirectJson`) to handle conversational filler text (e.g. LLM outputs before/after the JSON block) without requiring markdown codeblocks. It finds the substring between the first `{` and last `}` when a direct JSON parse fails, which increases robustness.