### PR TITLE
fix(rust): prevent stale fan-out runtime facts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ verify byte-for-byte drift with `npm run protocol:check`. These generator-format
 are excluded from Prettier; never format them independently.
 Full-v1 loops may omit `until`; such loops repeat to their bound unless an inner terminal ends the
 graph first.
+Full-v1 fan-out joins must merge controls and channels only from the completed child subgraph and
+its structural map scope; never merge a child's inherited sibling snapshot back into the parent.
 Native release metadata and npm installer code stay outside the Rust-only `zeroshot-rust/`
 package. `distribution/zeroshot-rust-targets.json` is the authoritative release target list;
 the workflow matrix and checksum coverage must match it exactly.

--- a/zeroshot-rust/src/full_v1_reducer/groups.rs
+++ b/zeroshot-rust/src/full_v1_reducer/groups.rs
@@ -249,7 +249,13 @@ impl Engine<'_> {
                 set_path(&mut joined.state, &path, value)?;
                 joined.local_writes.insert(path);
             }
-            merge_runtime_facts(&branch_context, &mut joined);
+            let branch_names = descendant_names(branch);
+            merge_scoped_runtime_facts(
+                &branch_context,
+                &mut joined,
+                &branch_names,
+                traversal.map_indices,
+            );
         }
         Ok((joined, join_position, winner_set))
     }

--- a/zeroshot-rust/src/full_v1_reducer/groups/map.rs
+++ b/zeroshot-rust/src/full_v1_reducer/groups/map.rs
@@ -224,8 +224,9 @@ impl Engine<'_> {
             mode: traversal.mode,
             decisions: &mut self.decisions,
         })?;
+        let body_names = descendant_names(&group.body);
         for item in results {
-            merge_runtime_facts(&item.context, context);
+            merge_scoped_runtime_facts(&item.context, context, &body_names, &item.scope);
         }
         self.continue_decision(&group.name, traversal.mode);
         let position = results

--- a/zeroshot-rust/src/full_v1_reducer/values.rs
+++ b/zeroshot-rust/src/full_v1_reducer/values.rs
@@ -335,6 +335,30 @@ pub(super) fn merge_runtime_facts(source: &Context, target: &mut Context) {
     target.channels.extend(source.channels.clone());
 }
 
+pub(super) fn merge_scoped_runtime_facts(
+    source: &Context,
+    target: &mut Context,
+    names: &BTreeSet<NodeName>,
+    map_indices: &[u64],
+) {
+    target.controls.extend(
+        source
+            .controls
+            .iter()
+            .filter(|(key, _)| {
+                names.contains(&key.node) && key.map_indices.starts_with(map_indices)
+            })
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+    target.channels.extend(
+        source
+            .channels
+            .iter()
+            .filter(|((name, indices), _)| names.contains(name) && indices.starts_with(map_indices))
+            .map(|(key, value)| (key.clone(), value.clone())),
+    );
+}
+
 pub(super) fn descendant_names(node: &GraphNode) -> BTreeSet<NodeName> {
     let mut depths = BTreeMap::new();
     collect_map_depths(node, 0, &mut depths);

--- a/zeroshot-rust/src/native_v2_templates/tests.rs
+++ b/zeroshot-rust/src/native_v2_templates/tests.rs
@@ -148,6 +148,65 @@ async fn rejected_parallel_reviews_dispatch_repair_with_both_diagnostics() {
 }
 
 #[tokio::test]
+async fn accepted_second_review_round_ignores_stale_sibling_verdicts() {
+    let (verified, initial_input) = verified_software_template(TemplateDelivery::None).await;
+    let review_input = json!({"task":"repair checkout","deliveryFeedback":""});
+    let mut history = vec![
+        settled_worker(),
+        settled_review(2, "acceptance", ACCEPTED_LABEL, "requirements met"),
+        settled_review(3, "code", REJECTED_LABEL, "unsafe error handling"),
+        settled_agent(SettledExecutionSpec {
+            execution: 4,
+            node_instance: 4,
+            node: "review_repair",
+            settled_at: 4,
+            input: json!({
+                "task":"repair checkout",
+                "acceptanceFeedback":"requirements met",
+                "codeFeedback":"unsafe error handling",
+                "deliveryFeedback":""
+            }),
+        }),
+    ];
+    assert_dispatched_together(
+        &reduce(&verified, &initial_input, &history),
+        &["acceptance", "code"],
+    );
+
+    history.extend([
+        settled_review_execution(
+            SettledExecutionSpec {
+                execution: 5,
+                node_instance: 2,
+                node: "acceptance",
+                settled_at: 6,
+                input: review_input.clone(),
+            },
+            ACCEPTED_LABEL,
+            "repaired change meets requirements",
+        ),
+        settled_review_execution(
+            SettledExecutionSpec {
+                execution: 6,
+                node_instance: 3,
+                node: "code",
+                settled_at: 5,
+                input: review_input,
+            },
+            ACCEPTED_LABEL,
+            "repaired implementation is sound",
+        ),
+    ]);
+
+    assert_eq!(
+        reduce(&verified, &initial_input, &history).terminal,
+        Some(TerminalProjection::Succeeded {
+            output: serde_json::Value::Null,
+        })
+    );
+}
+
+#[tokio::test]
 async fn accepted_reviews_complete_or_dispatch_pull_request_delivery() {
     for delivery in [TemplateDelivery::None, TemplateDelivery::PullRequest] {
         let (verified, initial_input) = verified_software_template(delivery).await;

--- a/zeroshot-rust/tests/full_v1_reducer/cases_2.rs
+++ b/zeroshot-rust/tests/full_v1_reducer/cases_2.rs
@@ -140,6 +140,85 @@ async fn map_is_input_ordered_total_and_assigns_stable_nested_indices() {
 }
 
 #[tokio::test]
+async fn repeated_map_items_do_not_restore_stale_sibling_controls() {
+    let state = required_array_record(&[("items", "null")]);
+    let mapped = json!({
+        "kind":"map", "name":"reviews", "state":state.clone(),
+        "over":{"source":"state","path":["items"]}, "maxItems":2,
+        "promotedStatePaths":[], "body":verifier("check",1)
+    });
+    let route = json!({
+        "kind":"choice", "name":"review_result", "state":state.clone(),
+        "branches":[{
+            "when":{
+                "kind":"k_of_map", "count":2,
+                "value":{"name":"check","source":"signal","field":"verdict"},
+                "labels":["accepted"]
+            },
+            "node":succeed("done")
+        }],
+        "otherwise":step("repair",1), "promotedStatePaths":[]
+    });
+    let review_loop = json!({
+        "kind":"loop", "name":"review_loop", "state":state.clone(),
+        "body":{
+            "kind":"seq", "name":"review_iteration", "state":state.clone(),
+            "children":[mapped,route], "promotedStatePaths":[]
+        },
+        "maxIterations":3, "promotedStatePaths":[]
+    });
+    let mut root = sequence(
+        "root",
+        vec![
+            review_loop,
+            json!({"kind":"fail","name":"exhausted","reason":"exhausted"}),
+        ],
+    );
+    *root.get_mut("state").assert_value() = state;
+    let graph = verified(root, json!({"check":1})).await;
+    let history = [
+        settled(
+            SettledSpec::new(1, 1, "check")
+                .map_indices(vec![0])
+                .position(2),
+            verdict("rejected"),
+        ),
+        settled(
+            SettledSpec::new(2, 2, "check")
+                .map_indices(vec![1])
+                .position(3),
+            verdict("accepted"),
+        ),
+        settled(SettledSpec::new(3, 3, "repair").position(4), success(0)),
+        settled(
+            SettledSpec::new(4, 1, "check")
+                .map_indices(vec![0])
+                .position(8),
+            verdict("accepted"),
+        ),
+        settled(
+            SettledSpec::new(5, 2, "check")
+                .map_indices(vec![1])
+                .position(7),
+            verdict("accepted"),
+        ),
+    ];
+
+    assert!(matches!(
+        FullV1Reducer::native_v2(&graph)
+            .reduce(ReductionInput {
+                initial_input: &json!({"items":[null,null]}),
+                executions: &history,
+                next_node_instance: 4,
+                next_execution: 6,
+            })
+            .assert_value()
+            .terminal,
+        Some(TerminalProjection::Succeeded { .. })
+    ));
+}
+
+#[tokio::test]
 async fn authored_frontier_and_bytes_ignore_history_container_order() {
     let graph = verified_parallel_sequence(ParallelSequenceSpec {
         root_name: "root",


### PR DESCRIPTION
## Summary
- prevent parallel winners from restoring inherited sibling controls and channels
- scope map-item runtime-fact propagation by child subtree and structural item scope
- add regressions for the observed software-change review loop and the analogous repeated-map case

## Validation
- cargo test --manifest-path zeroshot-rust/Cargo.toml
- cargo clippy --manifest-path zeroshot-rust/Cargo.toml --all-targets -- -D warnings
- cargo fmt --manifest-path zeroshot-rust/Cargo.toml -- --check
- npm run opcore:check
- opcore-zero check and sense on changed and staged files