### PR TITLE
docs: document OrcaRouter as a bundled Gateway endpoint

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -340,6 +340,42 @@ Pass the Anthropic base URL exactly as shown. The bundled client appends
 `"protocol": "openai"` and omit `maxTokens` unless the endpoint needs a custom
 limit.
 
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway
+backed by a single `https://api.orcarouter.ai/v1` base URL. It exposes a
+`provider/model` namespace across many upstream providers and adds adaptive
+routing, automatic failover, zero-markup inference, observability, guardrails,
+and agent-tool governance behind the same endpoint. The special model id
+`orcarouter/auto` routes each prompt to a live upstream model, so no catalog
+entries are needed here.
+
+Example settings:
+
+```json
+{
+  "providerSettings": {
+    "gateway": {
+      "protocol": "openai",
+      "baseUrl": "https://api.orcarouter.ai/v1",
+      "apiKey": "your-api-key",
+      "model": "orcarouter/auto",
+      "toolPolicy": {
+        "roots": ["/absolute/path/to/worktree"],
+        "commands": ["node"]
+      }
+    }
+  }
+}
+```
+
+OrcaRouter also exposes the Anthropic Messages surface at
+`https://api.orcarouter.ai`, so Claude Code and other Anthropic-protocol tools
+can use it without a `/v1` suffix; on the bundled Gateway provider, keep
+`"protocol": "openai"` and the `/v1` base URL above, and pass any model id from
+the [OrcaRouter catalog](https://www.orcarouter.ai/models) (for example
+`openai/gpt-5.5-pro`) as `model`.
+
 ## Model Levels
 
 Zeroshot uses provider-agnostic levels:


### PR DESCRIPTION
This documents [OrcaRouter](https://www.orcarouter.ai) as a first-class endpoint for Zeroshot's bundled Gateway provider, so users can point `providerSettings.gateway` at OrcaRouter exactly as they already do for OpenRouter or MiniMax instead of treating it as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a documented `gateway` endpoint means this project's users get that whole stack through the provider registry they already use, with no new provider id and no code change. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The example uses `protocol: "openai"` with `baseUrl: "https://api.orcarouter.ai/v1"` and the `orcarouter/auto` routing model, and it mirrors the existing MiniMax subsection under "Gateway Provider" in `docs/providers.md`. I verified the exact settings live: the bundled gateway runner returned `ZEROSHOT_LIVE_SMOKE_OK` against `https://api.orcarouter.ai/v1` with `model=orcarouter/auto`, and `prettier --check docs/providers.md` passes.

Questions and help: Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter. I'm an engineer on the OrcaRouter team.
