### PR TITLE
fix(rust)!: harden provider process streaming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,38 @@ the literal `Continue` in the same session (or rerun the original prompt only wh
 created). Agent output gets at most two correction turns before `malformed`. Direct GitHub merge
 rejection is reobserved once for CI registration races, then terminates as a policy refusal.
 
+Native-v2 Claude and Codex JSONL readers never cap cumulative stdout bytes or event counts. They
+share only a 64 MiB unfinished-record allocation guard, tolerate whitespace and a complete final
+record without a newline, and stop interpreting bytes after the first valid terminal event while
+continuing to drain the provider process. Unknown future event types are ignored before their
+provider-owned fields are validated. Provider stdin is streamed concurrently with bounded stdout
+draining so large prompts and early provider output cannot deadlock each other. Incomplete stdin
+delivery is always fatal, but parsed session identity, usage, retry, and diagnostic evidence from
+the launched attempt must survive either I/O completion order. Pre-terminal identity faults remain
+sticky failures but do not stop the first real provider terminal event from supplying usage.
+
+Durable provider events cross bounded async queues end to end; producers apply backpressure, token
+usage survives cancellation, and supervisors preserve event order while batching ledger appends.
+Public capsule streams accept only bounded event receivers, endpoint cancellation is coalesced
+state, and post-cancellation usage is compacted into one checked total plus an incomplete marker.
+Both the cancellation-safe terminal-usage lane and its aggregate fail explicitly on overflow; a
+saturated lane synthesizes one trailing incomplete marker after all retained metadata drains.
+Safe-log timestamps are captured at the original producer boundary, persist as positive
+JavaScript-safe Unix epoch milliseconds, and remain unchanged across capsule and public replay.
+Run-scoped remote close interrupts saturated local bridges without promoting healthy connections
+to global loss, and drains terminal usage metadata before completion. Its timeout is distinct from
+ordinary control RPCs and must cover the shared contained-process cleanup budget plus transport
+margin.
+Endpoint and proxy execution activity is reserved atomically before any underlying start await;
+persistent run-close tombstones prevent late starts, close waits pending reservations, and no
+handle or stream for that run can surface after close returns.
+
+Contained provider sessions bound natural post-exit I/O draining by the original command deadline
+and a ten-minute ceiling while still observing cancellation and release. Bounded stderr tails carry
+explicit truncation evidence so credential redaction can cover secrets split by the tail boundary.
+Observable post-launch failures preserve safe operation, I/O kind, raw OS code, sanitized message,
+termination signal, and core-dump evidence; only unobservable drop cleanup is best-effort.
+
 Read-only safe commands: `zeroshot list`, `zeroshot status`, `zeroshot logs`
 
 Destructive commands (need permission): `zeroshot kill`, `zeroshot clear`, `zeroshot purge`

--- a/crates/openengine-cluster-protocol/src/native_v2_observation.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_observation.rs
@@ -71,6 +71,42 @@ impl JsonSchema for TokenCount {
 #[error("token count {0} exceeds the JavaScript-safe integer maximum {MAX_SAFE_GENERATION}")]
 pub struct TokenCountOutOfRange(pub u64);
 
+/// Milliseconds since the Unix epoch for one durable observation.
+///
+/// Timestamps are positive and bounded to integers JavaScript represents exactly. Unix
+/// milliseconds remain within that range for hundreds of thousands of years.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct UnixTimestampMillis(crate::PositiveInteger);
+
+impl UnixTimestampMillis {
+    /// Earliest timestamp admitted by the wire contract.
+    pub const MIN: Self = Self(crate::PositiveInteger::ONE);
+
+    pub fn new(value: u64) -> Result<Self, crate::ContractValueError> {
+        crate::PositiveInteger::new(value).map(Self)
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl JsonSchema for UnixTimestampMillis {
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn schema_name() -> Cow<'static, str> {
+        "UnixTimestampMillis".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        crate::value::javascript_safe_integer_schema(1)
+    }
+}
+
 /// Run-wide sum of provider-reported usage for every launched agent invocation.
 ///
 /// `complete` is false when at least one invocation did not report usable counters. Cache
@@ -213,6 +249,8 @@ pub struct RunLogEventNotification {
     pub subscription_id: SubscriptionId,
     pub run_id: RunId,
     pub cursor: Cursor,
+    /// Producer-captured Unix epoch milliseconds, preserved unchanged by durable replay.
+    pub timestamp: UnixTimestampMillis,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution: Option<ExecutionRef>,
     pub record: LogRecord,

--- a/crates/openengine-cluster-protocol/src/payload.rs
+++ b/crates/openengine-cluster-protocol/src/payload.rs
@@ -179,6 +179,8 @@ impl JsonSchema for FieldPath {
 pub struct PositiveInteger(u64);
 
 impl PositiveInteger {
+    pub(crate) const ONE: Self = Self(1);
+
     pub fn new(value: u64) -> Result<Self, ContractValueError> {
         if value == 0 || value > MAX_SAFE_GENERATION {
             Err(ContractValueError::NotPositive)

--- a/crates/openengine-cluster-protocol/tests/native_v2_observation.rs
+++ b/crates/openengine-cluster-protocol/tests/native_v2_observation.rs
@@ -10,7 +10,7 @@ use openengine_cluster_protocol::{
     RunForceParams, RunForceResult, RunId, RunLogEventNotification, RunLogsParams, RunMetadata,
     RunSize, RunStatus, RunStatusParams, RunStatusResult, RunTitle, RunWatchEventNotification,
     RunWatchParams, ResolvedSource, SubscriptionId, TerminalResult, TokenCount, TokenUsage,
-    MAX_SAFE_GENERATION,
+    UnixTimestampMillis, MAX_SAFE_GENERATION,
 };
 use serde_json::json;
 
@@ -151,6 +151,16 @@ fn token_usage_rejects_counters_that_javascript_cannot_represent_exactly() {
 }
 
 #[test]
+fn log_timestamps_are_positive_javascript_safe_unix_milliseconds() {
+    assert!(UnixTimestampMillis::new(1).is_ok());
+    assert!(UnixTimestampMillis::new(MAX_SAFE_GENERATION).is_ok());
+    assert!(UnixTimestampMillis::new(0).is_err());
+    assert!(UnixTimestampMillis::new(MAX_SAFE_GENERATION + 1).is_err());
+    assert!(serde_json::from_value::<UnixTimestampMillis>(json!(0)).is_err());
+    assert!(serde_json::from_value::<UnixTimestampMillis>(json!(MAX_SAFE_GENERATION + 1)).is_err());
+}
+
+#[test]
 fn durable_events_carry_run_and_stable_cursor() {
     let terminal_output = json!({
         "kind": "verification_receipt",
@@ -203,6 +213,7 @@ fn durable_events_carry_run_and_stable_cursor() {
         "subscriptionId": "logs-1",
         "runId": "run-1",
         "cursor": "v2:9",
+        "timestamp": 1725000000123_u64,
         "execution": "opaque-verifier-b",
         "record": {
             "level": "info",
@@ -214,6 +225,10 @@ fn durable_events_carry_run_and_stable_cursor() {
     assert_eq!(serde_json::to_value(log).assert_value(), value);
     assert_eq!(json_read::json_at(&value, "/runId"), &json!("run-1"));
     assert_eq!(json_read::json_at(&value, "/cursor"), &json!("v2:9"));
+    assert_eq!(
+        json_read::json_at(&value, "/timestamp"),
+        &json!(1_725_000_000_123_u64)
+    );
     assert_eq!(
         json_read::json_at(&value, "/execution"),
         &json!("opaque-verifier-b")

--- a/crates/openengine-cluster-server/tests/native_v2.rs
+++ b/crates/openengine-cluster-server/tests/native_v2.rs
@@ -8,7 +8,7 @@ use openengine_cluster_protocol::{
     RunForceResult, RunId, RunListParams, RunListResult, RunLogEventNotification, RunLogsParams,
     RunLogsResult, RunStatus, RunStatusParams, RunStatusResult, RunSubmitParams, RunSubmitResult,
     RunSize, RunTitle, RunWatchEventNotification, RunWatchParams, RunWatchResult,
-    ServerCapabilities, SubscriptionCloseReason, SubscriptionId,
+    ServerCapabilities, SubscriptionCloseReason, SubscriptionId, UnixTimestampMillis,
 };
 use openengine_cluster_server::native_v2::{
     RunAttachEventStream, RunLogEventStream, RunSubscriptionItem, RunSubscriptionSource,
@@ -179,6 +179,7 @@ impl ClusterBackend for FakeBackend {
                 subscription_id,
                 run_id: run_id(),
                 cursor: cursor(4),
+                timestamp: UnixTimestampMillis::new(1_725_000_000_123).assert_value(),
                 execution: Some(execution()),
                 record: LogRecord {
                     level: LogLevel::Info,

--- a/crates/openengine-cluster-testkit/src/native_v2_observation_artifacts.rs
+++ b/crates/openengine-cluster-testkit/src/native_v2_observation_artifacts.rs
@@ -10,6 +10,7 @@ use openengine_cluster_protocol::{
     RunMetadata, RunSize, RunStatus, RunStatusParams, RunStatusResult, RunTitle,
     RunWatchEventNotification, RunWatchParams, RunWatchResult, SourceBranchId, SourceRepositoryId,
     SourceRevisionId, ResolvedSource, SubscriptionId, TerminalResult, TokenCount, TokenUsage,
+    UnixTimestampMillis,
 };
 use schemars::{schema_for, JsonSchema};
 use serde_json::{json, Value};
@@ -165,6 +166,7 @@ fn logs_fixture() -> Value {
             subscription_id: SubscriptionId::new("logs-1"),
             run_id: run_id(),
             cursor: cursor(9),
+            timestamp: UnixTimestampMillis::new(1_725_000_000_123).assert_value(),
             execution: Some(execution("opaque-verifier-b")),
             record: LogRecord {
                 level: LogLevel::Info,

--- a/protocol/openengine-cluster/v1/fixtures/native_v2_observation/logs.json
+++ b/protocol/openengine-cluster/v1/fixtures/native_v2_observation/logs.json
@@ -8,7 +8,8 @@
       "target": "agent"
     },
     "runId": "run-1",
-    "subscriptionId": "logs-1"
+    "subscriptionId": "logs-1",
+    "timestamp": 1725000000123
   },
   "params": {
     "execution": "opaque-verifier-b",

--- a/protocol/openengine-cluster/v1/native-v2-observation.schema.json
+++ b/protocol/openengine-cluster/v1/native-v2-observation.schema.json
@@ -676,12 +676,19 @@
         },
         "subscriptionId": {
           "type": "string"
+        },
+        "timestamp": {
+          "description": "Producer-captured Unix epoch milliseconds, preserved unchanged by durable replay.",
+          "maximum": 9007199254740991,
+          "minimum": 1,
+          "type": "integer"
         }
       },
       "required": [
         "subscriptionId",
         "runId",
         "cursor",
+        "timestamp",
         "record"
       ],
       "type": "object"

--- a/protocol/openengine-cluster/v1/schema.json
+++ b/protocol/openengine-cluster/v1/schema.json
@@ -3916,12 +3916,19 @@
         },
         "subscriptionId": {
           "type": "string"
+        },
+        "timestamp": {
+          "description": "Producer-captured Unix epoch milliseconds, preserved unchanged by durable replay.",
+          "maximum": 9007199254740991,
+          "minimum": 1,
+          "type": "integer"
         }
       },
       "required": [
         "subscriptionId",
         "runId",
         "cursor",
+        "timestamp",
         "record"
       ],
       "type": "object"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -94,7 +94,8 @@ starts or a direct target is contacted.
 `Run.watch(after=...)` and `Run.logs(after=..., execution=...)` resume strictly after opaque native
 cursors. A `wait_timeout` expiry raises `RunWaitTimeout` carrying the still-active `Run`; cancelling
 the Python await also detaches without stopping it. `Run.force_stop()` is the only operation that
-changes run lifetime.
+changes run lifetime. Each `LogEvent.timestamp` is the positive, JavaScript-safe Unix epoch
+millisecond captured at the producer and preserved unchanged by durable replay.
 
 ## Environment values
 

--- a/sdks/python/src/zeroshot/_projection.py
+++ b/sdks/python/src/zeroshot/_projection.py
@@ -12,6 +12,7 @@ from .values import JsonValue
 _Size: TypeAlias = Literal["tiny", "small", "standard", "large"]
 _Phase: TypeAlias = Literal["admitted", "running", "stopping", "finished"]
 _Level: TypeAlias = Literal["debug", "info", "error"]
+_MAX_JAVASCRIPT_SAFE_INTEGER = 9_007_199_254_740_991
 
 
 def _status(value: object) -> RunStatus:
@@ -84,6 +85,7 @@ def _log_event(value: object) -> LogEvent:
     return LogEvent(
         run_id=_string(root, "runId", "log event"),
         cursor=_string(root, "cursor", "log event"),
+        timestamp=_positive_javascript_safe_integer(root, "timestamp", "log event"),
         execution=execution,
         level=cast(
             _Level,
@@ -149,6 +151,17 @@ def _mapping_list(value: object, kind: str) -> tuple[Mapping[str, object], ...]:
 def _string(value: Mapping[str, object], name: str, kind: str) -> str:
     selected = value.get(name)
     if not isinstance(selected, str):
+        raise ProtocolError(f"Zeroshot Rust emitted malformed {kind}.{name}")
+    return selected
+
+
+def _positive_javascript_safe_integer(
+    value: Mapping[str, object],
+    name: str,
+    kind: str,
+) -> int:
+    selected = value.get(name)
+    if type(selected) is not int or not 1 <= selected <= _MAX_JAVASCRIPT_SAFE_INTEGER:
         raise ProtocolError(f"Zeroshot Rust emitted malformed {kind}.{name}")
     return selected
 

--- a/sdks/python/src/zeroshot/runs.py
+++ b/sdks/python/src/zeroshot/runs.py
@@ -137,6 +137,7 @@ class LogEvent:
     Args:
         run_id: Public durable run identity.
         cursor: Opaque durable log cursor.
+        timestamp: Producer-captured Unix epoch milliseconds, preserved by replay.
         execution: Opaque execution selector, or None for run-wide records.
         level: Native debug, info, or error level.
         target: Bounded native log target.
@@ -145,6 +146,7 @@ class LogEvent:
 
     run_id: str
     cursor: str
+    timestamp: int
     execution: str | None
     level: Literal["debug", "info", "error"]
     target: str

--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -118,6 +118,7 @@ elif args and args[0] == "logs":
     event = {
         "runId": args[1],
         "cursor": "v2:3",
+        "timestamp": 1725000000123,
         "record": {"level": "info", "target": "agent", "message": "done"},
     }
     if option("--execution") is not None:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -87,6 +87,7 @@ def test_direct_target_uses_the_same_client_and_durable_run_surface(fake_native:
             assert summaries[0].phase == "admitted"
             logs = [event async for event in run.logs(after="v2:2", execution="worker-1")]
             assert [(event.execution, event.message) for event in logs] == [("worker-1", "done")]
+            assert logs[0].timestamp == 1_725_000_000_123
             result = await run.force_stop()
             assert not result.succeeded
             assert result.failure == "force_stopped"

--- a/sdks/python/tests/test_projection.py
+++ b/sdks/python/tests/test_projection.py
@@ -1,0 +1,38 @@
+"""Strict native projection tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from zeroshot._projection import _log_event
+from zeroshot.errors import ProtocolError
+
+
+def log_event(*, timestamp: object = 1_725_000_000_123) -> dict[str, object]:
+    return {
+        "runId": "run-1",
+        "cursor": "v2:3",
+        "timestamp": timestamp,
+        "record": {"level": "info", "target": "agent", "message": "done"},
+    }
+
+
+@pytest.mark.parametrize("timestamp", [1, 1_725_000_000_123, 9_007_199_254_740_991])
+def test_log_event_preserves_exact_timestamp(timestamp: int) -> None:
+    assert _log_event(log_event(timestamp=timestamp)).timestamp == timestamp
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [True, 1.0, "1", 0, -1, 9_007_199_254_740_992],
+)
+def test_log_event_rejects_invalid_timestamp(timestamp: object) -> None:
+    with pytest.raises(ProtocolError, match=r"malformed log event\.timestamp"):
+        _log_event(log_event(timestamp=timestamp))
+
+
+def test_log_event_rejects_missing_timestamp() -> None:
+    value = log_event()
+    del value["timestamp"]
+    with pytest.raises(ProtocolError, match=r"malformed log event\.timestamp"):
+        _log_event(value)

--- a/src/cluster/generated/protocol-schema.ts
+++ b/src/cluster/generated/protocol-schema.ts
@@ -669,285 +669,288 @@ export const CLUSTER_PROTOCOL_SCHEMA: unknown = JSON.parse(
   "sor\":{\"type\":\"string\"},\"execution\":{\"maxLength\":128,\"minLength\":1,\"patte" +
   "rn\":\"^[^\\\\u0000-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\":[\"string\",\"null\"]},\"re" +
   "cord\":{\"$ref\":\"#/$defs/LogRecord\"},\"runId\":{\"type\":\"string\"},\"subscripti" +
-  "onId\":{\"type\":\"string\"}},\"required\":[\"subscriptionId\",\"runId\",\"cursor\",\"" +
-  "record\"],\"type\":\"object\"},\"RunLogsParams\":{\"additionalProperties\":false," +
-  "\"description\":\"Establishes durable run log replay followed by live deliv" +
-  "ery.\\n\\nAn optional execution filter selects one active or settled execu" +
-  "tion using the exact opaque\\nreference advertised by status. `fromCursor" +
-  "` is exclusive, with the same reconnect semantics\\nas [`RunWatchParams`]" +
-  ". Omitting both fields after `runId` replays the run's complete retained" +
-  "\\nsafe log history.\",\"properties\":{\"execution\":{\"maxLength\":128,\"minLeng" +
-  "th\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\":[\"string\"," +
-  "\"null\"]},\"fromCursor\":{\"type\":[\"string\",\"null\"]},\"runId\":{\"type\":\"string" +
-  "\"}},\"required\":[\"runId\"],\"type\":\"object\"},\"RunLogsResult\":{\"additionalPr" +
-  "operties\":false,\"properties\":{\"atCursor\":{\"type\":\"string\"},\"runId\":{\"typ" +
-  "e\":\"string\"},\"subscriptionId\":{\"type\":\"string\"}},\"required\":[\"subscripti" +
-  "onId\",\"runId\",\"atCursor\"],\"type\":\"object\"},\"RunMetadata\":{\"additionalPro" +
-  "perties\":false,\"description\":\"Additive metadata emitted only with a term" +
-  "inal run projection.\",\"properties\":{\"tokenUsage\":{\"anyOf\":[{\"$ref\":\"#/$d" +
-  "efs/TokenUsage\"},{\"type\":\"null\"}]}},\"type\":\"object\"},\"RunSize\":{\"enum\":[" +
-  "\"small\",\"medium\",\"large\"],\"type\":\"string\"},\"RunStatus\":{\"description\":\"P" +
-  "ublic run state. The closed phase variants make impossible combinations " +
-  "unrepresentable:\\nadmitted runs have no execution, stopping means force " +
-  "was requested, and finished runs have\\nexactly one terminal result and n" +
-  "o active execution. Running/stopping report every active\\nexecution rath" +
-  "er than a single \\\"current worker\\\" slot.\",\"oneOf\":[{\"additionalProperti" +
-  "es\":false,\"properties\":{\"phase\":{\"const\":\"admitted\",\"type\":\"string\"}},\"r" +
-  "equired\":[\"phase\"],\"type\":\"object\"},{\"additionalProperties\":false,\"prope" +
-  "rties\":{\"activeExecutions\":{\"items\":{\"$ref\":\"#/$defs/ActiveExecution\"},\"" +
-  "type\":\"array\"},\"phase\":{\"const\":\"running\",\"type\":\"string\"}},\"required\":[" +
-  "\"phase\",\"activeExecutions\"],\"type\":\"object\"},{\"additionalProperties\":fal" +
-  "se,\"properties\":{\"activeExecutions\":{\"items\":{\"$ref\":\"#/$defs/ActiveExec" +
-  "ution\"},\"type\":\"array\"},\"phase\":{\"const\":\"stopping\",\"type\":\"string\"}},\"r" +
-  "equired\":[\"phase\",\"activeExecutions\"],\"type\":\"object\"},{\"additionalPrope" +
-  "rties\":false,\"properties\":{\"metadata\":{\"$ref\":\"#/$defs/RunMetadata\",\"def" +
-  "ault\":{}},\"phase\":{\"const\":\"finished\",\"type\":\"string\"},\"terminalResult\":" +
-  "{\"$ref\":\"#/$defs/TerminalResult\"}},\"required\":[\"phase\",\"terminalResult\"]" +
-  ",\"type\":\"object\"}]},\"RunStatusParams\":{\"additionalProperties\":false,\"pro" +
-  "perties\":{\"runId\":{\"type\":\"string\"}},\"required\":[\"runId\"],\"type\":\"object" +
-  "\"},\"RunStatusResult\":{\"additionalProperties\":false,\"properties\":{\"atCurs" +
-  "or\":{\"type\":\"string\"},\"runId\":{\"type\":\"string\"},\"size\":{\"$ref\":\"#/$defs/" +
-  "RunSize\"},\"source\":{\"$ref\":\"#/$defs/ResolvedSource\"},\"status\":{\"$ref\":\"#" +
-  "/$defs/RunStatus\"},\"title\":{\"maxLength\":256,\"minLength\":1,\"pattern\":\"^[^" +
-  "\\\\u0000-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\":\"string\"}},\"required\":[\"runId\"" +
-  ",\"title\",\"source\",\"size\",\"atCursor\",\"status\"],\"type\":\"object\"},\"RunSubmi" +
-  "ssion\":{\"additionalProperties\":false,\"description\":\"Immutable, secret-fr" +
-  "ee native-v2 submission admitted by the selected target.\",\"properties\":{" +
-  "\"graph\":{\"$ref\":\"#/$defs/GraphSpec\"},\"initialInput\":true,\"runtime\":{\"$re" +
-  "f\":\"#/$defs/RuntimePlan\"},\"source\":{\"$ref\":\"#/$defs/ResolvedSource\"},\"su" +
-  "bmissionKey\":{\"maxLength\":256,\"minLength\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001" +
-  "f\\\\u007f-\\\\u009f]+$\",\"type\":\"string\"},\"title\":{\"maxLength\":256,\"minLengt" +
-  "h\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\":\"string\"}}," +
-  "\"required\":[\"title\",\"graph\",\"initialInput\",\"runtime\",\"source\",\"submissio" +
-  "nKey\"],\"type\":\"object\"},\"RunSubmitParams\":{\"additionalProperties\":false," +
-  "\"description\":\"Trusted controller bootstrap admission. The host assigns " +
-  "the only public run identity before\\ncontroller start; the immutable sub" +
-  "mission remains identity-neutral.\",\"properties\":{\"runId\":{\"type\":\"string" +
-  "\"},\"submission\":{\"$ref\":\"#/$defs/RunSubmission\"}},\"required\":[\"runId\",\"s" +
-  "ubmission\"],\"type\":\"object\"},\"RunSubmitResult\":{\"additionalProperties\":f" +
-  "alse,\"description\":\"A successful submission returns the one public ident" +
-  "ity used by every later run method.\",\"properties\":{\"runId\":{\"type\":\"stri" +
-  "ng\"}},\"required\":[\"runId\"],\"type\":\"object\"},\"RunWatchEventNotification\":" +
-  "{\"additionalProperties\":false,\"description\":\"One durable public status p" +
-  "rojection. `cursor` is stable run history, not a connection-local\\nseque" +
-  "nce; clients resume strictly after it.\",\"properties\":{\"cursor\":{\"type\":\"" +
-  "string\"},\"runId\":{\"type\":\"string\"},\"size\":{\"$ref\":\"#/$defs/RunSize\"},\"so" +
-  "urce\":{\"$ref\":\"#/$defs/ResolvedSource\"},\"status\":{\"$ref\":\"#/$defs/RunSta" +
-  "tus\"},\"subscriptionId\":{\"type\":\"string\"},\"title\":{\"maxLength\":256,\"minLe" +
+  "onId\":{\"type\":\"string\"},\"timestamp\":{\"description\":\"Producer-captured Un" +
+  "ix epoch milliseconds, preserved unchanged by durable replay.\",\"maximum\"" +
+  ":9007199254740991,\"minimum\":1,\"type\":\"integer\"}},\"required\":[\"subscripti" +
+  "onId\",\"runId\",\"cursor\",\"timestamp\",\"record\"],\"type\":\"object\"},\"RunLogsPa" +
+  "rams\":{\"additionalProperties\":false,\"description\":\"Establishes durable r" +
+  "un log replay followed by live delivery.\\n\\nAn optional execution filter" +
+  " selects one active or settled execution using the exact opaque\\nreferen" +
+  "ce advertised by status. `fromCursor` is exclusive, with the same reconn" +
+  "ect semantics\\nas [`RunWatchParams`]. Omitting both fields after `runId`" +
+  " replays the run's complete retained\\nsafe log history.\",\"properties\":{\"" +
+  "execution\":{\"maxLength\":128,\"minLength\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001f\\" +
+  "\\u007f-\\\\u009f]+$\",\"type\":[\"string\",\"null\"]},\"fromCursor\":{\"type\":[\"stri" +
+  "ng\",\"null\"]},\"runId\":{\"type\":\"string\"}},\"required\":[\"runId\"],\"type\":\"obj" +
+  "ect\"},\"RunLogsResult\":{\"additionalProperties\":false,\"properties\":{\"atCur" +
+  "sor\":{\"type\":\"string\"},\"runId\":{\"type\":\"string\"},\"subscriptionId\":{\"type" +
+  "\":\"string\"}},\"required\":[\"subscriptionId\",\"runId\",\"atCursor\"],\"type\":\"ob" +
+  "ject\"},\"RunMetadata\":{\"additionalProperties\":false,\"description\":\"Additi" +
+  "ve metadata emitted only with a terminal run projection.\",\"properties\":{" +
+  "\"tokenUsage\":{\"anyOf\":[{\"$ref\":\"#/$defs/TokenUsage\"},{\"type\":\"null\"}]}}," +
+  "\"type\":\"object\"},\"RunSize\":{\"enum\":[\"small\",\"medium\",\"large\"],\"type\":\"st" +
+  "ring\"},\"RunStatus\":{\"description\":\"Public run state. The closed phase va" +
+  "riants make impossible combinations unrepresentable:\\nadmitted runs have" +
+  " no execution, stopping means force was requested, and finished runs hav" +
+  "e\\nexactly one terminal result and no active execution. Running/stopping" +
+  " report every active\\nexecution rather than a single \\\"current worker\\\" " +
+  "slot.\",\"oneOf\":[{\"additionalProperties\":false,\"properties\":{\"phase\":{\"co" +
+  "nst\":\"admitted\",\"type\":\"string\"}},\"required\":[\"phase\"],\"type\":\"object\"}," +
+  "{\"additionalProperties\":false,\"properties\":{\"activeExecutions\":{\"items\":" +
+  "{\"$ref\":\"#/$defs/ActiveExecution\"},\"type\":\"array\"},\"phase\":{\"const\":\"run" +
+  "ning\",\"type\":\"string\"}},\"required\":[\"phase\",\"activeExecutions\"],\"type\":\"" +
+  "object\"},{\"additionalProperties\":false,\"properties\":{\"activeExecutions\":" +
+  "{\"items\":{\"$ref\":\"#/$defs/ActiveExecution\"},\"type\":\"array\"},\"phase\":{\"co" +
+  "nst\":\"stopping\",\"type\":\"string\"}},\"required\":[\"phase\",\"activeExecutions\"" +
+  "],\"type\":\"object\"},{\"additionalProperties\":false,\"properties\":{\"metadata" +
+  "\":{\"$ref\":\"#/$defs/RunMetadata\",\"default\":{}},\"phase\":{\"const\":\"finished" +
+  "\",\"type\":\"string\"},\"terminalResult\":{\"$ref\":\"#/$defs/TerminalResult\"}},\"" +
+  "required\":[\"phase\",\"terminalResult\"],\"type\":\"object\"}]},\"RunStatusParams" +
+  "\":{\"additionalProperties\":false,\"properties\":{\"runId\":{\"type\":\"string\"}}" +
+  ",\"required\":[\"runId\"],\"type\":\"object\"},\"RunStatusResult\":{\"additionalPro" +
+  "perties\":false,\"properties\":{\"atCursor\":{\"type\":\"string\"},\"runId\":{\"type" +
+  "\":\"string\"},\"size\":{\"$ref\":\"#/$defs/RunSize\"},\"source\":{\"$ref\":\"#/$defs/" +
+  "ResolvedSource\"},\"status\":{\"$ref\":\"#/$defs/RunStatus\"},\"title\":{\"maxLeng" +
+  "th\":256,\"minLength\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"" +
+  "type\":\"string\"}},\"required\":[\"runId\",\"title\",\"source\",\"size\",\"atCursor\"," +
+  "\"status\"],\"type\":\"object\"},\"RunSubmission\":{\"additionalProperties\":false" +
+  ",\"description\":\"Immutable, secret-free native-v2 submission admitted by " +
+  "the selected target.\",\"properties\":{\"graph\":{\"$ref\":\"#/$defs/GraphSpec\"}" +
+  ",\"initialInput\":true,\"runtime\":{\"$ref\":\"#/$defs/RuntimePlan\"},\"source\":{" +
+  "\"$ref\":\"#/$defs/ResolvedSource\"},\"submissionKey\":{\"maxLength\":256,\"minLe" +
   "ngth\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\":\"string\"" +
-  "}},\"required\":[\"subscriptionId\",\"runId\",\"title\",\"source\",\"size\",\"cursor\"" +
-  ",\"status\"],\"type\":\"object\"},\"RunWatchParams\":{\"additionalProperties\":fal" +
-  "se,\"description\":\"Establishes a durable run watch.\\n\\n`fromCursor` is ex" +
-  "clusive. Reconnecting with the last delivered cursor therefore returns e" +
-  "ach\\nlater watch record once, with no replayed boundary record and no sk" +
-  "ipped later record.\",\"properties\":{\"fromCursor\":{\"type\":[\"string\",\"null\"" +
-  "]},\"runId\":{\"type\":\"string\"}},\"required\":[\"runId\"],\"type\":\"object\"},\"Run" +
-  "WatchResult\":{\"additionalProperties\":false,\"properties\":{\"atCursor\":{\"ty" +
-  "pe\":\"string\"},\"runId\":{\"type\":\"string\"},\"subscriptionId\":{\"type\":\"string" +
-  "\"}},\"required\":[\"subscriptionId\",\"runId\",\"atCursor\"],\"type\":\"object\"},\"R" +
-  "untimePlan\":{\"oneOf\":[{\"additionalProperties\":false,\"properties\":{\"harne" +
-  "ss\":{\"const\":\"codex\",\"type\":\"string\"},\"nodes\":{\"additionalProperties\":fa" +
-  "lse,\"patternProperties\":{\"^[A-Za-z_][A-Za-z0-9_.-]*$\":{\"$ref\":\"#/$defs/N" +
-  "odeRuntimeBinding\"}},\"type\":\"object\"},\"provider\":{\"$ref\":\"#/$defs/CodexP" +
-  "rovider\"},\"size\":{\"$ref\":\"#/$defs/RunSize\"}},\"required\":[\"harness\",\"prov" +
-  "ider\",\"size\",\"nodes\"],\"type\":\"object\"},{\"additionalProperties\":false,\"pr" +
-  "operties\":{\"harness\":{\"const\":\"claude\",\"type\":\"string\"},\"nodes\":{\"additi" +
-  "onalProperties\":false,\"patternProperties\":{\"^[A-Za-z_][A-Za-z0-9_.-]*$\":" +
-  "{\"$ref\":\"#/$defs/NodeRuntimeBinding\"}},\"type\":\"object\"},\"provider\":{\"$re" +
-  "f\":\"#/$defs/ClaudeProvider\"},\"size\":{\"$ref\":\"#/$defs/RunSize\"}},\"require" +
-  "d\":[\"harness\",\"provider\",\"size\",\"nodes\"],\"type\":\"object\"}]},\"ServerCapab" +
-  "ilities\":{\"additionalProperties\":false,\"properties\":{\"agentAttach\":{\"def" +
-  "ault\":false,\"type\":\"boolean\"},\"graphProfiles\":{\"default\":[],\"items\":{\"$r" +
-  "ef\":\"#/$defs/GraphProfile\"},\"maxItems\":2,\"not\":{\"minItems\":2,\"prefixItem" +
-  "s\":[{\"const\":\"openengine.graph.single-worker/v1\"},{\"const\":\"openengine.g" +
-  "raph.full/v1\"}]},\"type\":\"array\",\"uniqueItems\":true},\"logs\":{\"default\":fa" +
-  "lse,\"type\":\"boolean\"}},\"type\":\"object\"},\"SessionScope\":{\"enum\":[\"executi" +
-  "on\",\"node_instance\"],\"type\":\"string\"},\"StopMode\":{\"enum\":[\"drain\",\"force" +
-  "\"],\"type\":\"string\"},\"StopParams\":{\"additionalProperties\":false,\"properti" +
-  "es\":{\"idempotencyKey\":{\"maxLength\":256,\"minLength\":1,\"pattern\":\"^[^\\\\u00" +
-  "00-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\":\"string\"},\"ifGeneration\":{\"maximum\"" +
-  ":9007199254740991,\"minimum\":0,\"type\":\"integer\"},\"mode\":{\"$ref\":\"#/$defs/" +
-  "StopMode\"}},\"required\":[\"mode\",\"ifGeneration\",\"idempotencyKey\"],\"type\":\"" +
-  "object\"},\"StopResult\":{\"additionalProperties\":false,\"properties\":{\"accep" +
-  "tedMode\":{\"$ref\":\"#/$defs/StopMode\"},\"atCursor\":{\"type\":\"string\"},\"dedup" +
-  "ed\":{\"type\":\"boolean\"},\"effectiveMode\":{\"$ref\":\"#/$defs/StopMode\"},\"gene" +
-  "ration\":{\"maximum\":9007199254740991,\"minimum\":0,\"type\":\"integer\"},\"opera" +
-  "tional\":{\"$ref\":\"#/$defs/OperationalStatus\"},\"phase\":{\"$ref\":\"#/$defs/Ph" +
-  "ase\"},\"runId\":{\"type\":\"string\"}},\"required\":[\"generation\",\"runId\",\"phase" +
-  "\",\"acceptedMode\",\"effectiveMode\",\"operational\",\"atCursor\",\"deduped\"],\"ty" +
-  "pe\":\"object\"},\"StructuralBounds\":{\"additionalProperties\":false,\"properti" +
-  "es\":{\"attemptsPerNode\":{\"additionalProperties\":{\"maximum\":90071992547409" +
-  "91,\"minimum\":1,\"type\":\"integer\"},\"propertyNames\":{\"maxLength\":128,\"minLe" +
-  "ngth\":1,\"pattern\":\"^[A-Za-z_][A-Za-z0-9_.-]*$\",\"type\":\"string\"},\"type\":\"" +
-  "object\"},\"maxNodeExecutions\":{\"maximum\":9007199254740991,\"minimum\":1,\"ty" +
-  "pe\":\"integer\"},\"peakConcurrency\":{\"maximum\":9007199254740991,\"minimum\":1" +
-  ",\"type\":\"integer\"},\"termination\":{\"$ref\":\"#/$defs/TerminationWitness\"}}," +
-  "\"required\":[\"termination\",\"maxNodeExecutions\",\"peakConcurrency\",\"attempt" +
-  "sPerNode\"],\"type\":\"object\"},\"SubscriptionCancelParams\":{\"additionalPrope" +
-  "rties\":false,\"description\":\"Wire body of the generic `subscription/cance" +
-  "l` client notification.\",\"properties\":{\"subscriptionId\":{\"type\":\"string\"" +
-  "}},\"required\":[\"subscriptionId\"],\"type\":\"object\"},\"SubscriptionCloseReas" +
-  "on\":{\"enum\":[\"done\",\"SLOW_CONSUMER\"],\"type\":\"string\"},\"SubscriptionClose" +
-  "dNotification\":{\"additionalProperties\":false,\"description\":\"Wire body of" +
-  " the terminal `subscription/closed` server notification.\",\"properties\":{" +
-  "\"lastDeliveredCursor\":{\"type\":[\"string\",\"null\"]},\"reason\":{\"$ref\":\"#/$de" +
-  "fs/SubscriptionCloseReason\"},\"subscriptionId\":{\"type\":\"string\"}},\"requir" +
-  "ed\":[\"subscriptionId\",\"reason\"],\"type\":\"object\"},\"TerminalResult\":{\"desc" +
-  "ription\":\"Authoritative terminal value for backends that can durably rec" +
-  "onstruct a completed graph.\\n\\nThis is additive to [`GetResult`]: backen" +
-  "ds that do not yet expose terminal values leave the\\noptional field abse" +
-  "nt, including when their status is already `finished`.\",\"oneOf\":[{\"addit" +
-  "ionalProperties\":false,\"properties\":{\"output\":true,\"status\":{\"const\":\"su" +
-  "cceeded\",\"type\":\"string\"}},\"required\":[\"status\",\"output\"],\"type\":\"object" +
-  "\"},{\"additionalProperties\":false,\"properties\":{\"reason\":{\"maxLength\":128" +
-  ",\"minLength\":1,\"pattern\":\"^[A-Za-z_][A-Za-z0-9_.-]*$\",\"type\":\"string\"},\"" +
-  "status\":{\"const\":\"failed\",\"type\":\"string\"}},\"required\":[\"status\",\"reason" +
-  "\"],\"type\":\"object\"}]},\"TerminationWitness\":{\"oneOf\":[{\"additionalPropert" +
-  "ies\":false,\"properties\":{\"kind\":{\"const\":\"acyclic\",\"type\":\"string\"},\"ord" +
-  "er\":{\"$ref\":\"#/$defs/NonEmptyVec_of_NodeName\"}},\"required\":[\"kind\",\"orde" +
-  "r\"],\"type\":\"object\"},{\"additionalProperties\":false,\"properties\":{\"kind\":" +
-  "{\"const\":\"bounded\",\"type\":\"string\"},\"maxIterations\":{\"maximum\":900719925" +
-  "4740991,\"minimum\":1,\"type\":\"integer\"},\"ranking\":{\"$ref\":\"#/$defs/NonEmpt" +
-  "yVec_of_FieldPath\"}},\"required\":[\"kind\",\"ranking\",\"maxIterations\"],\"type" +
-  "\":\"object\"}]},\"TokenUsage\":{\"additionalProperties\":false,\"description\":\"" +
-  "Run-wide sum of provider-reported usage for every launched agent invocat" +
-  "ion.\\n\\n`complete` is false when at least one invocation did not report " +
-  "usable counters. Cache\\ncounters are omitted when the provider does not " +
-  "expose them consistently.\",\"properties\":{\"cacheCreationInputTokens\":{\"ma" +
-  "ximum\":9007199254740991,\"minimum\":0,\"type\":[\"integer\",\"null\"]},\"cacheRea" +
-  "dInputTokens\":{\"maximum\":9007199254740991,\"minimum\":0,\"type\":[\"integer\"," +
-  "\"null\"]},\"complete\":{\"type\":\"boolean\"},\"inputTokens\":{\"maximum\":90071992" +
-  "54740991,\"minimum\":0,\"type\":\"integer\"},\"outputTokens\":{\"maximum\":9007199" +
-  "254740991,\"minimum\":0,\"type\":\"integer\"}},\"required\":[\"inputTokens\",\"outp" +
-  "utTokens\",\"complete\"],\"type\":\"object\"},\"UpdateParams\":{\"additionalProper" +
-  "ties\":false,\"anyOf\":[{\"required\":[\"labels\"]},{\"required\":[\"logLevel\"]},{" +
-  "\"required\":[\"suspended\"]}],\"properties\":{\"idempotencyKey\":{\"maxLength\":2" +
+  "},\"title\":{\"maxLength\":256,\"minLength\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001f\\\\" +
+  "u007f-\\\\u009f]+$\",\"type\":\"string\"}},\"required\":[\"title\",\"graph\",\"initial" +
+  "Input\",\"runtime\",\"source\",\"submissionKey\"],\"type\":\"object\"},\"RunSubmitPa" +
+  "rams\":{\"additionalProperties\":false,\"description\":\"Trusted controller bo" +
+  "otstrap admission. The host assigns the only public run identity before\\" +
+  "ncontroller start; the immutable submission remains identity-neutral.\",\"" +
+  "properties\":{\"runId\":{\"type\":\"string\"},\"submission\":{\"$ref\":\"#/$defs/Run" +
+  "Submission\"}},\"required\":[\"runId\",\"submission\"],\"type\":\"object\"},\"RunSub" +
+  "mitResult\":{\"additionalProperties\":false,\"description\":\"A successful sub" +
+  "mission returns the one public identity used by every later run method.\"" +
+  ",\"properties\":{\"runId\":{\"type\":\"string\"}},\"required\":[\"runId\"],\"type\":\"o" +
+  "bject\"},\"RunWatchEventNotification\":{\"additionalProperties\":false,\"descr" +
+  "iption\":\"One durable public status projection. `cursor` is stable run hi" +
+  "story, not a connection-local\\nsequence; clients resume strictly after i" +
+  "t.\",\"properties\":{\"cursor\":{\"type\":\"string\"},\"runId\":{\"type\":\"string\"},\"" +
+  "size\":{\"$ref\":\"#/$defs/RunSize\"},\"source\":{\"$ref\":\"#/$defs/ResolvedSourc" +
+  "e\"},\"status\":{\"$ref\":\"#/$defs/RunStatus\"},\"subscriptionId\":{\"type\":\"stri" +
+  "ng\"},\"title\":{\"maxLength\":256,\"minLength\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001" +
+  "f\\\\u007f-\\\\u009f]+$\",\"type\":\"string\"}},\"required\":[\"subscriptionId\",\"run" +
+  "Id\",\"title\",\"source\",\"size\",\"cursor\",\"status\"],\"type\":\"object\"},\"RunWatc" +
+  "hParams\":{\"additionalProperties\":false,\"description\":\"Establishes a dura" +
+  "ble run watch.\\n\\n`fromCursor` is exclusive. Reconnecting with the last " +
+  "delivered cursor therefore returns each\\nlater watch record once, with n" +
+  "o replayed boundary record and no skipped later record.\",\"properties\":{\"" +
+  "fromCursor\":{\"type\":[\"string\",\"null\"]},\"runId\":{\"type\":\"string\"}},\"requi" +
+  "red\":[\"runId\"],\"type\":\"object\"},\"RunWatchResult\":{\"additionalProperties\"" +
+  ":false,\"properties\":{\"atCursor\":{\"type\":\"string\"},\"runId\":{\"type\":\"strin" +
+  "g\"},\"subscriptionId\":{\"type\":\"string\"}},\"required\":[\"subscriptionId\",\"ru" +
+  "nId\",\"atCursor\"],\"type\":\"object\"},\"RuntimePlan\":{\"oneOf\":[{\"additionalPr" +
+  "operties\":false,\"properties\":{\"harness\":{\"const\":\"codex\",\"type\":\"string\"" +
+  "},\"nodes\":{\"additionalProperties\":false,\"patternProperties\":{\"^[A-Za-z_]" +
+  "[A-Za-z0-9_.-]*$\":{\"$ref\":\"#/$defs/NodeRuntimeBinding\"}},\"type\":\"object\"" +
+  "},\"provider\":{\"$ref\":\"#/$defs/CodexProvider\"},\"size\":{\"$ref\":\"#/$defs/Ru" +
+  "nSize\"}},\"required\":[\"harness\",\"provider\",\"size\",\"nodes\"],\"type\":\"object" +
+  "\"},{\"additionalProperties\":false,\"properties\":{\"harness\":{\"const\":\"claud" +
+  "e\",\"type\":\"string\"},\"nodes\":{\"additionalProperties\":false,\"patternProper" +
+  "ties\":{\"^[A-Za-z_][A-Za-z0-9_.-]*$\":{\"$ref\":\"#/$defs/NodeRuntimeBinding\"" +
+  "}},\"type\":\"object\"},\"provider\":{\"$ref\":\"#/$defs/ClaudeProvider\"},\"size\":" +
+  "{\"$ref\":\"#/$defs/RunSize\"}},\"required\":[\"harness\",\"provider\",\"size\",\"nod" +
+  "es\"],\"type\":\"object\"}]},\"ServerCapabilities\":{\"additionalProperties\":fal" +
+  "se,\"properties\":{\"agentAttach\":{\"default\":false,\"type\":\"boolean\"},\"graph" +
+  "Profiles\":{\"default\":[],\"items\":{\"$ref\":\"#/$defs/GraphProfile\"},\"maxItem" +
+  "s\":2,\"not\":{\"minItems\":2,\"prefixItems\":[{\"const\":\"openengine.graph.singl" +
+  "e-worker/v1\"},{\"const\":\"openengine.graph.full/v1\"}]},\"type\":\"array\",\"uni" +
+  "queItems\":true},\"logs\":{\"default\":false,\"type\":\"boolean\"}},\"type\":\"objec" +
+  "t\"},\"SessionScope\":{\"enum\":[\"execution\",\"node_instance\"],\"type\":\"string\"" +
+  "},\"StopMode\":{\"enum\":[\"drain\",\"force\"],\"type\":\"string\"},\"StopParams\":{\"a" +
+  "dditionalProperties\":false,\"properties\":{\"idempotencyKey\":{\"maxLength\":2" +
   "56,\"minLength\":1,\"pattern\":\"^[^\\\\u0000-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\"" +
   ":\"string\"},\"ifGeneration\":{\"maximum\":9007199254740991,\"minimum\":0,\"type\"" +
-  ":\"integer\"},\"labels\":{\"$ref\":\"#/$defs/Labels\"},\"logLevel\":{\"$ref\":\"#/$de" +
-  "fs/LogLevel\"},\"suspended\":{\"type\":\"boolean\"}},\"required\":[\"ifGeneration\"" +
-  ",\"idempotencyKey\"],\"type\":\"object\"},\"UpdateResult\":{\"additionalPropertie" +
-  "s\":false,\"properties\":{\"atCursor\":{\"type\":\"string\"},\"deduped\":{\"type\":\"b" +
-  "oolean\"},\"generation\":{\"maximum\":9007199254740991,\"minimum\":0,\"type\":\"in" +
-  "teger\"},\"operational\":{\"$ref\":\"#/$defs/OperationalStatus\"},\"phase\":{\"$re" +
-  "f\":\"#/$defs/Phase\"},\"runId\":{\"type\":\"string\"}},\"required\":[\"generation\"," +
-  "\"runId\",\"phase\",\"operational\",\"atCursor\",\"deduped\"],\"type\":\"object\"},\"Wa" +
-  "tchEvent\":{\"description\":\"The closed public event algebra. `Phase` folds" +
-  " the observable cluster status (admission\\ncommit, update, suspend/resum" +
-  "e, stop-request); `NodeBegin`/`NodeEnd` are a testkit-only\\nsynthetic ho" +
-  "ok decoupled from the real dispatch/lease turn mechanism, since no nativ" +
-  "e graph\\nexecutor exists yet; `Bookmark` advances the cursor without cha" +
-  "nging folded public state;\\n`Fault` carries a durable, backend-neutral p" +
-  "rojected `BackendFault`: it correlates to the\\nenclosing `EventNotificat" +
-  "ion.run_id` plus its own optional opaque `executionRef`, and its\\norderi" +
-  "ng/emission never itself authorizes a retry or changes terminal semantic" +
-  "s -- it folds to\\nno public status change, exactly like `Bookmark`; `Fin" +
-  "ished` is always the last event for a\\nrun.\",\"oneOf\":[{\"additionalProper" +
-  "ties\":false,\"properties\":{\"admission\":{\"anyOf\":[{\"$ref\":\"#/$defs/Admissi" +
-  "onTransition\"},{\"type\":\"null\"}]},\"status\":{\"$ref\":\"#/$defs/ClusterStatus" +
-  "\"},\"type\":{\"const\":\"phase\",\"type\":\"string\"}},\"required\":[\"type\",\"status\"" +
-  "],\"type\":\"object\"},{\"additionalProperties\":false,\"properties\":{\"input\":t" +
-  "rue,\"node\":{\"$ref\":\"#/$defs/NodeAddress\"},\"type\":{\"const\":\"node_begin\",\"" +
-  "type\":\"string\"}},\"required\":[\"type\",\"node\",\"input\"],\"type\":\"object\"},{\"a" +
-  "dditionalProperties\":false,\"properties\":{\"node\":{\"$ref\":\"#/$defs/NodeAdd" +
-  "ress\"},\"outcome\":{\"$ref\":\"#/$defs/WorkerOutcome\"},\"type\":{\"const\":\"node_" +
-  "end\",\"type\":\"string\"}},\"required\":[\"type\",\"node\",\"outcome\"],\"type\":\"obje" +
-  "ct\"},{\"additionalProperties\":false,\"properties\":{\"type\":{\"const\":\"bookma" +
-  "rk\",\"type\":\"string\"}},\"required\":[\"type\"],\"type\":\"object\"},{\"additionalP" +
-  "roperties\":false,\"properties\":{\"fault\":{\"$ref\":\"#/$defs/BackendFault\"},\"" +
-  "type\":{\"const\":\"fault\",\"type\":\"string\"}},\"required\":[\"type\",\"fault\"],\"ty" +
-  "pe\":\"object\"},{\"additionalProperties\":false,\"properties\":{\"final_status\"" +
-  ":{\"$ref\":\"#/$defs/ClusterStatus\"},\"stop_mode\":{\"anyOf\":[{\"$ref\":\"#/$defs" +
-  "/StopMode\"},{\"type\":\"null\"}]},\"type\":{\"const\":\"finished\",\"type\":\"string\"" +
-  "}},\"required\":[\"type\",\"final_status\"],\"type\":\"object\"}]},\"WatchParams\":{" +
-  "\"additionalProperties\":false,\"properties\":{\"fromCursor\":{\"default\":null," +
-  "\"type\":[\"string\",\"null\"]},\"runId\":{\"default\":null,\"type\":[\"string\",\"null" +
-  "\"]}},\"type\":\"object\"},\"WatchResult\":{\"properties\":{\"atCursor\":{\"type\":[\"" +
-  "string\",\"null\"]},\"runId\":{\"type\":[\"string\",\"null\"]},\"subscriptionId\":{\"t" +
-  "ype\":\"string\"}},\"required\":[\"subscriptionId\"],\"type\":\"object\"},\"WorkerEr" +
-  "rorCode\":{\"enum\":[\"timeout\",\"crash\",\"malformed\",\"refusal\"],\"type\":\"strin" +
-  "g\"},\"WorkerFailureReason\":{\"enum\":[\"declared_failure\",\"policy_denied\",\"i" +
-  "nteractive_input_required\",\"authentication_required\",\"malformed_result\"]" +
-  ",\"type\":\"string\"},\"WorkerOutcome\":{\"allOf\":[{\"$ref\":\"#/$defs/WorkerOutco" +
-  "meWire\"},{\"if\":{\"properties\":{\"status\":{\"const\":\"error\"}},\"required\":[\"s" +
-  "tatus\"]},\"then\":{\"oneOf\":[{\"properties\":{\"reason\":{\"const\":\"declared_fai" +
-  "lure\"}},\"required\":[\"reason\"]},{\"properties\":{\"code\":{\"const\":\"refusal\"}" +
-  ",\"reason\":{\"enum\":[\"policy_denied\",\"interactive_input_required\",\"authent" +
-  "ication_required\"]}},\"required\":[\"code\",\"reason\"]},{\"properties\":{\"code\"" +
-  ":{\"const\":\"malformed\"},\"reason\":{\"const\":\"malformed_result\"}},\"required\"" +
-  ":[\"code\",\"reason\"]}]}}]},\"WorkerOutcomeWire\":{\"oneOf\":[{\"additionalPrope" +
-  "rties\":false,\"properties\":{\"artifacts\":{\"items\":{\"$ref\":\"#/$defs/Artifac" +
-  "tRef\"},\"type\":\"array\"},\"output\":true,\"status\":{\"const\":\"verified\",\"type\"" +
-  ":\"string\"}},\"required\":[\"status\",\"output\",\"artifacts\"],\"type\":\"object\"}," +
-  "{\"additionalProperties\":false,\"properties\":{\"artifacts\":{\"items\":{\"$ref\"" +
-  ":\"#/$defs/ArtifactRef\"},\"type\":\"array\"},\"diagnostic\":true,\"output\":true," +
-  "\"signals\":{\"additionalProperties\":{\"maxLength\":128,\"minLength\":1,\"patter" +
-  "n\":\"^[A-Za-z_][A-Za-z0-9_.-]*$\",\"type\":\"string\"},\"propertyNames\":{\"maxLe" +
-  "ngth\":128,\"minLength\":1,\"pattern\":\"^[A-Za-z_][A-Za-z0-9_.-]*$\",\"type\":\"s" +
-  "tring\"},\"type\":\"object\"},\"status\":{\"const\":\"verifier\",\"type\":\"string\"}}," +
-  "\"required\":[\"status\",\"output\",\"signals\",\"diagnostic\",\"artifacts\"],\"type\"" +
-  ":\"object\"},{\"additionalProperties\":false,\"properties\":{\"code\":{\"$ref\":\"#" +
-  "/$defs/WorkerErrorCode\"},\"reason\":{\"$ref\":\"#/$defs/WorkerFailureReason\"}" +
-  ",\"status\":{\"const\":\"error\",\"type\":\"string\"}},\"required\":[\"status\",\"code\"" +
-  ",\"reason\"],\"type\":\"object\"}]},\"WriteBinding\":{\"additionalProperties\":fal" +
-  "se,\"properties\":{\"target\":{\"items\":{\"maxLength\":128,\"minLength\":1,\"patte" +
-  "rn\":\"^[A-Za-z_][A-Za-z0-9_.-]*$\",\"type\":\"string\"},\"maxItems\":64,\"minItem" +
-  "s\":1,\"type\":\"array\"},\"value\":{\"$ref\":\"#/$defs/NodeOutputSelector\"}},\"req" +
-  "uired\":[\"value\",\"target\"],\"type\":\"object\"}},\"$schema\":\"https://json-sche" +
-  "ma.org/draft/2020-12/schema\",\"properties\":{\"agent_attach_closed_notifica" +
-  "tion\":{\"$ref\":\"#/$defs/JsonRpcNotification8\"},\"agent_attach_event_notifi" +
-  "cation\":{\"$ref\":\"#/$defs/JsonRpcNotification7\"},\"agent_attach_request\":{" +
-  "\"$ref\":\"#/$defs/JsonRpcRequest12\"},\"agent_attach_response\":{\"$ref\":\"#/$d" +
-  "efs/JsonRpcResponse12\"},\"apply_request\":{\"$ref\":\"#/$defs/JsonRpcRequest3" +
-  "\"},\"apply_response\":{\"$ref\":\"#/$defs/JsonRpcResponse3\"},\"cancel_request_" +
-  "notification\":{\"$ref\":\"#/$defs/JsonRpcNotification4\"},\"delete_request\":{" +
-  "\"$ref\":\"#/$defs/JsonRpcRequest9\"},\"delete_response\":{\"$ref\":\"#/$defs/Jso" +
-  "nRpcResponse9\"},\"event_notification\":{\"$ref\":\"#/$defs/JsonRpcNotificatio" +
-  "n\"},\"get_request\":{\"$ref\":\"#/$defs/JsonRpcRequest4\"},\"get_response\":{\"$r" +
-  "ef\":\"#/$defs/JsonRpcResponse4\"},\"initialize_request\":{\"$ref\":\"#/$defs/Js" +
-  "onRpcRequest\"},\"initialize_response\":{\"$ref\":\"#/$defs/JsonRpcResponse\"}," +
-  "\"log_event_notification\":{\"$ref\":\"#/$defs/JsonRpcNotification5\"},\"logs_c" +
-  "losed_notification\":{\"$ref\":\"#/$defs/JsonRpcNotification6\"},\"logs_reques" +
-  "t\":{\"$ref\":\"#/$defs/JsonRpcRequest11\"},\"logs_response\":{\"$ref\":\"#/$defs/" +
-  "JsonRpcResponse11\"},\"plan_request\":{\"$ref\":\"#/$defs/JsonRpcRequest2\"},\"p" +
-  "lan_response\":{\"$ref\":\"#/$defs/JsonRpcResponse2\"},\"resubmit_request\":{\"$" +
-  "ref\":\"#/$defs/JsonRpcRequest8\"},\"resubmit_response\":{\"$ref\":\"#/$defs/Jso" +
-  "nRpcResponse8\"},\"retry_request\":{\"$ref\":\"#/$defs/JsonRpcRequest7\"},\"retr" +
-  "y_response\":{\"$ref\":\"#/$defs/JsonRpcResponse7\"},\"run_attach_event_notifi" +
-  "cation\":{\"$ref\":\"#/$defs/JsonRpcNotification11\"},\"run_attach_request\":{\"" +
-  "$ref\":\"#/$defs/JsonRpcRequest18\"},\"run_attach_response\":{\"$ref\":\"#/$defs" +
-  "/JsonRpcResponse18\"},\"run_force_request\":{\"$ref\":\"#/$defs/JsonRpcRequest" +
-  "19\"},\"run_force_response\":{\"$ref\":\"#/$defs/JsonRpcResponse19\"},\"run_list" +
-  "_request\":{\"$ref\":\"#/$defs/JsonRpcRequest14\"},\"run_list_response\":{\"$ref" +
-  "\":\"#/$defs/JsonRpcResponse14\"},\"run_log_event_notification\":{\"$ref\":\"#/$" +
-  "defs/JsonRpcNotification10\"},\"run_logs_request\":{\"$ref\":\"#/$defs/JsonRpc" +
-  "Request17\"},\"run_logs_response\":{\"$ref\":\"#/$defs/JsonRpcResponse17\"},\"ru" +
-  "n_status_request\":{\"$ref\":\"#/$defs/JsonRpcRequest15\"},\"run_status_respon" +
-  "se\":{\"$ref\":\"#/$defs/JsonRpcResponse15\"},\"run_submit_request\":{\"$ref\":\"#" +
-  "/$defs/JsonRpcRequest13\"},\"run_submit_response\":{\"$ref\":\"#/$defs/JsonRpc" +
-  "Response13\"},\"run_watch_event_notification\":{\"$ref\":\"#/$defs/JsonRpcNoti" +
-  "fication9\"},\"run_watch_request\":{\"$ref\":\"#/$defs/JsonRpcRequest16\"},\"run" +
-  "_watch_response\":{\"$ref\":\"#/$defs/JsonRpcResponse16\"},\"stop_request\":{\"$" +
-  "ref\":\"#/$defs/JsonRpcRequest6\"},\"stop_response\":{\"$ref\":\"#/$defs/JsonRpc" +
-  "Response6\"},\"subscription_cancel_notification\":{\"$ref\":\"#/$defs/JsonRpcN" +
-  "otification2\"},\"subscription_closed_notification\":{\"$ref\":\"#/$defs/JsonR" +
-  "pcNotification3\"},\"update_request\":{\"$ref\":\"#/$defs/JsonRpcRequest5\"},\"u" +
-  "pdate_response\":{\"$ref\":\"#/$defs/JsonRpcResponse5\"},\"watch_request\":{\"$r" +
-  "ef\":\"#/$defs/JsonRpcRequest10\"},\"watch_response\":{\"$ref\":\"#/$defs/JsonRp" +
-  "cResponse10\"}},\"required\":[\"initialize_request\",\"initialize_response\",\"p" +
-  "lan_request\",\"plan_response\",\"apply_request\",\"apply_response\",\"get_reque" +
-  "st\",\"get_response\",\"update_request\",\"update_response\",\"stop_request\",\"st" +
-  "op_response\",\"retry_request\",\"retry_response\",\"resubmit_request\",\"resubm" +
-  "it_response\",\"delete_request\",\"delete_response\",\"watch_request\",\"watch_r" +
-  "esponse\",\"event_notification\",\"subscription_cancel_notification\",\"subscr" +
-  "iption_closed_notification\",\"cancel_request_notification\",\"logs_request\"" +
-  ",\"logs_response\",\"log_event_notification\",\"logs_closed_notification\",\"ag" +
-  "ent_attach_request\",\"agent_attach_response\",\"agent_attach_event_notifica" +
-  "tion\",\"agent_attach_closed_notification\",\"run_submit_request\",\"run_submi" +
-  "t_response\",\"run_list_request\",\"run_list_response\",\"run_status_request\"," +
-  "\"run_status_response\",\"run_watch_request\",\"run_watch_response\",\"run_watc" +
-  "h_event_notification\",\"run_logs_request\",\"run_logs_response\",\"run_log_ev" +
-  "ent_notification\",\"run_attach_request\",\"run_attach_response\",\"run_attach" +
-  "_event_notification\",\"run_force_request\",\"run_force_response\"],\"title\":\"" +
-  "ImplementedProtocolSchema\",\"type\":\"object\"}"
+  ":\"integer\"},\"mode\":{\"$ref\":\"#/$defs/StopMode\"}},\"required\":[\"mode\",\"ifGe" +
+  "neration\",\"idempotencyKey\"],\"type\":\"object\"},\"StopResult\":{\"additionalPr" +
+  "operties\":false,\"properties\":{\"acceptedMode\":{\"$ref\":\"#/$defs/StopMode\"}" +
+  ",\"atCursor\":{\"type\":\"string\"},\"deduped\":{\"type\":\"boolean\"},\"effectiveMod" +
+  "e\":{\"$ref\":\"#/$defs/StopMode\"},\"generation\":{\"maximum\":9007199254740991," +
+  "\"minimum\":0,\"type\":\"integer\"},\"operational\":{\"$ref\":\"#/$defs/Operational" +
+  "Status\"},\"phase\":{\"$ref\":\"#/$defs/Phase\"},\"runId\":{\"type\":\"string\"}},\"re" +
+  "quired\":[\"generation\",\"runId\",\"phase\",\"acceptedMode\",\"effectiveMode\",\"op" +
+  "erational\",\"atCursor\",\"deduped\"],\"type\":\"object\"},\"StructuralBounds\":{\"a" +
+  "dditionalProperties\":false,\"properties\":{\"attemptsPerNode\":{\"additionalP" +
+  "roperties\":{\"maximum\":9007199254740991,\"minimum\":1,\"type\":\"integer\"},\"pr" +
+  "opertyNames\":{\"maxLength\":128,\"minLength\":1,\"pattern\":\"^[A-Za-z_][A-Za-z" +
+  "0-9_.-]*$\",\"type\":\"string\"},\"type\":\"object\"},\"maxNodeExecutions\":{\"maxim" +
+  "um\":9007199254740991,\"minimum\":1,\"type\":\"integer\"},\"peakConcurrency\":{\"m" +
+  "aximum\":9007199254740991,\"minimum\":1,\"type\":\"integer\"},\"termination\":{\"$" +
+  "ref\":\"#/$defs/TerminationWitness\"}},\"required\":[\"termination\",\"maxNodeEx" +
+  "ecutions\",\"peakConcurrency\",\"attemptsPerNode\"],\"type\":\"object\"},\"Subscri" +
+  "ptionCancelParams\":{\"additionalProperties\":false,\"description\":\"Wire bod" +
+  "y of the generic `subscription/cancel` client notification.\",\"properties" +
+  "\":{\"subscriptionId\":{\"type\":\"string\"}},\"required\":[\"subscriptionId\"],\"ty" +
+  "pe\":\"object\"},\"SubscriptionCloseReason\":{\"enum\":[\"done\",\"SLOW_CONSUMER\"]" +
+  ",\"type\":\"string\"},\"SubscriptionClosedNotification\":{\"additionalPropertie" +
+  "s\":false,\"description\":\"Wire body of the terminal `subscription/closed` " +
+  "server notification.\",\"properties\":{\"lastDeliveredCursor\":{\"type\":[\"stri" +
+  "ng\",\"null\"]},\"reason\":{\"$ref\":\"#/$defs/SubscriptionCloseReason\"},\"subscr" +
+  "iptionId\":{\"type\":\"string\"}},\"required\":[\"subscriptionId\",\"reason\"],\"typ" +
+  "e\":\"object\"},\"TerminalResult\":{\"description\":\"Authoritative terminal val" +
+  "ue for backends that can durably reconstruct a completed graph.\\n\\nThis " +
+  "is additive to [`GetResult`]: backends that do not yet expose terminal v" +
+  "alues leave the\\noptional field absent, including when their status is a" +
+  "lready `finished`.\",\"oneOf\":[{\"additionalProperties\":false,\"properties\":" +
+  "{\"output\":true,\"status\":{\"const\":\"succeeded\",\"type\":\"string\"}},\"required" +
+  "\":[\"status\",\"output\"],\"type\":\"object\"},{\"additionalProperties\":false,\"pr" +
+  "operties\":{\"reason\":{\"maxLength\":128,\"minLength\":1,\"pattern\":\"^[A-Za-z_]" +
+  "[A-Za-z0-9_.-]*$\",\"type\":\"string\"},\"status\":{\"const\":\"failed\",\"type\":\"st" +
+  "ring\"}},\"required\":[\"status\",\"reason\"],\"type\":\"object\"}]},\"TerminationWi" +
+  "tness\":{\"oneOf\":[{\"additionalProperties\":false,\"properties\":{\"kind\":{\"co" +
+  "nst\":\"acyclic\",\"type\":\"string\"},\"order\":{\"$ref\":\"#/$defs/NonEmptyVec_of_" +
+  "NodeName\"}},\"required\":[\"kind\",\"order\"],\"type\":\"object\"},{\"additionalPro" +
+  "perties\":false,\"properties\":{\"kind\":{\"const\":\"bounded\",\"type\":\"string\"}," +
+  "\"maxIterations\":{\"maximum\":9007199254740991,\"minimum\":1,\"type\":\"integer\"" +
+  "},\"ranking\":{\"$ref\":\"#/$defs/NonEmptyVec_of_FieldPath\"}},\"required\":[\"ki" +
+  "nd\",\"ranking\",\"maxIterations\"],\"type\":\"object\"}]},\"TokenUsage\":{\"additio" +
+  "nalProperties\":false,\"description\":\"Run-wide sum of provider-reported us" +
+  "age for every launched agent invocation.\\n\\n`complete` is false when at " +
+  "least one invocation did not report usable counters. Cache\\ncounters are" +
+  " omitted when the provider does not expose them consistently.\",\"properti" +
+  "es\":{\"cacheCreationInputTokens\":{\"maximum\":9007199254740991,\"minimum\":0," +
+  "\"type\":[\"integer\",\"null\"]},\"cacheReadInputTokens\":{\"maximum\":90071992547" +
+  "40991,\"minimum\":0,\"type\":[\"integer\",\"null\"]},\"complete\":{\"type\":\"boolean" +
+  "\"},\"inputTokens\":{\"maximum\":9007199254740991,\"minimum\":0,\"type\":\"integer" +
+  "\"},\"outputTokens\":{\"maximum\":9007199254740991,\"minimum\":0,\"type\":\"intege" +
+  "r\"}},\"required\":[\"inputTokens\",\"outputTokens\",\"complete\"],\"type\":\"object" +
+  "\"},\"UpdateParams\":{\"additionalProperties\":false,\"anyOf\":[{\"required\":[\"l" +
+  "abels\"]},{\"required\":[\"logLevel\"]},{\"required\":[\"suspended\"]}],\"properti" +
+  "es\":{\"idempotencyKey\":{\"maxLength\":256,\"minLength\":1,\"pattern\":\"^[^\\\\u00" +
+  "00-\\\\u001f\\\\u007f-\\\\u009f]+$\",\"type\":\"string\"},\"ifGeneration\":{\"maximum\"" +
+  ":9007199254740991,\"minimum\":0,\"type\":\"integer\"},\"labels\":{\"$ref\":\"#/$def" +
+  "s/Labels\"},\"logLevel\":{\"$ref\":\"#/$defs/LogLevel\"},\"suspended\":{\"type\":\"b" +
+  "oolean\"}},\"required\":[\"ifGeneration\",\"idempotencyKey\"],\"type\":\"object\"}," +
+  "\"UpdateResult\":{\"additionalProperties\":false,\"properties\":{\"atCursor\":{\"" +
+  "type\":\"string\"},\"deduped\":{\"type\":\"boolean\"},\"generation\":{\"maximum\":900" +
+  "7199254740991,\"minimum\":0,\"type\":\"integer\"},\"operational\":{\"$ref\":\"#/$de" +
+  "fs/OperationalStatus\"},\"phase\":{\"$ref\":\"#/$defs/Phase\"},\"runId\":{\"type\":" +
+  "\"string\"}},\"required\":[\"generation\",\"runId\",\"phase\",\"operational\",\"atCur" +
+  "sor\",\"deduped\"],\"type\":\"object\"},\"WatchEvent\":{\"description\":\"The closed" +
+  " public event algebra. `Phase` folds the observable cluster status (admi" +
+  "ssion\\ncommit, update, suspend/resume, stop-request); `NodeBegin`/`NodeE" +
+  "nd` are a testkit-only\\nsynthetic hook decoupled from the real dispatch/" +
+  "lease turn mechanism, since no native graph\\nexecutor exists yet; `Bookm" +
+  "ark` advances the cursor without changing folded public state;\\n`Fault` " +
+  "carries a durable, backend-neutral projected `BackendFault`: it correlat" +
+  "es to the\\nenclosing `EventNotification.run_id` plus its own optional op" +
+  "aque `executionRef`, and its\\nordering/emission never itself authorizes " +
+  "a retry or changes terminal semantics -- it folds to\\nno public status c" +
+  "hange, exactly like `Bookmark`; `Finished` is always the last event for " +
+  "a\\nrun.\",\"oneOf\":[{\"additionalProperties\":false,\"properties\":{\"admission" +
+  "\":{\"anyOf\":[{\"$ref\":\"#/$defs/AdmissionTransition\"},{\"type\":\"null\"}]},\"st" +
+  "atus\":{\"$ref\":\"#/$defs/ClusterStatus\"},\"type\":{\"const\":\"phase\",\"type\":\"s" +
+  "tring\"}},\"required\":[\"type\",\"status\"],\"type\":\"object\"},{\"additionalPrope" +
+  "rties\":false,\"properties\":{\"input\":true,\"node\":{\"$ref\":\"#/$defs/NodeAddr" +
+  "ess\"},\"type\":{\"const\":\"node_begin\",\"type\":\"string\"}},\"required\":[\"type\"," +
+  "\"node\",\"input\"],\"type\":\"object\"},{\"additionalProperties\":false,\"properti" +
+  "es\":{\"node\":{\"$ref\":\"#/$defs/NodeAddress\"},\"outcome\":{\"$ref\":\"#/$defs/Wo" +
+  "rkerOutcome\"},\"type\":{\"const\":\"node_end\",\"type\":\"string\"}},\"required\":[\"" +
+  "type\",\"node\",\"outcome\"],\"type\":\"object\"},{\"additionalProperties\":false,\"" +
+  "properties\":{\"type\":{\"const\":\"bookmark\",\"type\":\"string\"}},\"required\":[\"t" +
+  "ype\"],\"type\":\"object\"},{\"additionalProperties\":false,\"properties\":{\"faul" +
+  "t\":{\"$ref\":\"#/$defs/BackendFault\"},\"type\":{\"const\":\"fault\",\"type\":\"strin" +
+  "g\"}},\"required\":[\"type\",\"fault\"],\"type\":\"object\"},{\"additionalProperties" +
+  "\":false,\"properties\":{\"final_status\":{\"$ref\":\"#/$defs/ClusterStatus\"},\"s" +
+  "top_mode\":{\"anyOf\":[{\"$ref\":\"#/$defs/StopMode\"},{\"type\":\"null\"}]},\"type\"" +
+  ":{\"const\":\"finished\",\"type\":\"string\"}},\"required\":[\"type\",\"final_status\"" +
+  "],\"type\":\"object\"}]},\"WatchParams\":{\"additionalProperties\":false,\"proper" +
+  "ties\":{\"fromCursor\":{\"default\":null,\"type\":[\"string\",\"null\"]},\"runId\":{\"" +
+  "default\":null,\"type\":[\"string\",\"null\"]}},\"type\":\"object\"},\"WatchResult\":" +
+  "{\"properties\":{\"atCursor\":{\"type\":[\"string\",\"null\"]},\"runId\":{\"type\":[\"s" +
+  "tring\",\"null\"]},\"subscriptionId\":{\"type\":\"string\"}},\"required\":[\"subscri" +
+  "ptionId\"],\"type\":\"object\"},\"WorkerErrorCode\":{\"enum\":[\"timeout\",\"crash\"," +
+  "\"malformed\",\"refusal\"],\"type\":\"string\"},\"WorkerFailureReason\":{\"enum\":[\"" +
+  "declared_failure\",\"policy_denied\",\"interactive_input_required\",\"authenti" +
+  "cation_required\",\"malformed_result\"],\"type\":\"string\"},\"WorkerOutcome\":{\"" +
+  "allOf\":[{\"$ref\":\"#/$defs/WorkerOutcomeWire\"},{\"if\":{\"properties\":{\"statu" +
+  "s\":{\"const\":\"error\"}},\"required\":[\"status\"]},\"then\":{\"oneOf\":[{\"properti" +
+  "es\":{\"reason\":{\"const\":\"declared_failure\"}},\"required\":[\"reason\"]},{\"pro" +
+  "perties\":{\"code\":{\"const\":\"refusal\"},\"reason\":{\"enum\":[\"policy_denied\",\"" +
+  "interactive_input_required\",\"authentication_required\"]}},\"required\":[\"co" +
+  "de\",\"reason\"]},{\"properties\":{\"code\":{\"const\":\"malformed\"},\"reason\":{\"co" +
+  "nst\":\"malformed_result\"}},\"required\":[\"code\",\"reason\"]}]}}]},\"WorkerOutc" +
+  "omeWire\":{\"oneOf\":[{\"additionalProperties\":false,\"properties\":{\"artifact" +
+  "s\":{\"items\":{\"$ref\":\"#/$defs/ArtifactRef\"},\"type\":\"array\"},\"output\":true" +
+  ",\"status\":{\"const\":\"verified\",\"type\":\"string\"}},\"required\":[\"status\",\"ou" +
+  "tput\",\"artifacts\"],\"type\":\"object\"},{\"additionalProperties\":false,\"prope" +
+  "rties\":{\"artifacts\":{\"items\":{\"$ref\":\"#/$defs/ArtifactRef\"},\"type\":\"arra" +
+  "y\"},\"diagnostic\":true,\"output\":true,\"signals\":{\"additionalProperties\":{\"" +
+  "maxLength\":128,\"minLength\":1,\"pattern\":\"^[A-Za-z_][A-Za-z0-9_.-]*$\",\"typ" +
+  "e\":\"string\"},\"propertyNames\":{\"maxLength\":128,\"minLength\":1,\"pattern\":\"^" +
+  "[A-Za-z_][A-Za-z0-9_.-]*$\",\"type\":\"string\"},\"type\":\"object\"},\"status\":{\"" +
+  "const\":\"verifier\",\"type\":\"string\"}},\"required\":[\"status\",\"output\",\"signa" +
+  "ls\",\"diagnostic\",\"artifacts\"],\"type\":\"object\"},{\"additionalProperties\":f" +
+  "alse,\"properties\":{\"code\":{\"$ref\":\"#/$defs/WorkerErrorCode\"},\"reason\":{\"" +
+  "$ref\":\"#/$defs/WorkerFailureReason\"},\"status\":{\"const\":\"error\",\"type\":\"s" +
+  "tring\"}},\"required\":[\"status\",\"code\",\"reason\"],\"type\":\"object\"}]},\"Write" +
+  "Binding\":{\"additionalProperties\":false,\"properties\":{\"target\":{\"items\":{" +
+  "\"maxLength\":128,\"minLength\":1,\"pattern\":\"^[A-Za-z_][A-Za-z0-9_.-]*$\",\"ty" +
+  "pe\":\"string\"},\"maxItems\":64,\"minItems\":1,\"type\":\"array\"},\"value\":{\"$ref\"" +
+  ":\"#/$defs/NodeOutputSelector\"}},\"required\":[\"value\",\"target\"],\"type\":\"ob" +
+  "ject\"}},\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"proper" +
+  "ties\":{\"agent_attach_closed_notification\":{\"$ref\":\"#/$defs/JsonRpcNotifi" +
+  "cation8\"},\"agent_attach_event_notification\":{\"$ref\":\"#/$defs/JsonRpcNoti" +
+  "fication7\"},\"agent_attach_request\":{\"$ref\":\"#/$defs/JsonRpcRequest12\"},\"" +
+  "agent_attach_response\":{\"$ref\":\"#/$defs/JsonRpcResponse12\"},\"apply_reque" +
+  "st\":{\"$ref\":\"#/$defs/JsonRpcRequest3\"},\"apply_response\":{\"$ref\":\"#/$defs" +
+  "/JsonRpcResponse3\"},\"cancel_request_notification\":{\"$ref\":\"#/$defs/JsonR" +
+  "pcNotification4\"},\"delete_request\":{\"$ref\":\"#/$defs/JsonRpcRequest9\"},\"d" +
+  "elete_response\":{\"$ref\":\"#/$defs/JsonRpcResponse9\"},\"event_notification\"" +
+  ":{\"$ref\":\"#/$defs/JsonRpcNotification\"},\"get_request\":{\"$ref\":\"#/$defs/J" +
+  "sonRpcRequest4\"},\"get_response\":{\"$ref\":\"#/$defs/JsonRpcResponse4\"},\"ini" +
+  "tialize_request\":{\"$ref\":\"#/$defs/JsonRpcRequest\"},\"initialize_response\"" +
+  ":{\"$ref\":\"#/$defs/JsonRpcResponse\"},\"log_event_notification\":{\"$ref\":\"#/" +
+  "$defs/JsonRpcNotification5\"},\"logs_closed_notification\":{\"$ref\":\"#/$defs" +
+  "/JsonRpcNotification6\"},\"logs_request\":{\"$ref\":\"#/$defs/JsonRpcRequest11" +
+  "\"},\"logs_response\":{\"$ref\":\"#/$defs/JsonRpcResponse11\"},\"plan_request\":{" +
+  "\"$ref\":\"#/$defs/JsonRpcRequest2\"},\"plan_response\":{\"$ref\":\"#/$defs/JsonR" +
+  "pcResponse2\"},\"resubmit_request\":{\"$ref\":\"#/$defs/JsonRpcRequest8\"},\"res" +
+  "ubmit_response\":{\"$ref\":\"#/$defs/JsonRpcResponse8\"},\"retry_request\":{\"$r" +
+  "ef\":\"#/$defs/JsonRpcRequest7\"},\"retry_response\":{\"$ref\":\"#/$defs/JsonRpc" +
+  "Response7\"},\"run_attach_event_notification\":{\"$ref\":\"#/$defs/JsonRpcNoti" +
+  "fication11\"},\"run_attach_request\":{\"$ref\":\"#/$defs/JsonRpcRequest18\"},\"r" +
+  "un_attach_response\":{\"$ref\":\"#/$defs/JsonRpcResponse18\"},\"run_force_requ" +
+  "est\":{\"$ref\":\"#/$defs/JsonRpcRequest19\"},\"run_force_response\":{\"$ref\":\"#" +
+  "/$defs/JsonRpcResponse19\"},\"run_list_request\":{\"$ref\":\"#/$defs/JsonRpcRe" +
+  "quest14\"},\"run_list_response\":{\"$ref\":\"#/$defs/JsonRpcResponse14\"},\"run_" +
+  "log_event_notification\":{\"$ref\":\"#/$defs/JsonRpcNotification10\"},\"run_lo" +
+  "gs_request\":{\"$ref\":\"#/$defs/JsonRpcRequest17\"},\"run_logs_response\":{\"$r" +
+  "ef\":\"#/$defs/JsonRpcResponse17\"},\"run_status_request\":{\"$ref\":\"#/$defs/J" +
+  "sonRpcRequest15\"},\"run_status_response\":{\"$ref\":\"#/$defs/JsonRpcResponse" +
+  "15\"},\"run_submit_request\":{\"$ref\":\"#/$defs/JsonRpcRequest13\"},\"run_submi" +
+  "t_response\":{\"$ref\":\"#/$defs/JsonRpcResponse13\"},\"run_watch_event_notifi" +
+  "cation\":{\"$ref\":\"#/$defs/JsonRpcNotification9\"},\"run_watch_request\":{\"$r" +
+  "ef\":\"#/$defs/JsonRpcRequest16\"},\"run_watch_response\":{\"$ref\":\"#/$defs/Js" +
+  "onRpcResponse16\"},\"stop_request\":{\"$ref\":\"#/$defs/JsonRpcRequest6\"},\"sto" +
+  "p_response\":{\"$ref\":\"#/$defs/JsonRpcResponse6\"},\"subscription_cancel_not" +
+  "ification\":{\"$ref\":\"#/$defs/JsonRpcNotification2\"},\"subscription_closed_" +
+  "notification\":{\"$ref\":\"#/$defs/JsonRpcNotification3\"},\"update_request\":{" +
+  "\"$ref\":\"#/$defs/JsonRpcRequest5\"},\"update_response\":{\"$ref\":\"#/$defs/Jso" +
+  "nRpcResponse5\"},\"watch_request\":{\"$ref\":\"#/$defs/JsonRpcRequest10\"},\"wat" +
+  "ch_response\":{\"$ref\":\"#/$defs/JsonRpcResponse10\"}},\"required\":[\"initiali" +
+  "ze_request\",\"initialize_response\",\"plan_request\",\"plan_response\",\"apply_" +
+  "request\",\"apply_response\",\"get_request\",\"get_response\",\"update_request\"," +
+  "\"update_response\",\"stop_request\",\"stop_response\",\"retry_request\",\"retry_" +
+  "response\",\"resubmit_request\",\"resubmit_response\",\"delete_request\",\"delet" +
+  "e_response\",\"watch_request\",\"watch_response\",\"event_notification\",\"subsc" +
+  "ription_cancel_notification\",\"subscription_closed_notification\",\"cancel_" +
+  "request_notification\",\"logs_request\",\"logs_response\",\"log_event_notifica" +
+  "tion\",\"logs_closed_notification\",\"agent_attach_request\",\"agent_attach_re" +
+  "sponse\",\"agent_attach_event_notification\",\"agent_attach_closed_notificat" +
+  "ion\",\"run_submit_request\",\"run_submit_response\",\"run_list_request\",\"run_" +
+  "list_response\",\"run_status_request\",\"run_status_response\",\"run_watch_req" +
+  "uest\",\"run_watch_response\",\"run_watch_event_notification\",\"run_logs_requ" +
+  "est\",\"run_logs_response\",\"run_log_event_notification\",\"run_attach_reques" +
+  "t\",\"run_attach_response\",\"run_attach_event_notification\",\"run_force_requ" +
+  "est\",\"run_force_response\"],\"title\":\"ImplementedProtocolSchema\",\"type\":\"o" +
+  "bject\"}"
 );

--- a/src/cluster/generated/protocol.ts
+++ b/src/cluster/generated/protocol.ts
@@ -733,6 +733,7 @@ export type RunLogEventNotification =
   readonly "record": LogRecord;
   readonly "runId": string;
   readonly "subscriptionId": string;
+  readonly "timestamp": number;
   };
 export type RunLogsParams =
   { readonly "execution"?: string

--- a/zeroshot-rust/src/execution/process.rs
+++ b/zeroshot-rust/src/execution/process.rs
@@ -4,28 +4,50 @@ mod platform_unix;
 #[cfg(windows)]
 mod platform_windows;
 mod session;
+mod session_io;
 mod session_runtime;
 mod spawn_recovery;
+mod tail_buffer;
+
+#[path = "process/diagnostic.rs"]
+mod diagnostic;
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use thiserror::Error;
 
 use platform::ProcessContainment;
+pub(super) use diagnostic::io_error_detail;
 pub use session::{
     MAX_PROCESS_FRAME_BYTES, MAX_PROCESS_FRAMING_OVERHEAD_BYTES, MAX_PROCESS_MESSAGE_BYTES,
     PROCESS_STDIN_CAPACITY, PROCESS_STDOUT_CAPACITY, ProcessFrame, ProcessOutputChunk,
     ProcessSession, ProcessSessionCommand, ProcessSessionOutput,
 };
+pub(crate) use session::ProcessStdout;
 
 pub const MAX_PROCESS_DIAGNOSTIC_BYTES: usize = 64 * 1024;
-pub const MAX_PROCESS_ARGV_ITEMS: usize = 256;
-pub const MAX_PROCESS_ARGV_BYTES: usize = 64 * 1024;
-pub const MAX_PROCESS_ENV_ITEMS: usize = 256;
-pub const MAX_PROCESS_ENV_BYTES: usize = 64 * 1024;
+/// Last-resort allocation guards for already-constructed provider commands.
+///
+/// Provider-owned schemas and admitted environments have substantially smaller domain bounds.
+/// These limits deliberately sit far above those bounds so this generic process seam cannot
+/// reject an otherwise valid provider invocation before the operating system applies its own
+/// platform-specific launch limits.
+pub const MAX_PROCESS_ARGV_ITEMS: usize = 16 * 1024;
+pub const MAX_PROCESS_ARGV_BYTES: usize = 16 * 1024 * 1024;
+pub const MAX_PROCESS_ENV_ITEMS: usize = 16 * 1024;
+pub const MAX_PROCESS_ENV_BYTES: usize = 16 * 1024 * 1024;
 pub const HOSTED_WORKER_UID: u32 = 10_002;
 pub const HOSTED_WORKER_GID: u32 = 10_002;
+pub(super) const PROCESS_RELEASE_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+pub(super) const PROCESS_TREE_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+pub(super) const PROCESS_FORCED_IO_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+pub(crate) const CONTAINED_PROCESS_CLEANUP_BUDGET: Duration = Duration::from_secs(
+    PROCESS_RELEASE_WAIT_TIMEOUT.as_secs()
+        + PROCESS_TREE_CLEANUP_TIMEOUT.as_secs()
+        + PROCESS_FORCED_IO_DRAIN_TIMEOUT.as_secs(),
+);
 
 pub(crate) fn write_new_file(path: &Path, bytes: &[u8], unix_mode: u32) -> std::io::Result<()> {
     let mut options = std::fs::OpenOptions::new();
@@ -301,15 +323,19 @@ fn create_private_directory(path: &Path) -> Result<(), ProcessRunnerError> {
     match std::fs::create_dir(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
-        Err(_) => Err(ProcessRunnerError::Launch(
-            "provider private home could not be created".to_owned(),
-        )),
+        Err(error) => Err(ProcessRunnerError::Launch(io_error_detail(
+            "provider private home create failed",
+            &error,
+        ))),
     }
 }
 
 fn validate_private_directory(path: &Path) -> Result<(), ProcessRunnerError> {
-    let metadata = std::fs::symlink_metadata(path).map_err(|_| {
-        ProcessRunnerError::Launch("provider private home could not be inspected".to_owned())
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        ProcessRunnerError::Launch(io_error_detail(
+            "provider private home inspection failed",
+            &error,
+        ))
     })?;
     if !metadata.is_dir() || metadata.file_type().is_symlink() {
         return Err(ProcessRunnerError::InvalidCommand(
@@ -323,8 +349,11 @@ fn validate_private_directory(path: &Path) -> Result<(), ProcessRunnerError> {
 fn set_private_directory_mode(path: &Path) -> Result<(), ProcessRunnerError> {
     use std::os::unix::fs::PermissionsExt;
 
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).map_err(|_| {
-        ProcessRunnerError::Launch("provider private home mode could not be set".to_owned())
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).map_err(|error| {
+        ProcessRunnerError::Launch(io_error_detail(
+            "provider private home chmod failed",
+            &error,
+        ))
     })
 }
 
@@ -346,9 +375,10 @@ fn set_private_directory_owner(
         })?;
         // SAFETY: the path is a live NUL-free C string and the caller supplied fixed numeric IDs.
         if unsafe { libc::chown(path.as_ptr(), uid, gid) } != 0 {
-            return Err(ProcessRunnerError::Launch(
-                "provider private home ownership could not be set".to_owned(),
-            ));
+            return Err(ProcessRunnerError::Launch(io_error_detail(
+                "provider private home chown failed",
+                &std::io::Error::last_os_error(),
+            )));
         }
     }
     Ok(())

--- a/zeroshot-rust/src/execution/process/diagnostic.rs
+++ b/zeroshot-rust/src/execution/process/diagnostic.rs
@@ -1,0 +1,71 @@
+use std::io;
+
+use tokio::task::JoinError;
+
+pub(crate) fn io_error_detail(operation: &'static str, error: &io::Error) -> String {
+    let raw_os_error = error
+        .raw_os_error()
+        .map_or_else(|| "none".to_owned(), |code| code.to_string());
+    let message = sanitize_message(&error.to_string());
+    format!(
+        "{operation}: kind={:?}, raw_os_error={raw_os_error}, message={message}",
+        error.kind()
+    )
+}
+
+pub(super) fn task_join_detail(operation: &'static str, error: &JoinError) -> String {
+    let cause = if error.is_panic() {
+        "task panicked"
+    } else if error.is_cancelled() {
+        "task was cancelled"
+    } else {
+        "task failed"
+    };
+    format!("{operation}: {cause}")
+}
+
+fn sanitize_message(message: &str) -> String {
+    message
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_testkit::assertions::AssertError;
+
+    use super::*;
+
+    #[test]
+    fn io_detail_preserves_structured_cause_and_sanitizes_controls() {
+        let error = io::Error::new(io::ErrorKind::PermissionDenied, "denied\nsecret-path");
+
+        let detail = io_error_detail("stdout read failed", &error);
+
+        assert_eq!(
+            detail,
+            "stdout read failed: kind=PermissionDenied, raw_os_error=none, message=denied secret-path"
+        );
+    }
+
+    #[tokio::test]
+    async fn join_detail_classifies_panics_without_exposing_the_payload() {
+        let joined = tokio::spawn(async {
+            assert!(std::hint::black_box(false), "sensitive panic payload");
+        })
+        .await
+        .assert_error();
+
+        let detail = task_join_detail("stderr task failed", &joined);
+
+        assert_eq!(detail, "stderr task failed: task panicked");
+        assert!(!detail.contains("sensitive"));
+    }
+}

--- a/zeroshot-rust/src/execution/process/platform.rs
+++ b/zeroshot-rust/src/execution/process/platform.rs
@@ -3,7 +3,8 @@ use std::io;
 use tokio::process::Command;
 use tokio::time::{Duration, Instant, sleep, timeout_at};
 
-const PROCESS_TREE_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+use super::{PROCESS_TREE_CLEANUP_TIMEOUT, io_error_detail};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProcessContainment {
     ProcessGroup,
@@ -174,19 +175,26 @@ pub async fn terminate_process_tree(
     handle: &ProcessTreeHandle,
     child: &mut tokio::process::Child,
 ) -> TerminationOutcome {
-    kill_process_tree(handle, child);
+    let mut errors = kill_process_tree(handle, child);
     let cleanup_deadline = Instant::now() + PROCESS_TREE_CLEANUP_TIMEOUT;
     match timeout_at(cleanup_deadline, child.wait()).await {
         Ok(Ok(status)) => {
             let cleanup = await_group_exit(handle, cleanup_deadline).await;
+            errors.extend(cleanup.error);
             TerminationOutcome {
                 exit_status: Some(status),
                 cleanup: cleanup.cleanup,
-                error: cleanup.error,
+                error: join_errors(errors),
             }
         }
-        Ok(Err(error)) => termination_without_status(handle, cleanup_deadline, Some(error)).await,
-        Err(_) => termination_without_status(handle, cleanup_deadline, None).await,
+        Ok(Err(error)) => {
+            errors.push(io_error_detail("process cleanup wait failed", &error));
+            termination_without_status(handle, cleanup_deadline, errors).await
+        }
+        Err(_) => {
+            errors.push("process cleanup wait timed out".to_owned());
+            termination_without_status(handle, cleanup_deadline, errors).await
+        }
     }
 }
 
@@ -203,7 +211,7 @@ pub fn configure_process(command: &mut Command, _containment: ProcessContainment
 pub fn configure_process(_command: &mut Command, _containment: ProcessContainment) {}
 
 #[cfg(unix)]
-fn kill_process_tree(handle: &ProcessTreeHandle, child: &mut tokio::process::Child) {
+fn kill_process_tree(handle: &ProcessTreeHandle, child: &mut tokio::process::Child) -> Vec<String> {
     super::platform_unix::kill_process_tree(
         handle.process_group_id,
         {
@@ -217,17 +225,23 @@ fn kill_process_tree(handle: &ProcessTreeHandle, child: &mut tokio::process::Chi
             }
         },
         child,
-    );
+    )
 }
 
 #[cfg(windows)]
-fn kill_process_tree(handle: &ProcessTreeHandle, child: &mut tokio::process::Child) {
-    super::platform_windows::kill_process_tree(handle.job, child);
+fn kill_process_tree(handle: &ProcessTreeHandle, child: &mut tokio::process::Child) -> Vec<String> {
+    super::platform_windows::kill_process_tree(handle.job, child)
 }
 
 #[cfg(all(not(unix), not(windows)))]
-fn kill_process_tree(_handle: &ProcessTreeHandle, child: &mut tokio::process::Child) {
-    let _ = child.start_kill();
+fn kill_process_tree(
+    _handle: &ProcessTreeHandle,
+    child: &mut tokio::process::Child,
+) -> Vec<String> {
+    child.start_kill().map_or_else(
+        |error| vec![io_error_detail("process termination failed", &error)],
+        |()| Vec::new(),
+    )
 }
 
 pub fn process_tree_has_live_members(handle: &ProcessTreeHandle) -> Result<bool, io::Error> {
@@ -287,7 +301,7 @@ async fn await_process_group_exit(process_group_id: i32, deadline: Instant) -> C
     loop {
         #[cfg(target_os = "linux")]
         if let Err(error) = super::platform_unix::reap_process_group_children(process_group_id) {
-            return cleanup_failure(error);
+            return cleanup_failure("process group child reap failed", &error);
         }
         match super::platform_unix::process_group_has_live_members(process_group_id) {
             Ok(false) => {
@@ -297,7 +311,7 @@ async fn await_process_group_exit(process_group_id: i32, deadline: Instant) -> C
                 };
             }
             Ok(true) => {}
-            Err(error) => return cleanup_failure(error),
+            Err(error) => return cleanup_failure("process group inspection failed", &error),
         }
         if Instant::now() >= deadline {
             return cleanup_timeout();
@@ -316,7 +330,7 @@ async fn await_worker_uid_exit(worker_uid: u32, deadline: Instant) -> CleanupOut
                 };
             }
             Ok(true) => {}
-            Err(error) => return cleanup_failure(error),
+            Err(error) => return cleanup_failure("worker containment cleanup failed", &error),
         }
         if Instant::now() >= deadline {
             return cleanup_timeout();
@@ -336,7 +350,7 @@ async fn await_process_tree_exit(handle: &ProcessTreeHandle, deadline: Instant) 
                 };
             }
             Ok(true) => {}
-            Err(error) => return cleanup_failure(error),
+            Err(error) => return cleanup_failure("Windows job inspection failed", &error),
         }
         if Instant::now() >= deadline {
             return cleanup_timeout();
@@ -345,10 +359,10 @@ async fn await_process_tree_exit(handle: &ProcessTreeHandle, deadline: Instant) 
     }
 }
 
-fn cleanup_failure(error: io::Error) -> CleanupOutcome {
+fn cleanup_failure(operation: &'static str, error: &io::Error) -> CleanupOutcome {
     CleanupOutcome {
         cleanup: ProcessCleanupEvidence::TimedOut,
-        error: Some(format!("process cleanup failed: {error}")),
+        error: Some(io_error_detail(operation, error)),
     }
 }
 
@@ -362,20 +376,46 @@ fn cleanup_timeout() -> CleanupOutcome {
 async fn termination_without_status(
     handle: &ProcessTreeHandle,
     cleanup_deadline: Instant,
-    wait_error: Option<io::Error>,
+    mut errors: Vec<String>,
 ) -> TerminationOutcome {
     let cleanup = await_group_exit(handle, cleanup_deadline).await;
-    let error = match (wait_error, cleanup.error) {
-        (Some(wait_error), Some(cleanup_error)) => Some(format!(
-            "process cleanup wait failed: {wait_error}; {cleanup_error}"
-        )),
-        (Some(wait_error), None) => Some(format!("process cleanup wait failed: {wait_error}")),
-        (None, Some(cleanup_error)) => Some(cleanup_error),
-        (None, None) => Some("process cleanup timed out".to_owned()),
-    };
+    errors.extend(cleanup.error);
     TerminationOutcome {
         exit_status: None,
         cleanup: cleanup.cleanup,
-        error,
+        error: join_errors(errors),
+    }
+}
+
+fn join_errors(errors: Vec<String>) -> Option<String> {
+    (!errors.is_empty()).then(|| errors.join("; "))
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_testkit::assertions::AssertValue;
+
+    use super::*;
+
+    #[test]
+    fn cleanup_failure_retains_structured_io_evidence() {
+        let error = io::Error::new(io::ErrorKind::PermissionDenied, "injected cleanup cause");
+
+        let outcome = cleanup_failure("process group inspection failed", &error);
+        let detail = outcome.error.assert_value();
+
+        assert_eq!(outcome.cleanup, ProcessCleanupEvidence::TimedOut);
+        assert!(detail.starts_with("process group inspection failed"));
+        assert!(detail.contains("kind=PermissionDenied"));
+        assert!(detail.contains("raw_os_error=none"));
+        assert!(detail.contains("message=injected cleanup cause"));
+    }
+
+    #[test]
+    fn termination_errors_keep_all_observable_causes() {
+        assert_eq!(
+            join_errors(vec!["kill cause".to_owned(), "wait cause".to_owned()]),
+            Some("kill cause; wait cause".to_owned())
+        );
     }
 }

--- a/zeroshot-rust/src/execution/process/platform_unix.rs
+++ b/zeroshot-rust/src/execution/process/platform_unix.rs
@@ -41,22 +41,43 @@ pub(super) fn kill_process_tree(
     process_group_id: Option<i32>,
     worker_uid: Option<u32>,
     child: &mut tokio::process::Child,
-) {
+) -> Vec<String> {
+    let mut errors = Vec::new();
     #[cfg(target_os = "linux")]
     if let Some(worker_uid) = worker_uid {
-        let _ = kill_linux_uid_processes(worker_uid);
+        if let Err(error) = kill_linux_uid_processes(worker_uid) {
+            errors.push(super::io_error_detail(
+                "worker process termination failed",
+                &error,
+            ));
+        }
     }
     #[cfg(not(target_os = "linux"))]
     let _ = worker_uid;
     let Some(process_group_id) = process_group_id else {
-        let _ = child.start_kill();
-        return;
+        if let Err(error) = child.start_kill() {
+            errors.push(super::io_error_detail(
+                "root process termination failed",
+                &error,
+            ));
+        }
+        return errors;
     };
     if let Err(error) = kill_process_group(process_group_id) {
         if error.raw_os_error() != Some(libc::ESRCH) {
-            let _ = child.start_kill();
+            errors.push(super::io_error_detail(
+                "process group termination failed",
+                &error,
+            ));
+            if let Err(error) = child.start_kill() {
+                errors.push(super::io_error_detail(
+                    "root process termination fallback failed",
+                    &error,
+                ));
+            }
         }
     }
+    errors
 }
 
 fn kill_process_group(process_group_id: i32) -> Result<(), io::Error> {

--- a/zeroshot-rust/src/execution/process/platform_windows.rs
+++ b/zeroshot-rust/src/execution/process/platform_windows.rs
@@ -104,11 +104,23 @@ pub(super) fn configure_process_group(command: &mut Command) {
     command.creation_flags(CREATE_SUSPENDED);
 }
 
-pub(super) fn kill_process_tree(job: usize, child: &mut tokio::process::Child) {
+pub(super) fn kill_process_tree(job: usize, child: &mut tokio::process::Child) -> Vec<String> {
     let terminated = unsafe { TerminateJobObject(job as HANDLE, 1) };
-    if terminated == 0 {
-        let _ = child.start_kill();
+    if terminated != 0 {
+        return Vec::new();
     }
+    let termination_error = io::Error::last_os_error();
+    let mut errors = vec![super::io_error_detail(
+        "Windows job termination failed",
+        &termination_error,
+    )];
+    if let Err(error) = child.start_kill() {
+        errors.push(super::io_error_detail(
+            "root process termination fallback failed",
+            &error,
+        ));
+    }
+    errors
 }
 
 fn resume_suspended_process(process_id: u32) -> Result<(), io::Error> {

--- a/zeroshot-rust/src/execution/process/session.rs
+++ b/zeroshot-rust/src/execution/process/session.rs
@@ -8,13 +8,12 @@ use tokio::time::Instant;
 use crate::execution::driver::{DriverCancellation, WorkspaceCapability};
 
 use super::platform::{ProcessContainment, capture_process_tree, register_process_tree_for};
-use super::session_runtime::{
-    SupervisorRequest, TailBuffer, WriterCommand, spawn_stderr_pump, spawn_stdout_pump,
-    spawn_writer, supervise_session,
-};
+use super::session_io::{WriterCommand, spawn_stderr_pump, spawn_stdout_pump, spawn_writer};
+use super::session_runtime::{SupervisorRequest, supervise_session};
 use super::spawn_recovery::{
     ChildCommandSpec, SpawnRecovery, build_child_command, validate_launch_fields,
 };
+use super::tail_buffer::TailBuffer;
 use super::{LocalProcessRunner, ProcessCleanupEvidence, ProcessLaunchEvidence, ProcessRunnerError};
 
 pub const PROCESS_STDOUT_CAPACITY: usize = 64;
@@ -113,7 +112,10 @@ impl ProcessOutputChunk {
 pub struct ProcessSessionOutput {
     pub launch_evidence: ProcessLaunchEvidence,
     pub exit_code: Option<i32>,
+    pub termination_signal: Option<i32>,
+    pub core_dumped: bool,
     pub stderr_tail: Vec<u8>,
+    pub stderr_tail_truncated: bool,
     pub cancelled: bool,
     pub timed_out: bool,
     pub cleanup: ProcessCleanupEvidence,
@@ -126,6 +128,20 @@ pub struct ProcessSession {
     release: watch::Sender<bool>,
     completion: watch::Receiver<Option<Arc<ProcessSessionOutput>>>,
     stdin_closed: bool,
+}
+
+/// The bounded stdout half of a running process session.
+///
+/// Detaching this half lets callers drain child output while they continue streaming stdin,
+/// without adding another buffer between the process pump and the provider parser.
+pub(crate) struct ProcessStdout {
+    stdout: mpsc::Receiver<ProcessOutputChunk>,
+}
+
+impl ProcessStdout {
+    pub(crate) async fn recv(&mut self) -> Option<ProcessOutputChunk> {
+        self.stdout.recv().await
+    }
 }
 
 impl ProcessSession {
@@ -160,7 +176,7 @@ impl ProcessSession {
         acknowledged
             .await
             .map_err(|_| ProcessRunnerError::Io("process stdin writer stopped".to_owned()))?
-            .map_err(|message| ProcessRunnerError::Io(message.to_owned()))
+            .map_err(ProcessRunnerError::Io)
     }
 
     pub async fn close_stdin(&mut self) -> Result<(), ProcessRunnerError> {
@@ -189,11 +205,24 @@ impl ProcessSession {
         acknowledged
             .await
             .map_err(|_| ProcessRunnerError::Io("process stdin writer stopped".to_owned()))?
-            .map_err(|message| ProcessRunnerError::Io(message.to_owned()))
+            .map_err(ProcessRunnerError::Io)
     }
 
     pub async fn recv_stdout(&mut self) -> Option<ProcessOutputChunk> {
         self.stdout.recv().await
+    }
+
+    /// Detaches the single bounded stdout receiver from this session.
+    ///
+    /// A subsequent call receives an already-closed stream. Dropping the detached half closes its
+    /// receiver, so an input failure can unblock the stdout pump before releasing the process.
+    #[must_use]
+    pub(crate) fn detach_stdout(&mut self) -> ProcessStdout {
+        let (closed_sender, closed_receiver) = mpsc::channel(1);
+        drop(closed_sender);
+        ProcessStdout {
+            stdout: std::mem::replace(&mut self.stdout, closed_receiver),
+        }
     }
 
     /// Waits for process completion without consuming the bounded stdout queue.
@@ -207,6 +236,7 @@ impl ProcessSession {
 
     pub async fn release(&mut self) -> Result<ProcessSessionOutput, ProcessRunnerError> {
         self.stdin_closed = true;
+        self.stdout.close();
         self.release.send_replace(true);
         await_completion(&mut self.completion).await
     }
@@ -222,8 +252,11 @@ async fn spawn_contained_process(
     command: &ProcessSessionCommand,
     containment: ProcessContainment,
 ) -> Result<SpawnRecovery, ProcessRunnerError> {
-    let process_tree_registration = register_process_tree_for(containment).map_err(|_| {
-        ProcessRunnerError::Launch("process containment registration failed".to_owned())
+    let process_tree_registration = register_process_tree_for(containment).map_err(|error| {
+        ProcessRunnerError::Launch(super::io_error_detail(
+            "process containment registration failed",
+            &error,
+        ))
     })?;
     let mut recovery = SpawnRecovery::registered();
     let mut child_command = build_child_command(
@@ -236,8 +269,8 @@ async fn spawn_contained_process(
         containment,
     );
     child_command.kill_on_drop(true);
-    let child = child_command.spawn().map_err(|_| {
-        ProcessRunnerError::Launch("operating system rejected process launch".to_owned())
+    let child = child_command.spawn().map_err(|error| {
+        ProcessRunnerError::Launch(super::io_error_detail("process spawn failed", &error))
     })?;
     recovery.capture(child);
     let Some(recovery_child) = recovery.child_mut() else {
@@ -247,11 +280,13 @@ async fn spawn_contained_process(
     };
     let process_tree = match capture_process_tree(process_tree_registration, recovery_child) {
         Ok(process_tree) => process_tree,
-        Err(_) => {
-            recovery.recover().await;
-            return Err(ProcessRunnerError::Io(
-                "process containment capture failed".to_owned(),
-            ));
+        Err(error) => {
+            let mut detail = super::io_error_detail("process containment capture failed", &error);
+            if let Some(recovery_detail) = recovery.recover().await {
+                detail.push_str("; ");
+                detail.push_str(&recovery_detail);
+            }
+            return Err(ProcessRunnerError::Io(detail));
         }
     };
     recovery.capture_process_tree(process_tree);
@@ -268,10 +303,12 @@ impl LocalProcessRunner {
 
         let mut recovery = spawn_contained_process(&command, self.containment).await?;
         let Some(child) = recovery.child_mut() else {
-            recovery.recover().await;
-            return Err(ProcessRunnerError::Io(
-                "contained process was not retained".to_owned(),
-            ));
+            let mut detail = "contained process was not retained".to_owned();
+            if let Some(recovery_detail) = recovery.recover().await {
+                detail.push_str("; ");
+                detail.push_str(&recovery_detail);
+            }
+            return Err(ProcessRunnerError::Io(detail));
         };
         let stdin = child.stdin.take();
         let stdout = child.stdout.take();
@@ -302,9 +339,9 @@ impl LocalProcessRunner {
             release: release_rx,
             writer_stop: writer_stop_tx,
             io_failures: io_failure_rx,
-            stdout_task,
-            stderr_task,
-            writer_task,
+            stdout_task: Some(stdout_task),
+            stderr_task: Some(stderr_task),
+            writer_task: Some(writer_task),
             stderr_tail,
             completion: completion_tx,
         }));

--- a/zeroshot-rust/src/execution/process/session_io.rs
+++ b/zeroshot-rust/src/execution/process/session_io.rs
@@ -1,0 +1,255 @@
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio::task::JoinHandle;
+
+use super::io_error_detail;
+use super::session::ProcessOutputChunk;
+use super::tail_buffer::TailBuffer;
+
+pub(super) const PROCESS_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
+
+pub(super) enum WriterCommand {
+    Frame(Vec<u8>, oneshot::Sender<Result<(), String>>),
+    Close(oneshot::Sender<Result<(), String>>),
+}
+
+#[derive(Debug)]
+pub(super) struct IoFailure {
+    detail: String,
+    expected_during_release: bool,
+}
+
+impl IoFailure {
+    fn from_io(operation: &'static str, error: &std::io::Error) -> Self {
+        Self {
+            detail: io_error_detail(operation, error),
+            expected_during_release: false,
+        }
+    }
+
+    fn static_detail(detail: &'static str) -> Self {
+        Self {
+            detail: detail.to_owned(),
+            expected_during_release: false,
+        }
+    }
+
+    fn release_artifact(detail: &'static str) -> Self {
+        Self {
+            detail: detail.to_owned(),
+            expected_during_release: true,
+        }
+    }
+
+    pub(super) const fn should_report(&self, releasing: bool) -> bool {
+        !releasing || !self.expected_during_release
+    }
+
+    pub(super) fn into_detail(self) -> String {
+        self.detail
+    }
+}
+
+pub(super) fn spawn_stdout_pump(
+    stdout: Option<ChildStdout>,
+    output: mpsc::Sender<ProcessOutputChunk>,
+    failures: mpsc::UnboundedSender<IoFailure>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(stdout) = stdout else {
+            let _ = failures.send(IoFailure::static_detail(
+                "process stdout pipe is unavailable",
+            ));
+            return;
+        };
+        if let Err(failure) = read_stdout(stdout, output).await {
+            let _ = failures.send(failure);
+        }
+    })
+}
+
+async fn read_stdout<R>(
+    mut stdout: R,
+    output: mpsc::Sender<ProcessOutputChunk>,
+) -> Result<(), IoFailure>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut chunk = vec![0_u8; PROCESS_OUTPUT_CHUNK_BYTES];
+    loop {
+        let read = stdout
+            .read(&mut chunk)
+            .await
+            .map_err(|error| IoFailure::from_io("process stdout read failed", &error))?;
+        if read == 0 {
+            return Ok(());
+        }
+        let bytes = chunk.get(..read).ok_or_else(|| {
+            IoFailure::static_detail("process stdout read returned an invalid byte count")
+        })?;
+        output
+            .send(ProcessOutputChunk::from_bytes(bytes.to_vec()))
+            .await
+            .map_err(|_| IoFailure::release_artifact("process stdout delivery failed"))?;
+    }
+}
+
+pub(super) fn spawn_stderr_pump(
+    stderr: Option<ChildStderr>,
+    tail: Arc<Mutex<TailBuffer>>,
+    failures: mpsc::UnboundedSender<IoFailure>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(stderr) = stderr else {
+            let _ = failures.send(IoFailure::static_detail(
+                "process stderr pipe is unavailable",
+            ));
+            return;
+        };
+        if let Err(failure) = read_stderr(stderr, tail).await {
+            let _ = failures.send(failure);
+        }
+    })
+}
+
+async fn read_stderr<R>(mut stderr: R, tail: Arc<Mutex<TailBuffer>>) -> Result<(), IoFailure>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut chunk = [0_u8; 8192];
+    loop {
+        let read = stderr
+            .read(&mut chunk)
+            .await
+            .map_err(|error| IoFailure::from_io("process stderr read failed", &error))?;
+        if read == 0 {
+            return Ok(());
+        }
+        let bytes = chunk.get(..read).ok_or_else(|| {
+            IoFailure::static_detail("process stderr read returned an invalid byte count")
+        })?;
+        tail.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .append(bytes);
+    }
+}
+
+pub(super) fn spawn_writer(
+    stdin: Option<ChildStdin>,
+    commands: mpsc::Receiver<WriterCommand>,
+    stop: watch::Receiver<bool>,
+    failures: mpsc::UnboundedSender<IoFailure>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let Some(stdin) = stdin else {
+            let _ = failures.send(IoFailure::static_detail(
+                "process stdin pipe is unavailable",
+            ));
+            return;
+        };
+        run_writer(stdin, commands, stop, failures).await;
+    })
+}
+
+async fn run_writer<W>(
+    mut stdin: W,
+    mut commands: mpsc::Receiver<WriterCommand>,
+    mut stop: watch::Receiver<bool>,
+    failures: mpsc::UnboundedSender<IoFailure>,
+) where
+    W: AsyncWrite + Unpin,
+{
+    loop {
+        tokio::select! {
+            biased;
+            changed = stop.changed() => {
+                if changed.is_err() || *stop.borrow() {
+                    report_shutdown_failure(
+                        &mut stdin,
+                        "process stdin shutdown after writer stop failed",
+                        &failures,
+                    ).await;
+                    return;
+                }
+            }
+            command = commands.recv() => {
+                match command {
+                    Some(WriterCommand::Frame(frame, acknowledge)) => {
+                        let result = tokio::select! {
+                            biased;
+                            changed = stop.changed() => {
+                                let _ = changed;
+                                Err(IoFailure::static_detail("process stdin writer stopped"))
+                            }
+                            result = stdin.write_all(&frame) => {
+                                result.map_err(|error| {
+                                    IoFailure::from_io("process stdin write failed", &error)
+                                })
+                            }
+                        };
+                        if let Err(failure) = result {
+                            let _ = acknowledge.send(Err(failure.detail.clone()));
+                            let _ = failures.send(failure);
+                            report_shutdown_failure(
+                                &mut stdin,
+                                "process stdin shutdown after write failure failed",
+                                &failures,
+                            ).await;
+                            return;
+                        }
+                        let _ = acknowledge.send(Ok(()));
+                    }
+                    Some(WriterCommand::Close(acknowledge)) => {
+                        match shutdown_stdin(&mut stdin, "process stdin shutdown failed").await {
+                            Ok(()) => {
+                                let _ = acknowledge.send(Ok(()));
+                            }
+                            Err(failure) => {
+                                let _ = acknowledge.send(Err(failure.detail.clone()));
+                                let _ = failures.send(failure);
+                            }
+                        }
+                        return;
+                    }
+                    None => {
+                        report_shutdown_failure(
+                            &mut stdin,
+                            "process stdin shutdown after command channel closed failed",
+                            &failures,
+                        ).await;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn shutdown_stdin<W>(stdin: &mut W, operation: &'static str) -> Result<(), IoFailure>
+where
+    W: AsyncWrite + Unpin,
+{
+    stdin
+        .shutdown()
+        .await
+        .map_err(|error| IoFailure::from_io(operation, &error))
+}
+
+async fn report_shutdown_failure<W>(
+    stdin: &mut W,
+    operation: &'static str,
+    failures: &mpsc::UnboundedSender<IoFailure>,
+) where
+    W: AsyncWrite + Unpin,
+{
+    if let Err(failure) = shutdown_stdin(stdin, operation).await {
+        let _ = failures.send(failure);
+    }
+}
+
+#[cfg(test)]
+#[path = "session_io/tests.rs"]
+mod tests;

--- a/zeroshot-rust/src/execution/process/session_io/tests.rs
+++ b/zeroshot-rust/src/execution/process/session_io/tests.rs
@@ -1,0 +1,187 @@
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::sync::{mpsc, oneshot, watch};
+
+use super::*;
+
+struct FailingReader {
+    kind: io::ErrorKind,
+    message: &'static str,
+}
+
+impl AsyncRead for FailingReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        _buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Poll::Ready(Err(io::Error::new(self.kind, self.message)))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WriteFailure {
+    Write,
+    Shutdown,
+}
+
+struct FailingWriter(WriteFailure);
+
+impl AsyncWrite for FailingWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _context: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.0 {
+            WriteFailure::Write => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "injected write cause",
+            ))),
+            WriteFailure::Shutdown => Poll::Ready(Ok(buffer.len())),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.0 {
+            WriteFailure::Write => Poll::Ready(Ok(())),
+            WriteFailure::Shutdown => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "injected shutdown cause",
+            ))),
+        }
+    }
+}
+
+#[tokio::test]
+async fn stdout_and_stderr_read_failures_retain_the_io_cause() {
+    let (output, _output_rx) = mpsc::channel(1);
+    let stdout = read_stdout(
+        FailingReader {
+            kind: io::ErrorKind::ConnectionReset,
+            message: "injected stdout cause",
+        },
+        output,
+    )
+    .await
+    .assert_error()
+    .into_detail();
+    let stderr = read_stderr(
+        FailingReader {
+            kind: io::ErrorKind::UnexpectedEof,
+            message: "injected stderr cause",
+        },
+        std::sync::Arc::new(std::sync::Mutex::new(TailBuffer::new(16))),
+    )
+    .await
+    .assert_error()
+    .into_detail();
+
+    assert_io_detail(
+        &stdout,
+        "process stdout read failed",
+        "ConnectionReset",
+        "injected stdout cause",
+    );
+    assert_io_detail(
+        &stderr,
+        "process stderr read failed",
+        "UnexpectedEof",
+        "injected stderr cause",
+    );
+}
+
+#[tokio::test]
+async fn stdin_write_failure_reaches_acknowledgement_and_supervisor_channel() {
+    let (commands, command_rx) = mpsc::channel(1);
+    let (_stop, stop_rx) = watch::channel(false);
+    let (failures, mut failure_rx) = mpsc::unbounded_channel();
+    let (acknowledge, acknowledged) = oneshot::channel();
+    commands
+        .send(WriterCommand::Frame(b"input".to_vec(), acknowledge))
+        .await
+        .assert_value();
+
+    run_writer(
+        FailingWriter(WriteFailure::Write),
+        command_rx,
+        stop_rx,
+        failures,
+    )
+    .await;
+
+    let acknowledged = acknowledged.await.assert_value().assert_error();
+    let reported = failure_rx.recv().await.assert_value().into_detail();
+    assert_io_detail(
+        &acknowledged,
+        "process stdin write failed",
+        "BrokenPipe",
+        "injected write cause",
+    );
+    assert_eq!(reported, acknowledged);
+}
+
+#[tokio::test]
+async fn explicit_and_channel_drop_shutdown_failures_retain_the_io_cause() {
+    let explicit = shutdown_case(true).await;
+    let channel_drop = shutdown_case(false).await;
+
+    assert_io_detail(
+        &explicit,
+        "process stdin shutdown failed",
+        "PermissionDenied",
+        "injected shutdown cause",
+    );
+    assert_io_detail(
+        &channel_drop,
+        "process stdin shutdown after command channel closed failed",
+        "PermissionDenied",
+        "injected shutdown cause",
+    );
+}
+
+async fn shutdown_case(explicit: bool) -> String {
+    let (commands, command_rx) = mpsc::channel(1);
+    let (_stop, stop_rx) = watch::channel(false);
+    let (failures, mut failure_rx) = mpsc::unbounded_channel();
+    let acknowledged = if explicit {
+        let (acknowledge, acknowledged) = oneshot::channel();
+        commands
+            .send(WriterCommand::Close(acknowledge))
+            .await
+            .assert_value();
+        Some(acknowledged)
+    } else {
+        None
+    };
+    drop(commands);
+
+    run_writer(
+        FailingWriter(WriteFailure::Shutdown),
+        command_rx,
+        stop_rx,
+        failures,
+    )
+    .await;
+
+    let reported = failure_rx.recv().await.assert_value().into_detail();
+    if let Some(acknowledged) = acknowledged {
+        assert_eq!(acknowledged.await.assert_value().assert_error(), reported);
+    }
+    reported
+}
+
+fn assert_io_detail(detail: &str, operation: &str, kind: &str, message: &str) {
+    assert!(detail.starts_with(operation));
+    assert!(detail.contains(&format!("kind={kind}")));
+    assert!(detail.contains("raw_os_error=none"));
+    assert!(detail.contains(&format!("message={message}")));
+}

--- a/zeroshot-rust/src/execution/process/session_runtime.rs
+++ b/zeroshot-rust/src/execution/process/session_runtime.rs
@@ -1,30 +1,21 @@
 use std::sync::{Arc, Mutex};
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
-use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::process::Child;
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant, sleep_until, timeout, timeout_at};
 
 use crate::execution::driver::DriverCancellation;
 use super::platform::{ProcessTreeHandle, process_tree_has_live_members, terminate_process_tree};
-use super::session::{ProcessOutputChunk, ProcessSessionOutput};
-use super::{ProcessCleanupEvidence, ProcessLaunchEvidence};
+use super::session::ProcessSessionOutput;
+use super::session_io::IoFailure;
+use super::tail_buffer::TailBuffer;
+use super::{
+    PROCESS_FORCED_IO_DRAIN_TIMEOUT, PROCESS_RELEASE_WAIT_TIMEOUT, ProcessCleanupEvidence,
+    ProcessLaunchEvidence, io_error_detail,
+};
 
-const PROCESS_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
-const PROCESS_SESSION_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
-
-pub(super) enum WriterCommand {
-    Frame(Vec<u8>, oneshot::Sender<Result<(), &'static str>>),
-    Close(oneshot::Sender<Result<(), &'static str>>),
-}
-
-#[derive(Clone, Copy)]
-pub(super) enum IoFailure {
-    Stdout,
-    Stderr,
-    Stdin,
-}
+const PROCESS_IO_DRAIN_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 pub(super) struct SupervisorRequest {
     pub child: Child,
@@ -34,9 +25,9 @@ pub(super) struct SupervisorRequest {
     pub release: watch::Receiver<bool>,
     pub writer_stop: watch::Sender<bool>,
     pub io_failures: mpsc::UnboundedReceiver<IoFailure>,
-    pub stdout_task: JoinHandle<()>,
-    pub stderr_task: JoinHandle<()>,
-    pub writer_task: JoinHandle<()>,
+    pub stdout_task: Option<JoinHandle<()>>,
+    pub stderr_task: Option<JoinHandle<()>>,
+    pub writer_task: Option<JoinHandle<()>>,
     pub stderr_tail: Arc<Mutex<TailBuffer>>,
     pub completion: watch::Sender<Option<Arc<ProcessSessionOutput>>>,
 }
@@ -54,7 +45,9 @@ impl SessionState {
     fn record_wait(&mut self, status: Result<std::process::ExitStatus, std::io::Error>) {
         match status {
             Ok(status) => self.exit_status = Some(status),
-            Err(_) => self.errors.push("process wait failed".to_owned()),
+            Err(error) => self
+                .errors
+                .push(io_error_detail("process child wait failed", &error)),
         }
     }
 
@@ -64,18 +57,18 @@ impl SessionState {
         if self.exit_status.is_none() {
             self.exit_status = termination.exit_status;
         }
-        if termination.error.is_some() {
-            self.errors.push(failure.to_owned());
+        if let Some(error) = termination.error {
+            self.errors.push(format!("{failure}: {error}"));
         }
     }
 
     async fn release(&mut self, request: &mut SupervisorRequest) {
         request.writer_stop.send_replace(true);
-        match timeout(PROCESS_SESSION_DRAIN_TIMEOUT, request.child.wait()).await {
+        match timeout(PROCESS_RELEASE_WAIT_TIMEOUT, request.child.wait()).await {
             Ok(Ok(status)) => self.exit_status = Some(status),
-            Ok(Err(_)) => self
+            Ok(Err(error)) => self
                 .errors
-                .push("process wait failed during release".to_owned()),
+                .push(io_error_detail("process release wait failed", &error)),
             Err(_) => {
                 self.terminate(request, "process release cleanup failed")
                     .await;
@@ -136,30 +129,70 @@ async fn handle_io_failure(
     let Some(failure) = failure else {
         return false;
     };
-    state.errors.push(io_failure_message(failure).to_owned());
+    state.errors.push(failure.into_detail());
     state.terminate(request, "process I/O cleanup failed").await;
     true
 }
 
 async fn finish_supervision(request: &mut SupervisorRequest, state: &mut SessionState) {
     request.writer_stop.send_replace(true);
-    let drain_timed_out = drain_io_tasks(request, &mut state.errors).await;
+    let drain_timed_out = drain_io_tasks(request, state).await;
+    drain_io_failures(
+        &mut request.io_failures,
+        &mut state.errors,
+        *request.release.borrow(),
+    );
     ensure_containment(request, state, drain_timed_out).await;
     let stderr_tail = request
         .stderr_tail
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .snapshot();
+    let (exit_code, termination_signal, core_dumped) =
+        exit_status_detail(state.exit_status.as_ref());
     let output = ProcessSessionOutput {
         launch_evidence: ProcessLaunchEvidence::MayHaveStarted,
-        exit_code: state.exit_status.and_then(|status| status.code()),
-        stderr_tail,
+        exit_code,
+        termination_signal,
+        core_dumped,
+        stderr_tail: stderr_tail.bytes,
+        stderr_tail_truncated: stderr_tail.truncated,
         cancelled: state.cancelled,
         timed_out: state.timed_out,
         cleanup: state.cleanup,
         post_launch_error: join_errors(std::mem::take(&mut state.errors)),
     };
     request.completion.send_replace(Some(Arc::new(output)));
+}
+
+fn drain_io_failures(
+    failures: &mut mpsc::UnboundedReceiver<IoFailure>,
+    errors: &mut Vec<String>,
+    releasing: bool,
+) {
+    while let Ok(failure) = failures.try_recv() {
+        if failure.should_report(releasing) {
+            errors.push(failure.into_detail());
+        }
+    }
+}
+
+#[cfg(unix)]
+fn exit_status_detail(
+    status: Option<&std::process::ExitStatus>,
+) -> (Option<i32>, Option<i32>, bool) {
+    use std::os::unix::process::ExitStatusExt as _;
+
+    status.map_or((None, None, false), |status| {
+        (status.code(), status.signal(), status.core_dumped())
+    })
+}
+
+#[cfg(not(unix))]
+fn exit_status_detail(
+    status: Option<&std::process::ExitStatus>,
+) -> (Option<i32>, Option<i32>, bool) {
+    (status.and_then(std::process::ExitStatus::code), None, false)
 }
 
 fn join_errors(errors: Vec<String>) -> Option<String> {
@@ -187,33 +220,95 @@ async fn ensure_containment(
 fn inspect_tree(process_tree: &ProcessTreeHandle, errors: &mut Vec<String>) -> bool {
     match process_tree_has_live_members(process_tree) {
         Ok(has_live_members) => has_live_members,
-        Err(_) => {
-            errors.push("process containment inspection failed".to_owned());
+        Err(error) => {
+            errors.push(io_error_detail(
+                "process containment inspection failed",
+                &error,
+            ));
             true
         }
     }
 }
 
-async fn drain_io_tasks(request: &mut SupervisorRequest, errors: &mut Vec<String>) -> bool {
-    let deadline = Instant::now() + PROCESS_SESSION_DRAIN_TIMEOUT;
+async fn drain_io_tasks(request: &mut SupervisorRequest, state: &mut SessionState) -> bool {
+    let forced = state.cancelled || state.timed_out || *request.release.borrow();
+    if forced {
+        return drain_io_tasks_until(
+            request,
+            &mut state.errors,
+            Instant::now() + PROCESS_FORCED_IO_DRAIN_TIMEOUT,
+        )
+        .await;
+    }
+
+    let io_cap = Instant::now() + PROCESS_IO_DRAIN_TIMEOUT;
+    let command_deadline_wins = request.deadline <= io_cap;
+    let drain_deadline = std::cmp::min(request.deadline, io_cap);
+    let mut cancellation = request.cancellation.clone();
+    let mut release = request.release.clone();
+    enum DrainResult {
+        Complete(bool),
+        Cancelled,
+        Released,
+    }
+    let result = {
+        let drain = drain_io_tasks_until(request, &mut state.errors, drain_deadline);
+        tokio::pin!(drain);
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => DrainResult::Cancelled,
+            _ = release.changed() => DrainResult::Released,
+            result = &mut drain => DrainResult::Complete(result),
+        }
+    };
+    match result {
+        DrainResult::Complete(timed_out) => {
+            state.timed_out |= timed_out && command_deadline_wins;
+            timed_out
+        }
+        DrainResult::Cancelled => {
+            state.cancelled = true;
+            drain_io_tasks_until(
+                request,
+                &mut state.errors,
+                Instant::now() + PROCESS_FORCED_IO_DRAIN_TIMEOUT,
+            )
+            .await
+        }
+        DrainResult::Released => {
+            drain_io_tasks_until(
+                request,
+                &mut state.errors,
+                Instant::now() + PROCESS_FORCED_IO_DRAIN_TIMEOUT,
+            )
+            .await
+        }
+    }
+}
+
+async fn drain_io_tasks_until(
+    request: &mut SupervisorRequest,
+    errors: &mut Vec<String>,
+    deadline: Instant,
+) -> bool {
     let stdout = drain_io_task(
         &mut request.stdout_task,
         deadline,
-        "stdout task stopped unexpectedly",
+        "process stdout task failed",
         errors,
     )
     .await;
     let stderr = drain_io_task(
         &mut request.stderr_task,
         deadline,
-        "stderr task stopped unexpectedly",
+        "process stderr task failed",
         errors,
     )
     .await;
     let writer = drain_io_task(
         &mut request.writer_task,
         deadline,
-        "stdin task stopped unexpectedly",
+        "process stdin task failed",
         errors,
     )
     .await;
@@ -225,195 +320,33 @@ async fn drain_io_tasks(request: &mut SupervisorRequest, errors: &mut Vec<String
 }
 
 async fn drain_io_task(
-    task: &mut JoinHandle<()>,
+    task: &mut Option<JoinHandle<()>>,
     deadline: Instant,
-    failure: &'static str,
+    operation: &'static str,
     errors: &mut Vec<String>,
 ) -> bool {
-    match timeout_at(deadline, &mut *task).await {
-        Ok(Ok(())) => false,
-        Ok(Err(_)) => {
-            errors.push(failure.to_owned());
+    let Some(handle) = task.as_mut() else {
+        return false;
+    };
+    let result = timeout_at(deadline, handle).await;
+    match result {
+        Ok(joined) => {
+            task.take();
+            if let Err(error) = joined {
+                errors.push(super::diagnostic::task_join_detail(operation, &error));
+            }
             false
         }
         Err(_) => {
-            task.abort();
-            let _ = task.await;
+            if let Some(handle) = task.take() {
+                handle.abort();
+                let _ = handle.await;
+            }
             true
         }
     }
 }
 
-pub(super) fn spawn_stdout_pump(
-    stdout: Option<ChildStdout>,
-    output: mpsc::Sender<ProcessOutputChunk>,
-    failures: mpsc::UnboundedSender<IoFailure>,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let Some(mut stdout) = stdout else {
-            let _ = failures.send(IoFailure::Stdout);
-            return;
-        };
-        let mut chunk = vec![0_u8; PROCESS_OUTPUT_CHUNK_BYTES];
-        loop {
-            match stdout.read(&mut chunk).await {
-                Ok(0) => return,
-                Ok(read) => {
-                    let Some(bytes) = chunk.get(..read) else {
-                        let _ = failures.send(IoFailure::Stdout);
-                        return;
-                    };
-                    if output
-                        .send(ProcessOutputChunk::from_bytes(bytes.to_vec()))
-                        .await
-                        .is_err()
-                    {
-                        let _ = failures.send(IoFailure::Stdout);
-                        return;
-                    }
-                }
-                Err(_) => {
-                    let _ = failures.send(IoFailure::Stdout);
-                    return;
-                }
-            }
-        }
-    })
-}
-
-pub(super) fn spawn_stderr_pump(
-    stderr: Option<ChildStderr>,
-    tail: Arc<Mutex<TailBuffer>>,
-    failures: mpsc::UnboundedSender<IoFailure>,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let Some(stderr) = stderr else {
-            let _ = failures.send(IoFailure::Stderr);
-            return;
-        };
-        if read_stderr(stderr, tail).await.is_err() {
-            let _ = failures.send(IoFailure::Stderr);
-        }
-    })
-}
-
-async fn read_stderr<R>(mut stderr: R, tail: Arc<Mutex<TailBuffer>>) -> Result<(), ()>
-where
-    R: AsyncRead + Unpin,
-{
-    let mut chunk = [0_u8; 8192];
-    loop {
-        let read = stderr.read(&mut chunk).await.map_err(|_| ())?;
-        if read == 0 {
-            return Ok(());
-        }
-        tail.lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .append(chunk.get(..read).ok_or(())?);
-    }
-}
-
-pub(super) fn spawn_writer(
-    stdin: Option<ChildStdin>,
-    mut commands: mpsc::Receiver<WriterCommand>,
-    mut stop: watch::Receiver<bool>,
-    failures: mpsc::UnboundedSender<IoFailure>,
-) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        let Some(mut stdin) = stdin else {
-            let _ = failures.send(IoFailure::Stdin);
-            return;
-        };
-        loop {
-            tokio::select! {
-                biased;
-                changed = stop.changed() => {
-                    if changed.is_err() || *stop.borrow() {
-                        return;
-                    }
-                }
-                command = commands.recv() => {
-                    match command {
-                        Some(WriterCommand::Frame(frame, acknowledge)) => {
-                            let result = tokio::select! {
-                                biased;
-                                changed = stop.changed() => {
-                                    let _ = changed;
-                                    Err("process stdin writer stopped")
-                                }
-                                result = stdin.write_all(&frame) => {
-                                    result.map_err(|_| "process stdin write failed")
-                                }
-                            };
-                            let failed = result.is_err();
-                            let _ = acknowledge.send(result);
-                            if failed {
-                                let _ = failures.send(IoFailure::Stdin);
-                                return;
-                            }
-                        }
-                        Some(WriterCommand::Close(acknowledge)) => {
-                            let result = stdin
-                                .shutdown()
-                                .await
-                                .map_err(|_| "process stdin close failed");
-                            let failed = result.is_err();
-                            let _ = acknowledge.send(result);
-                            if failed {
-                                let _ = failures.send(IoFailure::Stdin);
-                            }
-                            return;
-                        }
-                        None => {
-                            let _ = stdin.shutdown().await;
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-    })
-}
-
-fn io_failure_message(failure: IoFailure) -> &'static str {
-    match failure {
-        IoFailure::Stdout => "process stdout stream failed",
-        IoFailure::Stderr => "process stderr stream failed",
-        IoFailure::Stdin => "process stdin stream failed",
-    }
-}
-
-pub(super) struct TailBuffer {
-    bytes: Vec<u8>,
-    capacity: usize,
-}
-
-impl TailBuffer {
-    pub(super) fn new(capacity: usize) -> Self {
-        Self {
-            bytes: Vec::with_capacity(capacity),
-            capacity,
-        }
-    }
-
-    fn append(&mut self, value: &[u8]) {
-        if value.len() >= self.capacity {
-            self.bytes.clear();
-            if let Some(tail) = value.get(value.len() - self.capacity..) {
-                self.bytes.extend_from_slice(tail);
-            }
-            return;
-        }
-        let required = self.bytes.len() + value.len();
-        if required > self.capacity {
-            let discard = required - self.capacity;
-            self.bytes.copy_within(discard.., 0);
-            self.bytes.truncate(self.bytes.len() - discard);
-        }
-        self.bytes.extend_from_slice(value);
-    }
-
-    fn snapshot(&self) -> Vec<u8> {
-        self.bytes.clone()
-    }
-}
+#[cfg(test)]
+#[path = "session_runtime/tests.rs"]
+mod tests;

--- a/zeroshot-rust/src/execution/process/session_runtime/tests.rs
+++ b/zeroshot-rust/src/execution/process/session_runtime/tests.rs
@@ -1,0 +1,58 @@
+use std::io;
+
+use super::*;
+
+#[test]
+fn child_wait_failure_retains_the_io_cause() {
+    let mut state = SessionState::default();
+
+    state.record_wait(Err(io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "injected child wait cause",
+    )));
+
+    assert_eq!(state.errors.len(), 1);
+    let detail = state.errors.first().map_or("", String::as_str);
+    assert!(detail.starts_with("process child wait failed"));
+    assert!(detail.contains("kind=PermissionDenied"));
+    assert!(detail.contains("message=injected child wait cause"));
+}
+
+#[tokio::test]
+async fn io_task_panic_is_classified_without_exposing_its_payload() {
+    let mut task = Some(tokio::spawn(async {
+        assert!(std::hint::black_box(false), "sensitive panic payload");
+    }));
+    let mut errors = Vec::new();
+
+    let timed_out = drain_io_task(
+        &mut task,
+        Instant::now() + Duration::from_secs(1),
+        "process stdout task failed",
+        &mut errors,
+    )
+    .await;
+
+    assert!(!timed_out);
+    assert_eq!(errors, ["process stdout task failed: task panicked"]);
+    assert!(!errors.join(" ").contains("sensitive"));
+}
+
+#[tokio::test]
+async fn io_task_cancellation_is_preserved_as_the_join_cause() {
+    let handle = tokio::spawn(std::future::pending::<()>());
+    handle.abort();
+    let mut task = Some(handle);
+    let mut errors = Vec::new();
+
+    let timed_out = drain_io_task(
+        &mut task,
+        Instant::now() + Duration::from_secs(1),
+        "process stderr task failed",
+        &mut errors,
+    )
+    .await;
+
+    assert!(!timed_out);
+    assert_eq!(errors, ["process stderr task failed: task was cancelled"]);
+}

--- a/zeroshot-rust/src/execution/process/spawn_recovery.rs
+++ b/zeroshot-rust/src/execution/process/spawn_recovery.rs
@@ -2,13 +2,14 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use tokio::process::{Child, Command};
+use tokio::time::{Instant, timeout_at};
 
 use crate::execution::driver::WorkspaceCapability;
 
 use super::platform::{self, ProcessContainment, ProcessTreeHandle, terminate_process_tree};
 use super::{
     MAX_PROCESS_ARGV_BYTES, MAX_PROCESS_ARGV_ITEMS, MAX_PROCESS_ENV_BYTES, MAX_PROCESS_ENV_ITEMS,
-    ProcessRunnerError,
+    PROCESS_TREE_CLEANUP_TIMEOUT, ProcessRunnerError, io_error_detail,
 };
 
 pub(super) struct SpawnRecovery {
@@ -36,16 +37,9 @@ impl SpawnRecovery {
         self.child.as_mut()
     }
 
-    pub(super) async fn recover(mut self) {
-        let Some(mut child) = self.child.take() else {
-            return;
-        };
-        if let Some(process_tree) = self.process_tree.take() {
-            let _ = terminate_process_tree(&process_tree, &mut child).await;
-        } else {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-        }
+    pub(super) async fn recover(mut self) -> Option<String> {
+        let mut child = self.child.take()?;
+        recover_child(&mut child, self.process_tree.take()).await
     }
 
     pub(super) fn disarm(mut self) -> Option<(Child, ProcessTreeHandle)> {
@@ -60,14 +54,30 @@ impl Drop for SpawnRecovery {
         };
         let process_tree = self.process_tree.take();
         tokio::spawn(async move {
-            if let Some(process_tree) = process_tree {
-                let _ = terminate_process_tree(&process_tree, &mut child).await;
-            } else {
-                let _ = child.start_kill();
-                let _ = child.wait().await;
-            }
+            // No observer remains during Drop, so cleanup is necessarily best-effort here. Every
+            // explicit recovery path awaits this same helper and returns its safe diagnostics.
+            let _ = recover_child(&mut child, process_tree).await;
         });
     }
+}
+
+async fn recover_child(
+    child: &mut Child,
+    process_tree: Option<ProcessTreeHandle>,
+) -> Option<String> {
+    if let Some(process_tree) = process_tree {
+        return terminate_process_tree(&process_tree, child).await.error;
+    }
+    let mut errors = Vec::new();
+    if let Err(error) = child.start_kill() {
+        errors.push(io_error_detail("spawn recovery kill failed", &error));
+    }
+    match timeout_at(Instant::now() + PROCESS_TREE_CLEANUP_TIMEOUT, child.wait()).await {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => errors.push(io_error_detail("spawn recovery wait failed", &error)),
+        Err(_) => errors.push("spawn recovery wait timed out".to_owned()),
+    }
+    (!errors.is_empty()).then(|| errors.join("; "))
 }
 
 pub(super) struct ChildCommandSpec<'a> {
@@ -183,4 +193,29 @@ fn total_env_bytes(environment: &BTreeMap<String, String>) -> Result<usize, Proc
 
 fn c_string_storage_bytes(value: &str) -> usize {
     value.len() + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launch_validation_accepts_domain_sized_schema_and_environment() {
+        let argv = vec!["--json-schema".to_owned(), "x".repeat(1024 * 1024)];
+        let environment = (0..4)
+            .map(|index| (format!("TOKEN_{index}"), "x".repeat(64 * 1024)))
+            .collect::<BTreeMap<_, _>>();
+
+        assert!(validate_launch_fields("claude", &argv, &environment).is_ok());
+    }
+
+    #[test]
+    fn launch_validation_retains_finite_allocation_guards() {
+        let oversized_argv = vec!["x".repeat(MAX_PROCESS_ARGV_BYTES)];
+        assert!(validate_launch_fields("claude", &oversized_argv, &BTreeMap::new()).is_err());
+
+        let oversized_environment =
+            BTreeMap::from([("TOKEN".to_owned(), "x".repeat(MAX_PROCESS_ENV_BYTES))]);
+        assert!(validate_launch_fields("claude", &[], &oversized_environment).is_err());
+    }
 }

--- a/zeroshot-rust/src/execution/process/tail_buffer.rs
+++ b/zeroshot-rust/src/execution/process/tail_buffer.rs
@@ -1,0 +1,46 @@
+pub(super) struct TailBuffer {
+    bytes: Vec<u8>,
+    capacity: usize,
+    truncated: bool,
+}
+
+pub(super) struct TailSnapshot {
+    pub bytes: Vec<u8>,
+    pub truncated: bool,
+}
+
+impl TailBuffer {
+    pub(super) fn new(capacity: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(capacity),
+            capacity,
+            truncated: false,
+        }
+    }
+
+    pub(super) fn append(&mut self, value: &[u8]) {
+        if value.len() >= self.capacity {
+            self.truncated |= !self.bytes.is_empty() || value.len() > self.capacity;
+            self.bytes.clear();
+            if let Some(tail) = value.get(value.len().saturating_sub(self.capacity)..) {
+                self.bytes.extend_from_slice(tail);
+            }
+            return;
+        }
+        let required = self.bytes.len() + value.len();
+        if required > self.capacity {
+            let discard = required - self.capacity;
+            self.bytes.copy_within(discard.., 0);
+            self.bytes.truncate(self.bytes.len() - discard);
+            self.truncated = true;
+        }
+        self.bytes.extend_from_slice(value);
+    }
+
+    pub(super) fn snapshot(&self) -> TailSnapshot {
+        TailSnapshot {
+            bytes: self.bytes.clone(),
+            truncated: self.truncated,
+        }
+    }
+}

--- a/zeroshot-rust/src/execution/process/tests.rs
+++ b/zeroshot-rust/src/execution/process/tests.rs
@@ -1,8 +1,19 @@
 use std::{fs, path::Path};
 
-use openengine_cluster_testkit::assertions::AssertValue;
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
 
+#[cfg(unix)]
+use super::session_io::PROCESS_OUTPUT_CHUNK_BYTES;
 use super::{HostedProcessPool, HostedProcessScope, write_new_file};
+#[cfg(unix)]
+use super::{
+    LocalProcessRunner, PROCESS_STDOUT_CAPACITY, ProcessCleanupEvidence, ProcessSession,
+    ProcessRunnerError, ProcessSessionCommand, ProcessSessionOutput, prepare_local_private_home,
+};
+#[cfg(unix)]
+use crate::execution::WorkspaceAccessMode;
+#[cfg(unix)]
+use crate::execution::driver::{DriverCancellation, WorkspaceCapability};
 use crate::native_v2_candidate::test_support::TestDirectory;
 
 #[test]
@@ -66,6 +77,309 @@ fn new_file_writes_are_exclusive_and_complete() {
     assert_eq!(fs::read(&path).assert_value(), b"complete");
     assert!(write_new_file(&path, b"replacement", 0o600).is_err());
     assert_eq!(fs::read(path).assert_value(), b"complete");
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn natural_exit_preserves_stdout_after_the_old_drain_deadline() {
+    let bytes = PROCESS_STDOUT_CAPACITY * PROCESS_OUTPUT_CHUNK_BYTES + 1;
+    let (_cancel, mut process) = stdout_saturating_process(bytes).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(1_500)).await;
+    let mut received = 0;
+    while let Some(chunk) = process.recv_stdout().await {
+        received += chunk.as_slice().len();
+    }
+    let completion = tokio::time::timeout(std::time::Duration::from_secs(2), process.wait())
+        .await
+        .assert_value()
+        .assert_value();
+
+    assert_eq!(received, bytes);
+    assert_eq!(completion.exit_code, Some(0));
+    assert_eq!(completion.post_launch_error, None);
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn unix_signal_exit_is_distinct_from_an_ordinary_missing_status() {
+    let (_cancel, mut process) = shell_process(
+        "kill -TERM $$".to_owned(),
+        tokio::time::Instant::now() + std::time::Duration::from_secs(2),
+    )
+    .await;
+
+    while process.recv_stdout().await.is_some() {}
+    let completion = wait_for_process(&mut process).await;
+
+    assert_eq!(completion.exit_code, None);
+    assert_eq!(completion.termination_signal, Some(libc::SIGTERM));
+    assert!(!completion.core_dumped);
+    assert!(!completion.timed_out);
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn natural_root_exit_cannot_leave_inherited_stdout_open_past_command_deadline() {
+    let started = tokio::time::Instant::now();
+    let (cancel, mut process) =
+        inherited_stdout_process(started + std::time::Duration::from_millis(500)).await;
+
+    let (stdout, completion) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        let mut stdout = Vec::new();
+        while let Some(chunk) = process.recv_stdout().await {
+            stdout.extend_from_slice(chunk.as_slice());
+        }
+        (stdout, process.wait().await.assert_value())
+    })
+    .await
+    .assert_value();
+    drop(cancel);
+
+    assert_eq!(stdout, b"root-exited\n");
+    assert_eq!(completion.exit_code, Some(0));
+    assert!(completion.timed_out);
+    assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+    assert!(
+        completion
+            .post_launch_error
+            .as_deref()
+            .is_some_and(|detail| detail.contains("process I/O drain timed out"))
+    );
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn cancellation_interrupts_natural_drain_after_root_exit() {
+    let (cancel, mut process) = natural_drain_process().await;
+    cancel.send_replace(true);
+
+    let completion = wait_for_process(&mut process).await;
+
+    assert!(completion.cancelled);
+    assert!(completion.cleanup.proves_tree_empty());
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn release_interrupts_natural_drain_after_root_exit() {
+    let (_cancel, mut process) = natural_drain_process().await;
+
+    let completion = tokio::time::timeout(std::time::Duration::from_secs(3), process.release())
+        .await
+        .assert_value()
+        .assert_value();
+
+    assert!(!completion.timed_out);
+    assert!(completion.cleanup.proves_tree_empty());
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn release_interrupts_a_saturated_stdout_drain() {
+    let bytes = PROCESS_STDOUT_CAPACITY * PROCESS_OUTPUT_CHUNK_BYTES + 1;
+    let (_cancel, mut process) = stdout_saturating_process(bytes).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), process.release())
+        .await
+        .assert_value()
+        .assert_value();
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn cancellation_interrupts_a_saturated_stdout_drain() {
+    let bytes = PROCESS_STDOUT_CAPACITY * PROCESS_OUTPUT_CHUNK_BYTES + 1;
+    let (cancel, mut process) = stdout_saturating_process(bytes).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    cancel.send_replace(true);
+
+    let completion = wait_for_process(&mut process).await;
+    assert!(completion.cancelled);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn private_home_create_failure_retains_enoent_without_exposing_the_path() {
+    let directory = TestDirectory::new("private-home-cause");
+    let missing_root = directory.child("missing-parent/runtime-root");
+    let error =
+        prepare_local_private_home(&missing_root, HostedProcessScope::Writer).assert_error();
+    let detail = launch_detail(error).assert_value();
+
+    assert_os_detail(&detail, "provider private home create failed", libc::ENOENT);
+    assert!(!detail.contains(&missing_root.to_string_lossy().into_owned()));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn private_home_followup_failures_retain_their_operation_and_os_cause() {
+    let directory = TestDirectory::new("private-home-followup-causes");
+    let missing = directory.child("missing-sensitive-home");
+    let failures = [
+        (
+            "provider private home inspection failed",
+            super::validate_private_directory(&missing),
+        ),
+        (
+            "provider private home chmod failed",
+            super::set_private_directory_mode(&missing),
+        ),
+        (
+            "provider private home chown failed",
+            super::set_private_directory_owner(&missing, Some((10_002, 10_002))),
+        ),
+    ];
+
+    for (operation, failure) in failures {
+        let detail = launch_detail(failure.assert_error()).assert_value();
+        assert_os_detail(&detail, operation, libc::ENOENT);
+        assert!(!detail.contains(&missing.to_string_lossy().into_owned()));
+    }
+}
+
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn spawn_failures_distinguish_enoent_eacces_and_e2big_without_command_values() {
+    let missing_program = "/definitely/missing/zeroshot-sensitive-program";
+    let missing = spawn_failure(missing_program, Vec::new()).await;
+    assert_os_detail(&missing, "process spawn failed", libc::ENOENT);
+    assert!(!missing.contains(missing_program));
+
+    let directory = TestDirectory::new("process-spawn-causes");
+    let denied_program = directory.child("not-executable-sensitive");
+    write_new_file(&denied_program, b"#!/bin/sh\nexit 0\n", 0o600).assert_value();
+    let denied = spawn_failure(&denied_program.to_string_lossy(), Vec::new()).await;
+    assert_os_detail(&denied, "process spawn failed", libc::EACCES);
+    assert!(!denied.contains(&denied_program.to_string_lossy().into_owned()));
+
+    let oversized_marker = "SENSITIVE_ARG_VALUE";
+    let oversized = format!("{oversized_marker}{}", "x".repeat(256 * 1024));
+    let too_big = spawn_failure("/bin/true", vec![oversized]).await;
+    assert_os_detail(&too_big, "process spawn failed", libc::E2BIG);
+    assert!(!too_big.contains(oversized_marker));
+}
+
+#[cfg(target_os = "linux")]
+async fn spawn_failure(program: &str, argv: Vec<String>) -> String {
+    let (cancel, cancellation) = tokio::sync::watch::channel(false);
+    let result = LocalProcessRunner::new()
+        .open(
+            process_command(program, argv),
+            DriverCancellation::new(cancellation),
+        )
+        .await;
+    drop(cancel);
+    launch_detail(result.assert_error()).assert_value()
+}
+
+#[cfg(target_os = "linux")]
+fn process_command(program: &str, argv: Vec<String>) -> ProcessSessionCommand {
+    process_command_with_deadline(
+        program,
+        argv,
+        tokio::time::Instant::now() + std::time::Duration::from_secs(2),
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn launch_detail(error: ProcessRunnerError) -> Option<String> {
+    match error {
+        ProcessRunnerError::Launch(detail) => Some(detail),
+        ProcessRunnerError::InvalidCommand(_) | ProcessRunnerError::Io(_) => None,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn assert_os_detail(detail: &str, operation: &str, raw_os_error: i32) {
+    assert!(detail.starts_with(operation));
+    assert!(detail.contains("kind="));
+    assert!(detail.contains(&format!("raw_os_error={raw_os_error}")));
+    assert!(detail.contains("message="));
+}
+
+#[cfg(unix)]
+async fn stdout_saturating_process(
+    bytes: usize,
+) -> (tokio::sync::watch::Sender<bool>, ProcessSession) {
+    shell_process(
+        format!("/usr/bin/head -c {bytes} /dev/zero"),
+        tokio::time::Instant::now() + std::time::Duration::from_secs(15),
+    )
+    .await
+}
+
+#[cfg(unix)]
+async fn shell_process(
+    script: String,
+    deadline: tokio::time::Instant,
+) -> (tokio::sync::watch::Sender<bool>, ProcessSession) {
+    let (cancel, cancellation) = tokio::sync::watch::channel(false);
+    let process = LocalProcessRunner::new()
+        .open(
+            process_command_with_deadline("/bin/sh", vec!["-c".to_owned(), script], deadline),
+            DriverCancellation::new(cancellation),
+        )
+        .await
+        .assert_value();
+    (cancel, process)
+}
+
+#[cfg(unix)]
+async fn inherited_stdout_process(
+    deadline: tokio::time::Instant,
+) -> (tokio::sync::watch::Sender<bool>, ProcessSession) {
+    shell_process(
+        "trap '' HUP; sleep 30 & printf 'root-exited\\n'".to_owned(),
+        deadline,
+    )
+    .await
+}
+
+#[cfg(unix)]
+async fn natural_drain_process() -> (tokio::sync::watch::Sender<bool>, ProcessSession) {
+    let (cancel, mut process) =
+        inherited_stdout_process(tokio::time::Instant::now() + std::time::Duration::from_secs(30))
+            .await;
+    assert_eq!(receive_root_output(&mut process).await, b"root-exited\n");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    (cancel, process)
+}
+
+#[cfg(unix)]
+async fn receive_root_output(process: &mut ProcessSession) -> Vec<u8> {
+    tokio::time::timeout(std::time::Duration::from_secs(2), process.recv_stdout())
+        .await
+        .assert_value()
+        .assert_value()
+        .into_inner()
+}
+
+#[cfg(unix)]
+async fn wait_for_process(process: &mut ProcessSession) -> ProcessSessionOutput {
+    tokio::time::timeout(std::time::Duration::from_secs(3), process.wait())
+        .await
+        .assert_value()
+        .assert_value()
+}
+
+#[cfg(unix)]
+fn process_command_with_deadline(
+    program: &str,
+    argv: Vec<String>,
+    deadline: tokio::time::Instant,
+) -> ProcessSessionCommand {
+    ProcessSessionCommand {
+        program: program.to_owned(),
+        argv,
+        environment: std::collections::BTreeMap::new(),
+        workspace: WorkspaceCapability {
+            current_dir: std::env::current_dir().assert_value(),
+            mode: WorkspaceAccessMode::ReadOnly,
+        },
+        deadline,
+    }
 }
 
 fn writer_identity(pool: HostedProcessPool) -> (u32, u32) {

--- a/zeroshot-rust/src/native_v2_candidate/tests.rs
+++ b/zeroshot-rust/src/native_v2_candidate/tests.rs
@@ -193,10 +193,12 @@ impl NodeDriver for ScriptedAgent {
         self.starts.fetch_add(1, Ordering::SeqCst);
         fs::write(self.workspace.join("result.txt"), "native v2\n")
             .map_err(|_| NodeRunnerError::Driver)?;
-        control.emit(crate::native_v2_runner::LiveOutput::new(
-            crate::native_v2_runner::LiveOutputStream::Output,
-            "worker: mutation ready",
-        )?)?;
+        control
+            .emit(crate::native_v2_runner::LiveOutput::new(
+                crate::native_v2_runner::LiveOutputStream::Output,
+                "worker: mutation ready",
+            )?)
+            .await?;
         Ok(WorkerOutcome::Verified {
             output: Value::Null,
             artifacts: Vec::new(),

--- a/zeroshot-rust/src/native_v2_capsule.rs
+++ b/zeroshot-rust/src/native_v2_capsule.rs
@@ -13,18 +13,100 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use openengine_cluster_protocol::RunId;
+use openengine_cluster_protocol::{RunId, UnixTimestampMillis};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{Mutex, mpsc, watch};
+use tokio::sync::{Mutex, mpsc, oneshot, watch};
 
-use crate::execution::process::{HostedProcessPool, HostedProcessScope};
+use crate::execution::process::{
+    CONTAINED_PROCESS_CLEANUP_BUDGET, HostedProcessPool, HostedProcessScope,
+};
 use crate::native_v2_contract::{ExecutionRef, NodeCompletion, TokenUsageDelta};
 use crate::native_v2_runner::{
-    DurableNodeEvent, LiveOutput, LiveOutputStream, NodeHandle, NodeRunRequest, NodeRunner,
-    NodeRunnerError, RemoteNodeHandleBridge, remote_node_handle,
+    DURABLE_OUTPUT_CAPACITY, DurableNodeEvent, LiveOutput, LiveOutputStream, NodeHandle,
+    NodeRunRequest, NodeRunner, NodeRunnerError, RemoteNodeHandleBridge, remote_node_handle,
 };
 
 const CONTROL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+const CLOSE_RPC_TRANSPORT_MARGIN: Duration = Duration::from_secs(60);
+const CLOSE_RPC_TIMEOUT: Duration =
+    CONTAINED_PROCESS_CLEANUP_BUDGET.saturating_add(CLOSE_RPC_TRANSPORT_MARGIN);
+
+#[cfg(test)]
+#[derive(Clone)]
+struct StartReadinessPause {
+    sent: watch::Sender<bool>,
+    release: watch::Sender<bool>,
+}
+
+#[cfg(test)]
+impl Default for StartReadinessPause {
+    fn default() -> Self {
+        let (sent, _) = watch::channel(false);
+        let (release, _) = watch::channel(false);
+        Self { sent, release }
+    }
+}
+
+#[cfg(test)]
+impl StartReadinessPause {
+    fn mark_sent(&self) {
+        self.sent.send_replace(true);
+    }
+
+    async fn pause_before_receive(&self) {
+        wait_for_signal(&mut self.sent.subscribe()).await;
+        wait_for_signal(&mut self.release.subscribe()).await;
+    }
+
+    async fn wait_until_sent(&self) {
+        wait_for_signal(&mut self.sent.subscribe()).await;
+    }
+
+    fn release(&self) {
+        self.release.send_replace(true);
+    }
+}
+
+#[cfg(test)]
+trait WithStartReadinessPause: Sized {
+    fn start_readiness_pause(&mut self) -> &mut Option<StartReadinessPause>;
+
+    fn with_start_readiness_pause(mut self, pause: StartReadinessPause) -> Self {
+        *self.start_readiness_pause() = Some(pause);
+        self
+    }
+}
+
+#[cfg(test)]
+fn mark_start_readiness_sent(pause: Option<&StartReadinessPause>) {
+    if let Some(pause) = pause {
+        pause.mark_sent();
+    }
+}
+
+#[cfg(test)]
+async fn pause_before_start_readiness(pause: Option<&StartReadinessPause>) {
+    if let Some(pause) = pause {
+        pause.pause_before_receive().await;
+    }
+}
+
+async fn wait_for_signal(signal: &mut watch::Receiver<bool>) {
+    while !*signal.borrow_and_update() {
+        if signal.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+async fn receive_start_acceptance(
+    acceptance: &mut Option<oneshot::Receiver<()>>,
+) -> Result<(), oneshot::error::RecvError> {
+    match acceptance {
+        Some(acceptance) => acceptance.await,
+        None => std::future::pending().await,
+    }
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -83,6 +165,7 @@ impl CapsuleNodeFailure {
             NodeRunnerError::SessionLost => Self::SessionLost,
             NodeRunnerError::RunClosed => Self::RunClosed,
             NodeRunnerError::ExecutionActive => Self::ExecutionActive,
+            NodeRunnerError::Driver | NodeRunnerError::DriverDetail(_) => Self::ExecutionFailed,
             _ => Self::ExecutionFailed,
         }
     }
@@ -101,24 +184,60 @@ impl CapsuleNodeFailure {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, tag = "kind", rename_all = "snake_case")]
 pub enum CapsuleNodeEvent {
-    Output { output: CapsuleOutput },
-    TokenUsage { usage: Option<TokenUsageDelta> },
-    Completed { completion: NodeCompletion },
-    Failed { failure: CapsuleNodeFailure },
+    Output {
+        output: CapsuleOutput,
+        timestamp: UnixTimestampMillis,
+    },
+    TokenUsage {
+        usage: Option<TokenUsageDelta>,
+    },
+    Completed {
+        completion: NodeCompletion,
+    },
+    Failed {
+        failure: CapsuleNodeFailure,
+    },
 }
 
 pub struct CapsuleExecutionStream {
-    events: mpsc::UnboundedReceiver<CapsuleNodeEvent>,
+    events: mpsc::Receiver<CapsuleNodeEvent>,
+    terminal: Option<oneshot::Receiver<Vec<CapsuleNodeEvent>>>,
+    terminal_events: std::vec::IntoIter<CapsuleNodeEvent>,
 }
 
 impl CapsuleExecutionStream {
     #[must_use]
-    pub fn from_receiver(events: mpsc::UnboundedReceiver<CapsuleNodeEvent>) -> Self {
-        Self { events }
+    pub fn from_receiver(events: mpsc::Receiver<CapsuleNodeEvent>) -> Self {
+        Self {
+            events,
+            terminal: None,
+            terminal_events: Vec::new().into_iter(),
+        }
+    }
+
+    fn from_bounded_receiver(
+        events: mpsc::Receiver<CapsuleNodeEvent>,
+        terminal: oneshot::Receiver<Vec<CapsuleNodeEvent>>,
+    ) -> Self {
+        Self {
+            events,
+            terminal: Some(terminal),
+            terminal_events: Vec::new().into_iter(),
+        }
     }
 
     pub async fn recv(&mut self) -> Option<CapsuleNodeEvent> {
-        self.events.recv().await
+        if let Some(event) = self.terminal_events.next() {
+            return Some(event);
+        }
+        let event = self.events.recv().await;
+        if event.is_some() {
+            return event;
+        }
+        let terminal = self.terminal.as_mut()?.await.ok()?;
+        self.terminal = None;
+        self.terminal_events = terminal.into_iter();
+        self.terminal_events.next()
     }
 }
 
@@ -146,6 +265,7 @@ pub trait CapsuleNodeChannel: Send + Sync {
 }
 
 mod endpoint;
+pub(crate) mod provider_json_lines;
 pub(crate) mod provider_process;
 mod remote;
 

--- a/zeroshot-rust/src/native_v2_capsule/endpoint.rs
+++ b/zeroshot-rust/src/native_v2_capsule/endpoint.rs
@@ -1,17 +1,31 @@
 use super::*;
 
+#[path = "endpoint/execution.rs"]
+mod execution;
+use execution::{LocalExecutionTask, remove_endpoint_execution, serve_local_execution};
+
 #[derive(Clone)]
 pub struct NativeCapsuleNodeEndpoint {
     runner: Arc<dyn NodeRunner>,
     loss: watch::Sender<bool>,
-    active: Arc<Mutex<Vec<EndpointExecution>>>,
+    state: Arc<Mutex<EndpointState>>,
+    #[cfg(test)]
+    start_readiness_pause: Option<StartReadinessPause>,
+}
+
+#[derive(Default)]
+struct EndpointState {
+    active: Vec<EndpointExecution>,
+    closed_runs: std::collections::BTreeSet<RunId>,
 }
 
 struct EndpointExecution {
     reference: ExecutionRef,
-    cancel: mpsc::UnboundedSender<()>,
+    cancel: watch::Sender<bool>,
     done: watch::Receiver<bool>,
 }
+
+type LocalStartAcceptance = oneshot::Sender<()>;
 
 impl NativeCapsuleNodeEndpoint {
     #[must_use]
@@ -20,7 +34,9 @@ impl NativeCapsuleNodeEndpoint {
         Self {
             runner,
             loss,
-            active: Arc::new(Mutex::new(Vec::new())),
+            state: Arc::default(),
+            #[cfg(test)]
+            start_readiness_pause: None,
         }
     }
 
@@ -28,8 +44,9 @@ impl NativeCapsuleNodeEndpoint {
     pub async fn disconnect(&self) {
         let _ = self.loss.send(true);
         let run_ids = {
-            let entries = self.active.lock().await;
-            entries
+            let state = self.state.lock().await;
+            state
+                .active
                 .iter()
                 .map(|entry| entry.reference.run_id.clone())
                 .collect::<std::collections::BTreeSet<_>>()
@@ -39,16 +56,129 @@ impl NativeCapsuleNodeEndpoint {
         }
     }
 
+    async fn settle_unusable_handle(&self, mut handle: NodeHandle) -> bool {
+        let mut durable = handle.take_initial_output();
+        handle.cancel();
+        let settled = tokio::time::timeout(CLOSE_RPC_TIMEOUT, async {
+            let completion = handle.completion();
+            let drain = async {
+                if let Some(output) = durable.as_mut() {
+                    while output.recv().await.is_ok() {}
+                }
+            };
+            let _ = tokio::join!(completion, drain);
+        })
+        .await
+        .is_ok();
+        if !settled {
+            self.loss.send_replace(true);
+        }
+        settled
+    }
+
+    async fn finish_reservation(&self, reference: &ExecutionRef, done: &watch::Sender<bool>) {
+        remove_endpoint_execution(&self.state, reference, done).await;
+        done.send_replace(true);
+    }
+
+    fn ensure_run_open(
+        &self,
+        state: &EndpointState,
+        run_id: &RunId,
+    ) -> Result<(), CapsuleConnectionError> {
+        if *self.loss.borrow() {
+            return Err(CapsuleConnectionError::Lost);
+        }
+        if state.closed_runs.contains(run_id) {
+            return Err(CapsuleConnectionError::Rejected(
+                CapsuleNodeFailure::RunClosed,
+            ));
+        }
+        Ok(())
+    }
+
+    async fn start_reserved(self, request: NodeRunRequest, reserved: ReservedLocalStart) {
+        let mut handle = match self.runner.start(request).await {
+            Ok(handle) => handle,
+            Err(error) => {
+                self.finish_reservation(&reserved.reference, &reserved.done)
+                    .await;
+                let _ = reserved.ready.send(Err(CapsuleConnectionError::Rejected(
+                    CapsuleNodeFailure::from_runner(&error),
+                )));
+                #[cfg(test)]
+                mark_start_readiness_sent(self.start_readiness_pause.as_ref());
+                return;
+            }
+        };
+        let Some(durable) = handle.take_initial_output() else {
+            let settled = self.settle_unusable_handle(handle).await;
+            self.finish_reservation(&reserved.reference, &reserved.done)
+                .await;
+            let error = if settled {
+                CapsuleConnectionError::Rejected(CapsuleNodeFailure::ExecutionFailed)
+            } else {
+                CapsuleConnectionError::Lost
+            };
+            let _ = reserved.ready.send(Err(error));
+            #[cfg(test)]
+            mark_start_readiness_sent(self.start_readiness_pause.as_ref());
+            return;
+        };
+        let (accept, acceptance) = oneshot::channel();
+        let _ = reserved.ready.send(Ok(accept));
+        #[cfg(test)]
+        mark_start_readiness_sent(self.start_readiness_pause.as_ref());
+        serve_local_execution(LocalExecutionTask {
+            handle,
+            durable,
+            commands: reserved.commands,
+            events: reserved.events,
+            terminal: reserved.terminal,
+            state: self.state.clone(),
+            reference: reserved.reference,
+            done: reserved.done,
+            acceptance: Some(acceptance),
+        })
+        .await;
+    }
+
+    async fn accept_local_start(
+        &self,
+        reference: &ExecutionRef,
+        done: &watch::Sender<bool>,
+        acceptance: LocalStartAcceptance,
+    ) -> Result<(), CapsuleConnectionError> {
+        let expected = done.subscribe();
+        let state = self.state.lock().await;
+        self.ensure_run_open(&state, &reference.run_id)?;
+        if !state
+            .active
+            .iter()
+            .any(|entry| entry.reference == *reference && entry.done.same_channel(&expected))
+        {
+            return Err(CapsuleConnectionError::Rejected(
+                CapsuleNodeFailure::Cancelled,
+            ));
+        }
+        acceptance
+            .send(())
+            .map_err(|_| CapsuleConnectionError::Rejected(CapsuleNodeFailure::Cancelled))
+    }
+
     async fn close_local_run(&self, run_id: &RunId) {
         let mut completions = {
-            let entries = self.active.lock().await;
-            for entry in entries
+            let mut state = self.state.lock().await;
+            state.closed_runs.insert(run_id.clone());
+            for entry in state
+                .active
                 .iter()
                 .filter(|entry| &entry.reference.run_id == run_id)
             {
-                let _ = entry.cancel.send(());
+                entry.cancel.send_replace(true);
             }
-            entries
+            state
+                .active
                 .iter()
                 .filter(|entry| &entry.reference.run_id == run_id)
                 .map(|entry| entry.done.clone())
@@ -74,56 +204,68 @@ impl CapsuleNodeChannel for NativeCapsuleNodeEndpoint {
         if *self.loss.borrow() {
             return Err(CapsuleConnectionError::Lost);
         }
-        let mut handle = self.runner.start(request).await.map_err(|error| {
-            CapsuleConnectionError::Rejected(CapsuleNodeFailure::from_runner(&error))
-        })?;
-        let reference = handle.reference().clone();
-        let Some(durable) = handle.take_initial_output() else {
-            handle.cancel();
-            let _ = handle.completion().await;
-            return Err(CapsuleConnectionError::Rejected(
-                CapsuleNodeFailure::ExecutionFailed,
-            ));
-        };
-        // Provider output is capped by the harness, so this lossless queue is bounded by that
-        // cap while keeping cancellation and cleanup independent of a slow controller reader.
-        let (events, receiver) = mpsc::unbounded_channel();
-        let (cancel, commands) = mpsc::unbounded_channel();
+        let reference = request.invocation.reference.clone();
+        let (events, receiver) = mpsc::channel(DURABLE_OUTPUT_CAPACITY);
+        let (terminal, terminal_receiver) = oneshot::channel();
+        let (cancel, commands) = watch::channel(false);
         let (done_sender, done) = watch::channel(false);
+        let done_identity = done_sender.clone();
         {
-            let mut active = self.active.lock().await;
-            if *self.loss.borrow() {
-                handle.cancel();
-                drop(active);
-                let _ = handle.completion().await;
-                return Err(CapsuleConnectionError::Lost);
+            let mut state = self.state.lock().await;
+            self.ensure_run_open(&state, &reference.run_id)?;
+            if state
+                .active
+                .iter()
+                .any(|entry| entry.reference == reference)
+            {
+                return Err(CapsuleConnectionError::Rejected(
+                    CapsuleNodeFailure::ExecutionActive,
+                ));
             }
-            active.push(EndpointExecution {
+            state.active.push(EndpointExecution {
                 reference: reference.clone(),
                 cancel,
                 done,
             });
         }
-        let active = self.active.clone();
-        tokio::spawn(serve_local_execution(LocalExecutionTask {
-            handle,
-            durable,
-            commands,
-            events,
-            active,
-            reference,
-            done: done_sender,
-        }));
-        Ok(CapsuleExecutionStream::from_receiver(receiver))
+        let (ready, readiness) = oneshot::channel();
+        let endpoint = self.clone();
+        let reserved_reference = reference.clone();
+        tokio::spawn(endpoint.start_reserved(
+            request,
+            ReservedLocalStart {
+                reference: reserved_reference,
+                done: done_sender,
+                ready,
+                commands,
+                events,
+                terminal,
+            },
+        ));
+        #[cfg(test)]
+        pause_before_start_readiness(self.start_readiness_pause.as_ref()).await;
+        let acceptance = readiness
+            .await
+            .unwrap_or(Err(CapsuleConnectionError::Lost))?;
+        self.accept_local_start(&reference, &done_identity, acceptance)
+            .await?;
+        Ok(CapsuleExecutionStream::from_bounded_receiver(
+            receiver,
+            terminal_receiver,
+        ))
     }
 
     async fn cancel(&self, reference: &ExecutionRef) -> Result<(), CapsuleConnectionError> {
         if *self.loss.borrow() {
             return Err(CapsuleConnectionError::Lost);
         }
-        let entries = self.active.lock().await;
-        if let Some(entry) = entries.iter().find(|entry| &entry.reference == reference) {
-            let _ = entry.cancel.send(());
+        let state = self.state.lock().await;
+        if let Some(entry) = state
+            .active
+            .iter()
+            .find(|entry| &entry.reference == reference)
+        {
+            entry.cancel.send_replace(true);
         }
         Ok(())
     }
@@ -141,148 +283,18 @@ impl CapsuleNodeChannel for NativeCapsuleNodeEndpoint {
     }
 }
 
-struct LocalExecutionTask {
-    handle: NodeHandle,
-    durable: crate::native_v2_runner::DurableOutput,
-    commands: mpsc::UnboundedReceiver<()>,
-    events: mpsc::UnboundedSender<CapsuleNodeEvent>,
-    active: Arc<Mutex<Vec<EndpointExecution>>>,
+#[cfg(test)]
+impl WithStartReadinessPause for NativeCapsuleNodeEndpoint {
+    fn start_readiness_pause(&mut self) -> &mut Option<StartReadinessPause> {
+        &mut self.start_readiness_pause
+    }
+}
+
+struct ReservedLocalStart {
     reference: ExecutionRef,
     done: watch::Sender<bool>,
-}
-
-enum LocalInput {
-    Completion(Result<NodeCompletion, NodeRunnerError>),
-    Output(Result<DurableNodeEvent, crate::native_v2_runner::AttachReceiveError>),
-    Cancel,
-}
-
-struct LocalAwait {
-    completion: bool,
-    output: bool,
-    command: bool,
-}
-
-struct LocalOutputContext<'a> {
-    events: &'a mpsc::UnboundedSender<CapsuleNodeEvent>,
-    handle: &'a mut NodeHandle,
-    output_closed: &'a mut bool,
-    consumer_gone: &'a mut bool,
-}
-
-async fn serve_local_execution(task: LocalExecutionTask) {
-    let LocalExecutionTask {
-        mut handle,
-        mut durable,
-        mut commands,
-        events,
-        active,
-        reference,
-        done,
-    } = task;
-    let mut completion = None;
-    let mut output_closed = false;
-    let mut consumer_gone = false;
-    while local_execution_pending(&completion, output_closed) {
-        let next = next_local_input(
-            &mut handle,
-            &mut durable,
-            &mut commands,
-            LocalAwait {
-                completion: completion.is_none(),
-                output: !output_closed,
-                command: !consumer_gone,
-            },
-        )
-        .await;
-        match next {
-            LocalInput::Completion(result) => completion = Some(result),
-            LocalInput::Output(output) => apply_local_output(
-                output,
-                LocalOutputContext {
-                    events: &events,
-                    handle: &mut handle,
-                    output_closed: &mut output_closed,
-                    consumer_gone: &mut consumer_gone,
-                },
-            ),
-            LocalInput::Cancel => handle.cancel(),
-        }
-    }
-    send_local_completion(&events, completion, consumer_gone);
-    remove_endpoint_execution(&active, &reference).await;
-    let _ = done.send(true);
-}
-
-fn local_execution_pending(
-    completion: &Option<Result<NodeCompletion, NodeRunnerError>>,
-    output_closed: bool,
-) -> bool {
-    completion.is_none() || !output_closed
-}
-
-async fn next_local_input(
-    handle: &mut NodeHandle,
-    durable: &mut crate::native_v2_runner::DurableOutput,
-    commands: &mut mpsc::UnboundedReceiver<()>,
-    awaiting: LocalAwait,
-) -> LocalInput {
-    tokio::select! {
-        result = handle.completion(), if awaiting.completion => LocalInput::Completion(result),
-        output = durable.recv(), if awaiting.output => LocalInput::Output(output),
-        _ = commands.recv(), if awaiting.command => LocalInput::Cancel,
-    }
-}
-
-fn apply_local_output(
-    output: Result<DurableNodeEvent, crate::native_v2_runner::AttachReceiveError>,
-    context: LocalOutputContext<'_>,
-) {
-    let Ok(output) = output else {
-        *context.output_closed = true;
-        return;
-    };
-    let event = match output {
-        DurableNodeEvent::Output(output) => CapsuleNodeEvent::Output {
-            output: output.into(),
-        },
-        DurableNodeEvent::TokenUsage(usage) => CapsuleNodeEvent::TokenUsage { usage },
-    };
-    if context.events.send(event).is_err() {
-        *context.consumer_gone = true;
-        context.handle.cancel();
-    }
-}
-
-fn send_local_completion(
-    events: &mpsc::UnboundedSender<CapsuleNodeEvent>,
-    completion: Option<Result<NodeCompletion, NodeRunnerError>>,
-    consumer_gone: bool,
-) {
-    if consumer_gone {
-        return;
-    }
-    let Some(completion) = completion else {
-        return;
-    };
-    let event = match completion {
-        Ok(completion) => CapsuleNodeEvent::Completed { completion },
-        Err(error) => CapsuleNodeEvent::Failed {
-            failure: CapsuleNodeFailure::from_runner(&error),
-        },
-    };
-    let _ = events.send(event);
-}
-
-async fn remove_endpoint_execution(
-    active: &Mutex<Vec<EndpointExecution>>,
-    reference: &ExecutionRef,
-) {
-    let mut entries = active.lock().await;
-    if let Some(index) = entries
-        .iter()
-        .position(|entry| &entry.reference == reference)
-    {
-        entries.swap_remove(index);
-    }
+    ready: oneshot::Sender<Result<LocalStartAcceptance, CapsuleConnectionError>>,
+    commands: watch::Receiver<bool>,
+    events: mpsc::Sender<CapsuleNodeEvent>,
+    terminal: oneshot::Sender<Vec<CapsuleNodeEvent>>,
 }

--- a/zeroshot-rust/src/native_v2_capsule/endpoint/execution.rs
+++ b/zeroshot-rust/src/native_v2_capsule/endpoint/execution.rs
@@ -1,0 +1,333 @@
+use super::*;
+
+pub(super) struct LocalExecutionTask {
+    pub(super) handle: NodeHandle,
+    pub(super) durable: crate::native_v2_runner::DurableOutput,
+    pub(super) commands: watch::Receiver<bool>,
+    pub(super) events: mpsc::Sender<CapsuleNodeEvent>,
+    pub(super) terminal: oneshot::Sender<Vec<CapsuleNodeEvent>>,
+    pub(super) state: Arc<Mutex<EndpointState>>,
+    pub(super) reference: ExecutionRef,
+    pub(super) done: watch::Sender<bool>,
+    pub(super) acceptance: Option<oneshot::Receiver<()>>,
+}
+
+enum LocalInput {
+    Completion(Result<NodeCompletion, NodeRunnerError>),
+    Output(Result<DurableNodeEvent, crate::native_v2_runner::AttachReceiveError>),
+    Cancel,
+    Acceptance(Result<(), oneshot::error::RecvError>),
+}
+
+struct LocalAwait {
+    completion: bool,
+    output: bool,
+    command: bool,
+    acceptance: bool,
+}
+
+struct LocalInputContext<'a> {
+    handle: &'a mut NodeHandle,
+    durable: &'a mut crate::native_v2_runner::DurableOutput,
+    commands: &'a mut watch::Receiver<bool>,
+    acceptance: &'a mut Option<oneshot::Receiver<()>>,
+    awaiting: LocalAwait,
+}
+
+struct LocalOutputContext<'a> {
+    events: &'a mpsc::Sender<CapsuleNodeEvent>,
+    commands: &'a mut watch::Receiver<bool>,
+    handle: &'a mut NodeHandle,
+    output_closed: &'a mut bool,
+    consumer_gone: &'a mut bool,
+    cancelled: &'a mut bool,
+    terminal_metadata: &'a mut TerminalMetadata,
+    acceptance: &'a mut Option<oneshot::Receiver<()>>,
+}
+
+#[derive(Default)]
+struct TerminalMetadata {
+    known_usage: Option<TokenUsageDelta>,
+    incomplete: bool,
+    overflowed: bool,
+}
+
+impl TerminalMetadata {
+    fn retain(&mut self, event: CapsuleNodeEvent) {
+        let CapsuleNodeEvent::TokenUsage { usage } = event else {
+            return;
+        };
+        let Some(usage) = usage else {
+            self.incomplete = true;
+            return;
+        };
+        if self.overflowed {
+            return;
+        }
+        self.known_usage = match self.known_usage {
+            None => Some(usage),
+            Some(total) => match add_usage(total, usage) {
+                Some(total) => Some(total),
+                None => {
+                    self.incomplete = true;
+                    self.overflowed = true;
+                    Some(total)
+                }
+            },
+        };
+    }
+
+    fn into_events(
+        self,
+        completion: Result<NodeCompletion, NodeRunnerError>,
+    ) -> Vec<CapsuleNodeEvent> {
+        let mut events = Vec::with_capacity(3);
+        if let Some(usage) = self.known_usage {
+            events.push(CapsuleNodeEvent::TokenUsage { usage: Some(usage) });
+        }
+        if self.incomplete {
+            events.push(CapsuleNodeEvent::TokenUsage { usage: None });
+        }
+        let terminal = if self.overflowed {
+            CapsuleNodeEvent::Failed {
+                failure: CapsuleNodeFailure::ExecutionFailed,
+            }
+        } else {
+            match completion {
+                Ok(completion) => CapsuleNodeEvent::Completed { completion },
+                Err(error) => CapsuleNodeEvent::Failed {
+                    failure: CapsuleNodeFailure::from_runner(&error),
+                },
+            }
+        };
+        events.push(terminal);
+        events
+    }
+}
+
+fn add_usage(left: TokenUsageDelta, right: TokenUsageDelta) -> Option<TokenUsageDelta> {
+    let input_tokens = left.input_tokens.checked_add(right.input_tokens)?;
+    let output_tokens = left.output_tokens.checked_add(right.output_tokens)?;
+    let cache_read_input_tokens =
+        add_optional_usage(left.cache_read_input_tokens, right.cache_read_input_tokens)?;
+    let cache_creation_input_tokens = add_optional_usage(
+        left.cache_creation_input_tokens,
+        right.cache_creation_input_tokens,
+    )?;
+    Some(TokenUsageDelta {
+        input_tokens,
+        output_tokens,
+        cache_read_input_tokens,
+        cache_creation_input_tokens,
+    })
+}
+
+fn add_optional_usage(
+    left: Option<openengine_cluster_protocol::TokenCount>,
+    right: Option<openengine_cluster_protocol::TokenCount>,
+) -> Option<Option<openengine_cluster_protocol::TokenCount>> {
+    match (left, right) {
+        (Some(left), Some(right)) => left.checked_add(right).map(Some),
+        _ => Some(None),
+    }
+}
+
+pub(super) async fn serve_local_execution(task: LocalExecutionTask) {
+    let LocalExecutionTask {
+        mut handle,
+        mut durable,
+        mut commands,
+        events,
+        terminal,
+        state,
+        reference,
+        done,
+        mut acceptance,
+    } = task;
+    let mut completion = None;
+    let mut output_closed = false;
+    let mut consumer_gone = false;
+    let mut cancelled = false;
+    let mut terminal_metadata = TerminalMetadata::default();
+    while local_execution_pending(&completion, output_closed, acceptance.is_some()) {
+        let awaiting_acceptance = acceptance.is_some();
+        let next = next_local_input(LocalInputContext {
+            handle: &mut handle,
+            durable: &mut durable,
+            commands: &mut commands,
+            acceptance: &mut acceptance,
+            awaiting: LocalAwait {
+                completion: completion.is_none(),
+                output: !output_closed,
+                command: !consumer_gone && !cancelled,
+                acceptance: awaiting_acceptance,
+            },
+        })
+        .await;
+        match next {
+            LocalInput::Completion(result) => completion = Some(result),
+            LocalInput::Output(output) => {
+                apply_local_output(
+                    output,
+                    LocalOutputContext {
+                        events: &events,
+                        commands: &mut commands,
+                        handle: &mut handle,
+                        output_closed: &mut output_closed,
+                        consumer_gone: &mut consumer_gone,
+                        cancelled: &mut cancelled,
+                        terminal_metadata: &mut terminal_metadata,
+                        acceptance: &mut acceptance,
+                    },
+                )
+                .await;
+            }
+            LocalInput::Cancel => {
+                cancelled = true;
+                handle.cancel();
+                acceptance.take();
+            }
+            LocalInput::Acceptance(result) => {
+                acceptance.take();
+                if result.is_err() {
+                    consumer_gone = true;
+                    cancelled = true;
+                    handle.cancel();
+                }
+            }
+        }
+    }
+    drop(events);
+    send_local_completion(terminal, completion, consumer_gone, terminal_metadata);
+    remove_endpoint_execution(&state, &reference, &done).await;
+    let _ = done.send(true);
+}
+
+fn local_execution_pending(
+    completion: &Option<Result<NodeCompletion, NodeRunnerError>>,
+    output_closed: bool,
+    awaiting_acceptance: bool,
+) -> bool {
+    completion.is_none() || !output_closed || awaiting_acceptance
+}
+
+async fn next_local_input(context: LocalInputContext<'_>) -> LocalInput {
+    tokio::select! {
+        result = context.handle.completion(), if context.awaiting.completion => LocalInput::Completion(result),
+        output = context.durable.recv(), if context.awaiting.output => LocalInput::Output(output),
+        () = wait_for_signal(context.commands), if context.awaiting.command => LocalInput::Cancel,
+        result = receive_start_acceptance(context.acceptance),
+            if context.awaiting.acceptance => LocalInput::Acceptance(result),
+    }
+}
+
+async fn apply_local_output(
+    output: Result<DurableNodeEvent, crate::native_v2_runner::AttachReceiveError>,
+    context: LocalOutputContext<'_>,
+) {
+    let Ok(output) = output else {
+        *context.output_closed = true;
+        return;
+    };
+    let event = match output {
+        DurableNodeEvent::Output { output, timestamp } => CapsuleNodeEvent::Output {
+            output: output.into(),
+            timestamp,
+        },
+        DurableNodeEvent::TokenUsage(usage) => CapsuleNodeEvent::TokenUsage { usage },
+    };
+    if *context.consumer_gone {
+        return;
+    }
+    if *context.cancelled {
+        context.terminal_metadata.retain(event);
+        return;
+    }
+    tokio::select! {
+        biased;
+        () = wait_for_signal(context.commands) => {
+            *context.cancelled = true;
+            context.handle.cancel();
+            context.acceptance.take();
+            context.terminal_metadata.retain(event);
+        }
+        permit = context.events.reserve() => match permit {
+            Ok(permit) => permit.send(event),
+            Err(_) => {
+                *context.consumer_gone = true;
+                context.handle.cancel();
+            }
+        }
+    }
+}
+
+fn send_local_completion(
+    terminal: oneshot::Sender<Vec<CapsuleNodeEvent>>,
+    completion: Option<Result<NodeCompletion, NodeRunnerError>>,
+    consumer_gone: bool,
+    metadata: TerminalMetadata,
+) {
+    if consumer_gone {
+        return;
+    }
+    let Some(completion) = completion else {
+        return;
+    };
+    let _ = terminal.send(metadata.into_events(completion));
+}
+
+pub(super) async fn remove_endpoint_execution(
+    state: &Mutex<EndpointState>,
+    reference: &ExecutionRef,
+    done: &watch::Sender<bool>,
+) {
+    let expected = done.subscribe();
+    let mut state = state.lock().await;
+    if let Some(index) = state
+        .active
+        .iter()
+        .position(|entry| &entry.reference == reference && entry.done.same_channel(&expected))
+    {
+        state.active.swap_remove(index);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_protocol::{MAX_SAFE_GENERATION, TokenCount};
+
+    use super::*;
+    use openengine_cluster_testkit::assertions::AssertValue;
+
+    fn usage(tokens: u64) -> TokenUsageDelta {
+        TokenUsageDelta {
+            input_tokens: TokenCount::new(tokens).assert_value(),
+            output_tokens: TokenCount::new(tokens).assert_value(),
+            cache_read_input_tokens: None,
+            cache_creation_input_tokens: None,
+        }
+    }
+
+    #[test]
+    fn usage_overflow_is_incomplete_and_overrides_cancellation() {
+        let mut metadata = TerminalMetadata::default();
+        metadata.retain(CapsuleNodeEvent::TokenUsage {
+            usage: Some(usage(MAX_SAFE_GENERATION)),
+        });
+        metadata.retain(CapsuleNodeEvent::TokenUsage {
+            usage: Some(usage(1)),
+        });
+
+        let events = metadata.into_events(Err(NodeRunnerError::Cancelled));
+        assert!(matches!(
+            events.as_slice(),
+            [
+                CapsuleNodeEvent::TokenUsage { usage: Some(known) },
+                CapsuleNodeEvent::TokenUsage { usage: None },
+                CapsuleNodeEvent::Failed {
+                    failure: CapsuleNodeFailure::ExecutionFailed
+                }
+            ] if known.input_tokens.get() == MAX_SAFE_GENERATION
+        ));
+    }
+}

--- a/zeroshot-rust/src/native_v2_capsule/provider_json_lines.rs
+++ b/zeroshot-rust/src/native_v2_capsule/provider_json_lines.rs
@@ -1,0 +1,144 @@
+//! Streaming framing for provider-owned JSON Lines output.
+//!
+//! Provider turns may legitimately produce an unbounded number of records. This helper therefore
+//! bounds only one unfinished record, which is the memory it retains between process chunks.
+
+pub(crate) const MAX_PROVIDER_JSONL_RECORD_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum ProviderJsonLine {
+    Record(Vec<u8>),
+    Oversized,
+}
+
+pub(crate) struct ProviderJsonLines {
+    pending: Vec<u8>,
+    discarding_oversized: bool,
+    max_record_bytes: usize,
+}
+
+impl ProviderJsonLines {
+    pub(crate) fn new() -> Self {
+        Self::with_max_record_bytes(MAX_PROVIDER_JSONL_RECORD_BYTES)
+    }
+
+    fn with_max_record_bytes(max_record_bytes: usize) -> Self {
+        Self {
+            pending: Vec::new(),
+            discarding_oversized: false,
+            max_record_bytes,
+        }
+    }
+
+    pub(crate) fn push(&mut self, bytes: &[u8]) -> Vec<ProviderJsonLine> {
+        let mut records = Vec::new();
+        let mut start = 0;
+        for (end, byte) in bytes.iter().enumerate() {
+            if *byte != b'\n' {
+                continue;
+            }
+            self.append(bytes.get(start..end).unwrap_or_default());
+            records.push(self.complete_record());
+            start = end + 1;
+        }
+        self.append(bytes.get(start..).unwrap_or_default());
+        records
+    }
+
+    pub(crate) fn finish(&mut self) -> Option<ProviderJsonLine> {
+        if self.pending.is_empty() && !self.discarding_oversized {
+            return None;
+        }
+        Some(self.complete_record())
+    }
+
+    pub(crate) fn discard(&mut self) {
+        self.pending = Vec::new();
+        self.discarding_oversized = false;
+    }
+
+    fn append(&mut self, bytes: &[u8]) {
+        if self.discarding_oversized {
+            return;
+        }
+        if bytes.len() <= self.max_record_bytes.saturating_sub(self.pending.len()) {
+            self.pending.extend_from_slice(bytes);
+            return;
+        }
+        self.pending = Vec::new();
+        self.discarding_oversized = true;
+    }
+
+    fn complete_record(&mut self) -> ProviderJsonLine {
+        if self.discarding_oversized {
+            self.discarding_oversized = false;
+            return ProviderJsonLine::Oversized;
+        }
+        let mut record = std::mem::take(&mut self.pending);
+        if record.last() == Some(&b'\r') {
+            record.pop();
+        }
+        ProviderJsonLine::Record(record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frames_split_crlf_blank_and_unterminated_records() {
+        let mut lines = ProviderJsonLines::with_max_record_bytes(64);
+        assert!(lines.push(b"{\"a\":").is_empty());
+        assert_eq!(
+            lines.push(b"1}\r\n\nlast"),
+            [
+                ProviderJsonLine::Record(br#"{"a":1}"#.to_vec()),
+                ProviderJsonLine::Record(Vec::new()),
+            ]
+        );
+        assert_eq!(
+            lines.finish(),
+            Some(ProviderJsonLine::Record(b"last".to_vec()))
+        );
+        assert_eq!(lines.finish(), None);
+    }
+
+    #[test]
+    fn discards_only_the_oversized_record_and_recovers() {
+        let mut lines = ProviderJsonLines::with_max_record_bytes(4);
+        assert_eq!(
+            lines.push(b"1234\n12345\nok\n"),
+            [
+                ProviderJsonLine::Record(b"1234".to_vec()),
+                ProviderJsonLine::Oversized,
+                ProviderJsonLine::Record(b"ok".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn discards_an_oversized_record_across_chunks_and_at_eof() {
+        let mut lines = ProviderJsonLines::with_max_record_bytes(4);
+        assert!(lines.push(b"123").is_empty());
+        assert!(lines.push(b"45").is_empty());
+        assert_eq!(lines.finish(), Some(ProviderJsonLine::Oversized));
+
+        assert!(lines.push(b"good").is_empty());
+        assert_eq!(
+            lines.finish(),
+            Some(ProviderJsonLine::Record(b"good".to_vec()))
+        );
+    }
+
+    #[test]
+    fn releases_the_pending_allocation_when_a_record_is_discarded() {
+        let mut lines = ProviderJsonLines::with_max_record_bytes(4);
+        assert!(lines.push(b"1234").is_empty());
+        assert!(lines.pending.capacity() >= 4);
+        assert!(lines.push(b"5").is_empty());
+        assert_eq!(lines.pending.capacity(), 0);
+        lines.discard();
+        assert_eq!(lines.pending.capacity(), 0);
+    }
+}

--- a/zeroshot-rust/src/native_v2_capsule/provider_process.rs
+++ b/zeroshot-rust/src/native_v2_capsule/provider_process.rs
@@ -1,6 +1,7 @@
 //! Shared contained-process mechanics for native-v2 agent harnesses.
 
 use std::path::{Path, PathBuf};
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Mutex;
@@ -8,7 +9,9 @@ use tokio::time::Instant;
 
 use crate::execution::SessionScope;
 use crate::execution::process::{
-    HostedProcessPool, HostedProcessScope, LocalProcessRunner, ProcessSessionOutput,
+    HostedProcessPool, HostedProcessScope, LocalProcessRunner, ProcessFrame, ProcessLaunchEvidence,
+    ProcessRunnerError, ProcessSession, ProcessSessionCommand, ProcessSessionOutput,
+    MAX_PROCESS_MESSAGE_BYTES,
 };
 use crate::native_v2_contract::NodeRuntimeBinding;
 use crate::native_v2_runner::{
@@ -16,8 +19,13 @@ use crate::native_v2_runner::{
 };
 use crate::worker_catalog::ReasoningEffort;
 
-const MAX_PROVIDER_DIAGNOSTIC_BYTES: usize = 8 * 1024;
 const CONTINUE_PROMPT: &str = "Continue";
+
+#[path = "provider_process/diagnostic.rs"]
+mod diagnostic;
+pub(crate) use diagnostic::{provider_failure_diagnostic, safe_provider_text};
+#[cfg(test)]
+use diagnostic::MAX_PROVIDER_DIAGNOSTIC_BYTES;
 
 #[derive(Clone, Copy)]
 pub(crate) enum ProviderProcessRunners {
@@ -38,20 +46,102 @@ impl ProviderProcessRunners {
         self,
         root: &Path,
         scope: HostedProcessScope,
-    ) -> Result<(LocalProcessRunner, PathBuf), NodeRunnerError> {
+    ) -> Result<(LocalProcessRunner, PathBuf), ProcessRunnerError> {
         match self {
             Self::Hosted(pool) => {
-                let identity = pool.identity(scope).map_err(|_| NodeRunnerError::Driver)?;
-                let home = identity
-                    .prepare_private_home(root)
-                    .map_err(|_| NodeRunnerError::Driver)?;
+                let identity = pool.identity(scope)?;
+                let home = identity.prepare_private_home(root)?;
                 Ok((identity.runner(), home))
             }
             Self::Local => {
-                let home = crate::execution::process::prepare_local_private_home(root, scope)
-                    .map_err(|_| NodeRunnerError::Driver)?;
+                let home = crate::execution::process::prepare_local_private_home(root, scope)?;
                 Ok((LocalProcessRunner::new(), home))
             }
+        }
+    }
+}
+
+pub(crate) async fn send_process_input(
+    process: &mut ProcessSession,
+    bytes: &[u8],
+) -> Result<(), ProcessRunnerError> {
+    for chunk in bytes.chunks(MAX_PROCESS_MESSAGE_BYTES) {
+        process.send(ProcessFrame::new(chunk.to_vec())?).await?;
+    }
+    process.close_stdin().await
+}
+
+pub(crate) enum ProcessExchange<T> {
+    Complete(T),
+    InputFailure(ProcessInputFailure<T>),
+}
+
+pub(crate) struct ProcessInputFailure<T> {
+    pub(crate) output: T,
+    pub(crate) input_error: ProcessRunnerError,
+    pub(crate) completion: Result<ProcessSessionOutput, ProcessRunnerError>,
+}
+
+/// Streams stdin while the provider-owned parser drains the existing bounded stdout queue.
+/// Cleanup and output draining remain concurrent after an input failure so parsed metadata is
+/// retained without introducing another output buffer.
+pub(crate) async fn exchange_process_io<T>(
+    process: &mut ProcessSession,
+    bytes: &[u8],
+    output: impl Future<Output = T>,
+) -> ProcessExchange<T> {
+    enum First<T> {
+        Input(Result<(), ProcessRunnerError>),
+        Output(T),
+    }
+
+    let mut input = Box::pin(send_process_input(process, bytes));
+    let mut output = Box::pin(output);
+    let first = tokio::select! {
+        result = &mut input => First::Input(result),
+        result = &mut output => First::Output(result),
+    };
+
+    match first {
+        First::Input(Ok(())) => ProcessExchange::Complete(output.await),
+        First::Input(Err(input_error)) => {
+            drop(input);
+            let (completion, output) = tokio::join!(process.release(), output);
+            ProcessExchange::InputFailure(ProcessInputFailure {
+                output,
+                input_error,
+                completion,
+            })
+        }
+        First::Output(output_result) => {
+            drop(output);
+            match input.await {
+                Ok(()) => ProcessExchange::Complete(output_result),
+                Err(input_error) => ProcessExchange::InputFailure(ProcessInputFailure {
+                    output: output_result,
+                    input_error,
+                    completion: process.release().await,
+                }),
+            }
+        }
+    }
+}
+
+pub(crate) async fn open_provider_process(
+    runner: LocalProcessRunner,
+    command: ProcessSessionCommand,
+    control: &DriverControl,
+) -> Result<Result<ProcessSession, ProcessRunnerError>, NodeRunnerError> {
+    match runner.open(command, control.cancellation()).await {
+        Ok(process) => Ok(Ok(process)),
+        Err(error) => {
+            if error.launch_evidence() == ProcessLaunchEvidence::MayHaveStarted {
+                control.record_token_usage(None).await?;
+            }
+            if control.is_cancelled() {
+                return Err(NodeRunnerError::Cancelled);
+            }
+            Ok(Err(error))
         }
     }
 }
@@ -148,71 +238,89 @@ pub(crate) fn process_scope(
     }
 }
 
-pub(crate) fn validate_process_output(
+/// Returns fatal process facts and, once either the process or provider output failed, stderr.
+pub(crate) fn process_failure_detail(
     output: &ProcessSessionOutput,
-    control: &DriverControl,
-) -> Result<(), NodeRunnerError> {
-    validate_process_cleanup(output, control)?;
-    if output.exit_code != Some(0) {
-        return Err(NodeRunnerError::Driver);
-    }
-    Ok(())
-}
-
-pub(crate) fn validate_process_cleanup(
-    output: &ProcessSessionOutput,
-    control: &DriverControl,
-) -> Result<(), NodeRunnerError> {
-    if output.cancelled || control.is_cancelled() {
+    externally_cancelled: bool,
+    provider_output_failed: bool,
+) -> Result<Option<String>, NodeRunnerError> {
+    if output.cancelled || externally_cancelled {
         return Err(NodeRunnerError::Cancelled);
     }
-    if output.timed_out || !output.cleanup.proves_tree_empty() || output.post_launch_error.is_some()
-    {
-        return Err(NodeRunnerError::Driver);
+    let mut failures = process_failure_reasons(output);
+    if failures.is_empty() && !provider_output_failed {
+        return Ok(None);
     }
-    Ok(())
+    append_process_stderr(
+        &mut failures,
+        &output.stderr_tail,
+        output.stderr_tail_truncated,
+    );
+    Ok((!failures.is_empty()).then(|| failures.join("; ")))
 }
 
-pub(crate) fn provider_failure_diagnostic(
-    provider: &str,
-    detail: Option<&str>,
-    output: Option<&ProcessSessionOutput>,
-    redactions: &[String],
-) -> String {
-    let mut detail = detail
-        .filter(|value| !value.trim().is_empty())
-        .map(str::to_owned)
-        .or_else(|| {
-            output.and_then(|process| {
-                (!process.stderr_tail.is_empty())
-                    .then(|| String::from_utf8_lossy(&process.stderr_tail).into_owned())
-            })
-        })
-        .or_else(|| output.and_then(|process| process.post_launch_error.clone()))
-        .unwrap_or_else(|| "execution failed without provider detail".to_owned());
-    for value in redactions {
-        detail = detail.replace(value, "[REDACTED]");
+fn process_failure_reasons(output: &ProcessSessionOutput) -> Vec<String> {
+    let mut failures = Vec::new();
+    if output.timed_out {
+        failures.push("provider process timed out".to_owned());
     }
-    detail = detail
-        .chars()
-        .map(|character| {
-            if character.is_control() && !matches!(character, '\n' | '\t') {
-                ' '
+    if !output.cleanup.proves_tree_empty() {
+        failures.push("process cleanup did not prove the process tree empty".to_owned());
+    }
+    if let Some(error) = output
+        .post_launch_error
+        .as_deref()
+        .filter(|error| !error.trim().is_empty())
+    {
+        failures.push(error.to_owned());
+    }
+    if !output.timed_out {
+        if let Some(signal) = output.termination_signal {
+            let core_dump = if output.core_dumped {
+                " (core dumped)"
             } else {
-                character
-            }
-        })
-        .collect();
-    let mut diagnostic = format!("{provider} provider failure: {}", detail.trim());
-    if diagnostic.len() > MAX_PROVIDER_DIAGNOSTIC_BYTES {
-        let mut end = MAX_PROVIDER_DIAGNOSTIC_BYTES.saturating_sub(3);
-        while !diagnostic.is_char_boundary(end) {
-            end -= 1;
+                ""
+            };
+            failures.push(format!(
+                "provider process terminated by signal {signal}{core_dump}"
+            ));
+        } else if output.exit_code != Some(0) {
+            failures.push(match output.exit_code {
+                Some(code) => format!("provider process exited with status {code}"),
+                None => "provider process exited without a status".to_owned(),
+            });
         }
-        diagnostic.truncate(end);
-        diagnostic.push_str("...");
     }
-    diagnostic
+    failures
+}
+
+fn append_process_stderr(failures: &mut Vec<String>, stderr: &[u8], truncated: bool) {
+    if stderr.is_empty() {
+        return;
+    }
+    let stderr = String::from_utf8_lossy(stderr);
+    if !stderr.trim().is_empty() {
+        let prefix = if truncated {
+            "stderr (truncated tail): "
+        } else {
+            "stderr: "
+        };
+        failures.push(format!("{prefix}{}", stderr.trim()));
+    }
+}
+
+/// Adds provider-safe context at a seam whose legacy error carried only `Driver`.
+///
+/// More specific failures retain their classification. Callers supply static context or values
+/// that are safe to publish; terminal reporting applies credential redaction before emission.
+pub(crate) fn with_driver_detail(
+    error: NodeRunnerError,
+    detail: impl Into<String>,
+) -> NodeRunnerError {
+    match error {
+        NodeRunnerError::Driver => NodeRunnerError::DriverDetail(detail.into()),
+        error => error,
+    }
 }
 
 pub(crate) struct ProviderFailureRetry {
@@ -243,22 +351,26 @@ impl ProviderFailureRetry {
         }
     }
 
-    pub(crate) fn after_failure(
+    pub(crate) async fn after_failure(
         &mut self,
         control: &DriverControl,
         failure: ProviderFailure<'_>,
     ) -> Result<String, NodeRunnerError> {
         let diagnostic =
             provider_failure_diagnostic(self.provider, failure.detail, None, &self.redactions);
-        control.emit(LiveOutput::new(LiveOutputStream::Error, diagnostic)?)?;
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Error, diagnostic)?)
+            .await?;
         if !failure.retryable || self.used || Instant::now() >= failure.deadline {
             return Err(NodeRunnerError::Driver);
         }
         self.used = true;
-        control.emit(LiveOutput::new(
-            LiveOutputStream::System,
-            format!("{} provider failed; continuing once", self.provider),
-        )?)?;
+        control
+            .emit(LiveOutput::new(
+                LiveOutputStream::System,
+                format!("{} provider failed; continuing once", self.provider),
+            )?)
+            .await?;
         Ok(if failure.has_session {
             CONTINUE_PROMPT.to_owned()
         } else {
@@ -266,16 +378,20 @@ impl ProviderFailureRetry {
         })
     }
 
-    pub(crate) fn report_terminal(
+    pub(crate) async fn report_terminal(
         &self,
         control: &DriverControl,
         error: &NodeRunnerError,
     ) -> Result<(), NodeRunnerError> {
-        if *error == NodeRunnerError::Driver {
-            let diagnostic =
-                provider_failure_diagnostic(self.provider, None, None, &self.redactions);
-            control.emit(LiveOutput::new(LiveOutputStream::Error, diagnostic)?)?;
-        }
+        let detail = match error {
+            NodeRunnerError::Driver => None,
+            NodeRunnerError::DriverDetail(detail) => Some(detail.as_str()),
+            _ => return Ok(()),
+        };
+        let diagnostic = provider_failure_diagnostic(self.provider, detail, None, &self.redactions);
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Error, diagnostic)?)
+            .await?;
         Ok(())
     }
 }
@@ -301,37 +417,5 @@ pub(crate) const fn effort_token(effort: ReasoningEffort) -> &'static str {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn closed_session_failure_maps_to_selected_runner_error() {
-        let session = ProviderSessionCore::new();
-        session.close();
-
-        assert_eq!(
-            session.ensure_live(ClosedSessionFailure::Driver),
-            Err(NodeRunnerError::Driver)
-        );
-        assert_eq!(
-            session.ensure_live(ClosedSessionFailure::SessionLost),
-            Err(NodeRunnerError::SessionLost)
-        );
-    }
-
-    #[test]
-    fn provider_diagnostic_is_redacted_sanitized_and_bounded() {
-        let detail = format!(
-            "token=secret\u{0} {}",
-            "x".repeat(MAX_PROVIDER_DIAGNOSTIC_BYTES)
-        );
-        let diagnostic =
-            provider_failure_diagnostic("Codex", Some(&detail), None, &["secret".to_owned()]);
-
-        assert!(diagnostic.starts_with("Codex provider failure: token=[REDACTED] "));
-        assert!(!diagnostic.contains("secret"));
-        assert!(!diagnostic.contains('\0'));
-        assert_eq!(diagnostic.len(), MAX_PROVIDER_DIAGNOSTIC_BYTES);
-        assert!(diagnostic.ends_with("..."));
-    }
-}
+#[path = "provider_process/tests.rs"]
+mod tests;

--- a/zeroshot-rust/src/native_v2_capsule/provider_process/diagnostic.rs
+++ b/zeroshot-rust/src/native_v2_capsule/provider_process/diagnostic.rs
@@ -1,0 +1,158 @@
+use crate::execution::process::ProcessSessionOutput;
+use crate::native_v2_runner::NodeRunnerError;
+
+use super::process_failure_detail;
+
+pub(super) const MAX_PROVIDER_DIAGNOSTIC_BYTES: usize = 8 * 1024;
+const DIAGNOSTIC_TRUNCATION_MARKER: &str = " ... [middle truncated] ... ";
+const TRUNCATED_STDERR_DETAIL_PREFIX: &str = "stderr (truncated tail): ";
+
+pub(crate) fn safe_provider_text(text: &str, redactions: &[String]) -> String {
+    let mut ordered = redactions
+        .iter()
+        .filter(|value| !value.is_empty())
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    ordered.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+    ordered.dedup();
+    let redacted = ordered.iter().fold(text.to_owned(), |safe, value| {
+        safe.replace(value, "[REDACTED]")
+    });
+    redact_stderr_boundary(redacted, &ordered).replace('\0', "\u{fffd}")
+}
+
+fn redact_stderr_boundary(mut text: String, redactions: &[&str]) -> String {
+    let boundaries = text
+        .match_indices(TRUNCATED_STDERR_DETAIL_PREFIX)
+        .map(|(index, _)| index + TRUNCATED_STDERR_DETAIL_PREFIX.len())
+        .collect::<Vec<_>>();
+    for boundary in boundaries.into_iter().rev() {
+        let Some(tail) = text.get(boundary..) else {
+            continue;
+        };
+        let replacement_bytes = tail
+            .chars()
+            .take_while(|character| *character == '\u{fffd}')
+            .map(char::len_utf8)
+            .sum::<usize>();
+        let Some(candidate) = tail.get(replacement_bytes..) else {
+            continue;
+        };
+        let Some(secret_bytes) = redactions
+            .iter()
+            .filter_map(|secret| leading_secret_suffix_bytes(candidate, secret))
+            .max()
+        else {
+            continue;
+        };
+        let Some(end) = boundary
+            .checked_add(replacement_bytes)
+            .and_then(|value| value.checked_add(secret_bytes))
+        else {
+            continue;
+        };
+        if text.get(boundary..end).is_some() {
+            text.replace_range(boundary..end, "[REDACTED]");
+        }
+    }
+    text
+}
+
+fn leading_secret_suffix_bytes(candidate: &str, secret: &str) -> Option<usize> {
+    secret
+        .char_indices()
+        .skip(1)
+        .filter_map(|(start, _)| secret.get(start..))
+        .filter(|suffix| candidate.starts_with(suffix))
+        .map(str::len)
+        .max()
+}
+
+pub(crate) fn provider_failure_diagnostic(
+    provider: &str,
+    detail: Option<&str>,
+    output: Option<&ProcessSessionOutput>,
+    redactions: &[String],
+) -> String {
+    let mut details = detail
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_owned)
+        .into_iter()
+        .collect::<Vec<_>>();
+    if let Some(process) = output {
+        let process_detail = match process_failure_detail(process, false, true) {
+            Ok(detail) => detail,
+            Err(NodeRunnerError::Cancelled) => Some("provider process was cancelled".to_owned()),
+            Err(_) => None,
+        };
+        if let Some(process_detail) = process_detail {
+            details.push(process_detail);
+        }
+    }
+    let detail = if details.is_empty() {
+        "execution failed without provider detail".to_owned()
+    } else {
+        details.join("; ")
+    };
+    let detail = sanitize_control_characters(&safe_provider_text(&detail, redactions));
+    bounded_provider_diagnostic(format!("{provider} provider failure: {}", detail.trim()))
+}
+
+fn sanitize_control_characters(detail: &str) -> String {
+    detail
+        .chars()
+        .map(|character| {
+            if character.is_control() && !matches!(character, '\n' | '\t') {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+fn bounded_provider_diagnostic(diagnostic: String) -> String {
+    if diagnostic.len() <= MAX_PROVIDER_DIAGNOSTIC_BYTES {
+        return diagnostic;
+    }
+    let content_bytes =
+        MAX_PROVIDER_DIAGNOSTIC_BYTES.saturating_sub(DIAGNOSTIC_TRUNCATION_MARKER.len());
+    let prefix = utf8_prefix(&diagnostic, content_bytes / 2);
+    let suffix = utf8_suffix(&diagnostic, content_bytes.saturating_sub(prefix.len()));
+    format!("{prefix}{DIAGNOSTIC_TRUNCATION_MARKER}{suffix}")
+}
+
+fn utf8_prefix(value: &str, maximum_bytes: usize) -> String {
+    let mut bytes = 0;
+    value
+        .chars()
+        .take_while(|character| {
+            let next = bytes + character.len_utf8();
+            if next > maximum_bytes {
+                false
+            } else {
+                bytes = next;
+                true
+            }
+        })
+        .collect()
+}
+
+fn utf8_suffix(value: &str, maximum_bytes: usize) -> String {
+    let mut bytes = 0;
+    let mut characters = value
+        .chars()
+        .rev()
+        .take_while(|character| {
+            let next = bytes + character.len_utf8();
+            if next > maximum_bytes {
+                false
+            } else {
+                bytes = next;
+                true
+            }
+        })
+        .collect::<Vec<_>>();
+    characters.reverse();
+    characters.into_iter().collect()
+}

--- a/zeroshot-rust/src/native_v2_capsule/provider_process/tests.rs
+++ b/zeroshot-rust/src/native_v2_capsule/provider_process/tests.rs
@@ -1,0 +1,228 @@
+use openengine_cluster_testkit::assertions::AssertValue;
+
+use super::*;
+
+#[test]
+fn closed_session_failure_maps_to_selected_runner_error() {
+    let session = ProviderSessionCore::new();
+    session.close();
+
+    assert_eq!(
+        session.ensure_live(ClosedSessionFailure::Driver),
+        Err(NodeRunnerError::Driver)
+    );
+    assert_eq!(
+        session.ensure_live(ClosedSessionFailure::SessionLost),
+        Err(NodeRunnerError::SessionLost)
+    );
+}
+
+fn process_output() -> ProcessSessionOutput {
+    ProcessSessionOutput {
+        launch_evidence: crate::execution::process::ProcessLaunchEvidence::MayHaveStarted,
+        exit_code: Some(0),
+        termination_signal: None,
+        core_dumped: false,
+        stderr_tail: Vec::new(),
+        stderr_tail_truncated: false,
+        cancelled: false,
+        timed_out: false,
+        cleanup: crate::execution::process::ProcessCleanupEvidence::NotRequired,
+        post_launch_error: None,
+    }
+}
+
+#[test]
+fn process_failure_preserves_cleanup_exit_and_stderr_detail() {
+    let mut output = process_output();
+    output.exit_code = Some(17);
+    output.stderr_tail = b"provider detail".to_vec();
+    output.cleanup = crate::execution::process::ProcessCleanupEvidence::TimedOut;
+    output.post_launch_error = Some("stdout pump failed".to_owned());
+
+    let detail = process_failure_detail(&output, false, false)
+        .assert_value()
+        .assert_value();
+    assert!(detail.contains("process cleanup did not prove the process tree empty"));
+    assert!(detail.contains("stdout pump failed"));
+    assert!(detail.contains("provider process exited with status 17"));
+    assert!(detail.contains("stderr: provider detail"));
+}
+
+#[test]
+fn process_failure_gives_cancellation_precedence() {
+    let output = process_output();
+    assert_eq!(
+        process_failure_detail(&output, true, false),
+        Err(NodeRunnerError::Cancelled)
+    );
+}
+
+#[test]
+fn clean_process_has_no_failure_detail() {
+    assert_eq!(
+        process_failure_detail(&process_output(), false, false),
+        Ok(None)
+    );
+}
+
+#[test]
+fn stderr_alone_is_evidence_only_after_provider_output_failure() {
+    let mut output = process_output();
+    output.stderr_tail = b"provider warning".to_vec();
+
+    assert_eq!(process_failure_detail(&output, false, false), Ok(None));
+    assert_eq!(
+        process_failure_detail(&output, false, true),
+        Ok(Some("stderr: provider warning".to_owned()))
+    );
+}
+
+#[test]
+fn process_failure_distinguishes_timeout_from_missing_exit_status() {
+    let mut output = process_output();
+    output.exit_code = None;
+    output.timed_out = true;
+    assert_eq!(
+        process_failure_detail(&output, false, false),
+        Ok(Some("provider process timed out".to_owned()))
+    );
+
+    output.timed_out = false;
+    assert_eq!(
+        process_failure_detail(&output, false, false),
+        Ok(Some("provider process exited without a status".to_owned()))
+    );
+}
+
+#[test]
+fn process_failure_distinguishes_unix_signal_and_core_dump_from_missing_status() {
+    let mut output = process_output();
+    output.exit_code = None;
+    output.termination_signal = Some(11);
+    output.core_dumped = true;
+
+    assert_eq!(
+        process_failure_detail(&output, false, false),
+        Ok(Some(
+            "provider process terminated by signal 11 (core dumped)".to_owned()
+        ))
+    );
+}
+
+#[test]
+fn diagnostic_retains_stderr_from_an_otherwise_clean_process() {
+    let mut output = process_output();
+    output.stderr_tail = b"clean-exit detail".to_vec();
+
+    let diagnostic = provider_failure_diagnostic("Claude", None, Some(&output), &[]);
+    assert_eq!(
+        diagnostic,
+        "Claude provider failure: stderr: clean-exit detail"
+    );
+}
+
+#[test]
+fn diagnostic_combines_parser_process_and_redacted_stderr_detail() {
+    let mut output = process_output();
+    output.exit_code = Some(2);
+    output.stderr_tail = b"token=secret".to_vec();
+
+    let diagnostic = provider_failure_diagnostic(
+        "Claude",
+        Some("JSONL stream ended without a result"),
+        Some(&output),
+        &["secret".to_owned()],
+    );
+    assert!(diagnostic.contains("JSONL stream ended without a result"));
+    assert!(diagnostic.contains("provider process exited with status 2"));
+    assert!(diagnostic.contains("stderr: token=[REDACTED]"));
+    assert!(!diagnostic.contains("secret"));
+}
+
+#[test]
+fn provider_diagnostic_is_redacted_sanitized_and_bounded() {
+    let detail = format!(
+        "token=secret\u{0} {}",
+        "x".repeat(MAX_PROVIDER_DIAGNOSTIC_BYTES)
+    );
+    let diagnostic =
+        provider_failure_diagnostic("Codex", Some(&detail), None, &["secret".to_owned()]);
+
+    assert!(diagnostic.starts_with("Codex provider failure: token=[REDACTED]\u{fffd} "));
+    assert!(!diagnostic.contains("secret"));
+    assert!(!diagnostic.contains('\0'));
+    assert_eq!(diagnostic.len(), MAX_PROVIDER_DIAGNOSTIC_BYTES);
+    assert!(diagnostic.contains(" ... [middle truncated] ... "));
+    assert!(diagnostic.ends_with('x'));
+}
+
+#[test]
+fn bounded_diagnostic_keeps_utf8_parser_context_and_process_root_cause() {
+    let mut output = process_output();
+    output.exit_code = Some(23);
+    output.stderr_tail = b"fatal root cause at stderr tail".to_vec();
+    let parser_detail = format!("parser context: {}", "界".repeat(4_000));
+
+    let diagnostic =
+        provider_failure_diagnostic("Claude", Some(&parser_detail), Some(&output), &[]);
+
+    assert!(diagnostic.starts_with("Claude provider failure: parser context: "));
+    assert!(diagnostic.contains(" ... [middle truncated] ... "));
+    assert!(diagnostic.contains("provider process exited with status 23"));
+    assert!(diagnostic.ends_with("stderr: fatal root cause at stderr tail"));
+    assert!(diagnostic.len() <= MAX_PROVIDER_DIAGNOSTIC_BYTES);
+}
+
+#[test]
+fn stderr_tail_cutoff_redacts_leading_ascii_secret_suffix() {
+    let secret = "declared-secret-value";
+    let split = "declared-".len();
+    let diagnostic = cutoff_secret_diagnostic(secret, split);
+
+    assert_eq!(
+        diagnostic,
+        "Claude provider failure: stderr (truncated tail): [REDACTED]: actionable root cause"
+    );
+}
+
+#[test]
+fn stderr_tail_cutoff_redacts_secret_split_inside_multibyte_character() {
+    let secret = "declared-🔐-suffix";
+    let split = secret.find('🔐').assert_value() + 1;
+    let diagnostic = cutoff_secret_diagnostic(secret, split);
+
+    assert_eq!(
+        diagnostic,
+        "Claude provider failure: stderr (truncated tail): [REDACTED]: actionable root cause"
+    );
+}
+
+fn cutoff_secret_diagnostic(secret: &str, split: usize) -> String {
+    let mut output = process_output();
+    output.stderr_tail_truncated = true;
+    output.stderr_tail = secret.as_bytes().get(split..).assert_value().to_vec();
+    output
+        .stderr_tail
+        .extend_from_slice(b": actionable root cause");
+    provider_failure_diagnostic("Claude", None, Some(&output), &[secret.to_owned()])
+}
+
+#[test]
+fn driver_context_upgrades_only_payload_free_failures() {
+    assert_eq!(
+        with_driver_detail(NodeRunnerError::Driver, "invalid provider configuration"),
+        NodeRunnerError::DriverDetail("invalid provider configuration".to_owned())
+    );
+    assert_eq!(
+        with_driver_detail(NodeRunnerError::Cancelled, "unused"),
+        NodeRunnerError::Cancelled
+    );
+    assert_eq!(
+        with_driver_detail(
+            NodeRunnerError::DriverDetail("specific".to_owned()),
+            "coarse"
+        ),
+        NodeRunnerError::DriverDetail("specific".to_owned())
+    );
+}

--- a/zeroshot-rust/src/native_v2_capsule/remote.rs
+++ b/zeroshot-rust/src/native_v2_capsule/remote.rs
@@ -1,5 +1,11 @@
 use super::*;
 
+mod activity;
+mod execution;
+mod start;
+use activity::{ProxyActivity, ProxyRegistration};
+use execution::drive_remote_execution;
+
 #[derive(Clone)]
 pub struct RemoteCapsuleNodeRunner {
     channel: Arc<dyn CapsuleNodeChannel>,
@@ -7,6 +13,9 @@ pub struct RemoteCapsuleNodeRunner {
     loss: RunnerLoss,
     activity: ProxyActivity,
     control_timeout: Duration,
+    close_timeout: Duration,
+    #[cfg(test)]
+    start_readiness_pause: Option<StartReadinessPause>,
 }
 
 impl RemoteCapsuleNodeRunner {
@@ -19,7 +28,7 @@ impl RemoteCapsuleNodeRunner {
             let forward = loss.clone();
             tokio::spawn(async move {
                 let mut channel_loss = channel_loss;
-                wait_for_connection_loss(&mut channel_loss).await;
+                wait_for_signal(&mut channel_loss).await;
                 forward.promote();
             });
         }
@@ -29,12 +38,26 @@ impl RemoteCapsuleNodeRunner {
             loss,
             activity: ProxyActivity::default(),
             control_timeout: CONTROL_RPC_TIMEOUT,
+            close_timeout: CLOSE_RPC_TIMEOUT,
+            #[cfg(test)]
+            start_readiness_pause: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(super) async fn wait_for_test_run_settled(&self, run_id: &RunId) {
+        self.activity.wait_run(run_id).await;
     }
 
     #[cfg(test)]
     pub(super) fn with_control_timeout(mut self, timeout: Duration) -> Self {
         self.control_timeout = timeout;
+        self
+    }
+
+    #[cfg(test)]
+    pub(super) fn with_close_timeout(mut self, timeout: Duration) -> Self {
+        self.close_timeout = timeout;
         self
     }
 
@@ -47,68 +70,35 @@ impl RemoteCapsuleNodeRunner {
 #[async_trait]
 impl NodeRunner for RemoteCapsuleNodeRunner {
     async fn start(&self, request: NodeRunRequest) -> Result<NodeHandle, NodeRunnerError> {
-        if connection_is_lost(&self.connection_loss) {
-            return Err(NodeRunnerError::ConnectionLost);
-        }
-        let reference = request.invocation.reference.clone();
-        let mut connection_loss = self.connection_loss.clone();
-        let start = self.channel.start(request);
-        tokio::pin!(start);
-        let stream = tokio::select! {
-            result = &mut start => match result {
-                Ok(stream) => stream,
-                Err(CapsuleConnectionError::Lost) => {
-                    self.loss.promote();
-                    return Err(NodeRunnerError::ConnectionLost);
-                }
-                Err(CapsuleConnectionError::Rejected(failure)) => {
-                    return Err(failure.into_runner());
-                }
-            },
-            () = wait_for_connection_loss(&mut connection_loss) => {
-                return Err(NodeRunnerError::ConnectionLost);
-            }
-        };
-        let (handle, bridge) = remote_node_handle(reference.clone());
-        let registration = self.activity.register(reference.clone()).await;
-        let runtime = ProxyRuntime {
-            channel: self.channel.clone(),
-            connection_loss: self.connection_loss.clone(),
-            loss: self.loss.clone(),
-            activity: self.activity.clone(),
-            control_timeout: self.control_timeout,
-        };
-        tokio::spawn(drive_remote_execution(RemoteExecutionTask {
-            runtime,
-            reference,
-            stream,
-            bridge,
-            registration,
-        }));
-        Ok(handle)
+        start::remote_start(self, request).await
     }
 
     async fn close_run(&self, run_id: &RunId) {
+        self.activity.begin_close(run_id).await;
         let mut connection_loss = self.connection_loss.clone();
         let closed = control_rpc(
             self.channel.close_run(run_id),
             &mut connection_loss,
-            self.control_timeout,
+            self.close_timeout,
         )
         .await;
         if !closed {
             self.loss.promote();
-            self.activity.lose_run(run_id).await;
         }
-        if tokio::time::timeout(self.control_timeout, self.activity.wait_run(run_id))
-            .await
-            .is_err()
-        {
-            self.loss.promote();
-            self.activity.lose_run(run_id).await;
+        self.activity.complete_close(run_id).await;
+        if closed {
+            self.activity.wait_run(run_id).await;
+        } else {
             let _ =
                 tokio::time::timeout(self.control_timeout, self.activity.wait_run(run_id)).await;
         }
+    }
+}
+
+#[cfg(test)]
+impl WithStartReadinessPause for RemoteCapsuleNodeRunner {
+    fn start_readiness_pause(&mut self) -> &mut Option<StartReadinessPause> {
+        &mut self.start_readiness_pause
     }
 }
 
@@ -155,6 +145,7 @@ struct RemoteExecutionTask {
     stream: CapsuleExecutionStream,
     bridge: RemoteNodeHandleBridge,
     registration: ProxyRegistration,
+    acceptance: Option<oneshot::Receiver<()>>,
 }
 
 struct RemoteEventContext<'a> {
@@ -162,62 +153,103 @@ struct RemoteEventContext<'a> {
     reference: &'a ExecutionRef,
     bridge: &'a mut RemoteNodeHandleBridge,
     connection_loss: &'a mut watch::Receiver<bool>,
+    closing: &'a mut watch::Receiver<bool>,
+    pending_bridge_failure: &'a mut Option<NodeRunnerError>,
 }
 
 enum RemoteInput {
     Event(Option<CapsuleNodeEvent>),
     Cancel,
+    Closing,
+    Closed,
     Lost,
+    Acceptance(Result<(), oneshot::error::RecvError>),
 }
 
-async fn drive_remote_execution(task: RemoteExecutionTask) {
-    let RemoteExecutionTask {
-        runtime,
-        reference,
-        mut stream,
-        mut bridge,
-        registration,
-    } = task;
-    let mut local_loss = registration.loss;
-    let mut cancellation_forwarded = false;
-    let mut connection_loss = runtime.connection_loss.clone();
-    let result = loop {
-        let next = tokio::select! {
-            biased;
-            () = wait_for_connection_loss(&mut connection_loss) => RemoteInput::Lost,
-            () = wait_for_connection_loss(&mut local_loss) => RemoteInput::Lost,
-            () = bridge.cancelled(), if !cancellation_forwarded => RemoteInput::Cancel,
-            event = stream.recv() => RemoteInput::Event(event),
-        };
-        let finished = match next {
-            RemoteInput::Lost => Some(Err(NodeRunnerError::ConnectionLost)),
-            RemoteInput::Cancel => {
-                cancellation_forwarded = true;
-                forward_cancel(&runtime, &reference, &mut connection_loss)
-                    .await
-                    .err()
-                    .map(Err)
-            }
-            RemoteInput::Event(event) => {
-                handle_remote_event(
-                    event,
-                    RemoteEventContext {
-                        runtime: &runtime,
-                        reference: &reference,
-                        bridge: &mut bridge,
-                        connection_loss: &mut connection_loss,
-                    },
-                )
-                .await
-            }
-        };
-        if let Some(result) = finished {
-            break result;
+async fn settle_remote_acceptance(
+    acceptance: &mut Option<oneshot::Receiver<()>>,
+    connection_loss: &mut watch::Receiver<bool>,
+    closing: &mut watch::Receiver<bool>,
+) {
+    if acceptance.is_none() {
+        return;
+    }
+    tokio::select! {
+        biased;
+        () = wait_for_signal(connection_loss) => {}
+        () = wait_for_signal(closing) => {}
+        _ = receive_start_acceptance(acceptance) => {}
+    }
+    acceptance.take();
+}
+
+async fn handle_remote_cancel(
+    context: RemoteCancelContext<'_>,
+) -> Option<Result<NodeCompletion, NodeRunnerError>> {
+    match forward_cancel(
+        context.runtime,
+        context.reference,
+        context.connection_loss,
+        context.closing_signal,
+    )
+    .await
+    {
+        CancelOutcome::Forwarded => None,
+        CancelOutcome::Closing => {
+            *context.closing = true;
+            None
         }
-    };
-    bridge.finish(result);
-    let _ = registration.done.send(true);
-    runtime.activity.finish(&reference).await;
+        CancelOutcome::ConnectionLost => Some(Err(NodeRunnerError::ConnectionLost)),
+    }
+}
+
+struct RemoteCancelContext<'a> {
+    runtime: &'a ProxyRuntime,
+    reference: &'a ExecutionRef,
+    connection_loss: &'a mut watch::Receiver<bool>,
+    closing_signal: &'a mut watch::Receiver<bool>,
+    closing: &'a mut bool,
+}
+
+async fn next_remote_input(context: RemoteInputContext<'_>) -> RemoteInput {
+    if context.closing {
+        tokio::select! {
+            biased;
+            () = wait_for_signal(context.connection_loss) => RemoteInput::Lost,
+            event = context.stream.recv() => RemoteInput::Event(event),
+            () = wait_for_signal(context.closed_signal) => RemoteInput::Closed,
+        }
+    } else {
+        tokio::select! {
+            biased;
+            () = wait_for_signal(context.connection_loss) => RemoteInput::Lost,
+            () = wait_for_signal(context.closing_signal) => RemoteInput::Closing,
+            () = context.bridge.cancelled(), if !context.cancellation_handled => RemoteInput::Cancel,
+            input = receive_remote_event_or_acceptance(context.stream, context.acceptance) => input,
+        }
+    }
+}
+
+async fn receive_remote_event_or_acceptance(
+    stream: &mut CapsuleExecutionStream,
+    acceptance: &mut Option<oneshot::Receiver<()>>,
+) -> RemoteInput {
+    if acceptance.is_some() {
+        RemoteInput::Acceptance(receive_start_acceptance(acceptance).await)
+    } else {
+        RemoteInput::Event(stream.recv().await)
+    }
+}
+
+struct RemoteInputContext<'a> {
+    stream: &'a mut CapsuleExecutionStream,
+    bridge: &'a mut RemoteNodeHandleBridge,
+    connection_loss: &'a mut watch::Receiver<bool>,
+    closing_signal: &'a mut watch::Receiver<bool>,
+    closed_signal: &'a mut watch::Receiver<bool>,
+    closing: bool,
+    cancellation_handled: bool,
+    acceptance: &'a mut Option<oneshot::Receiver<()>>,
 }
 
 async fn handle_remote_event(
@@ -229,9 +261,15 @@ async fn handle_remote_event(
             context.runtime.loss.promote();
             Some(Err(NodeRunnerError::ConnectionLost))
         }
-        Some(CapsuleNodeEvent::Output { output }) => handle_remote_output(output, context).await,
+        Some(CapsuleNodeEvent::Output { output, timestamp }) => {
+            handle_remote_output(output, timestamp, context).await
+        }
         Some(CapsuleNodeEvent::TokenUsage { usage }) => {
-            let result = context.bridge.record_token_usage(usage);
+            let result = await_remote_bridge(
+                context.bridge.record_token_usage(usage),
+                context.connection_loss,
+            )
+            .await;
             handle_remote_bridge(result, context).await
         }
         Some(CapsuleNodeEvent::Completed { completion })
@@ -246,14 +284,36 @@ async fn handle_remote_event(
 
 async fn handle_remote_output(
     output: CapsuleOutput,
+    timestamp: openengine_cluster_protocol::UnixTimestampMillis,
     context: RemoteEventContext<'_>,
 ) -> Option<Result<NodeCompletion, NodeRunnerError>> {
     let output = match output.into_live() {
         Ok(output) => output,
         Err(error) => return Some(Err(error)),
     };
-    let result = context.bridge.emit(output);
+    let result = await_remote_bridge(
+        context.bridge.emit_at(output, timestamp),
+        context.connection_loss,
+    )
+    .await;
     handle_remote_bridge(result, context).await
+}
+
+async fn await_remote_bridge<F>(
+    operation: F,
+    connection_loss: &mut watch::Receiver<bool>,
+) -> Result<(), NodeRunnerError>
+where
+    F: Future<Output = Result<(), NodeRunnerError>>,
+{
+    tokio::pin!(operation);
+    tokio::select! {
+        biased;
+        () = wait_for_signal(connection_loss) => {
+            Err(NodeRunnerError::ConnectionLost)
+        }
+        result = &mut operation => result,
+    }
 }
 
 async fn handle_remote_bridge(
@@ -263,31 +323,58 @@ async fn handle_remote_bridge(
     let Err(error) = result else {
         return None;
     };
-    Some(
-        match forward_cancel(context.runtime, context.reference, context.connection_loss).await {
-            Ok(()) => Err(error),
-            Err(connection_lost) => Err(connection_lost),
+    match error {
+        NodeRunnerError::Cancelled => None,
+        NodeRunnerError::ConnectionLost => Some(Err(NodeRunnerError::ConnectionLost)),
+        error => match forward_cancel(
+            context.runtime,
+            context.reference,
+            context.connection_loss,
+            context.closing,
+        )
+        .await
+        {
+            CancelOutcome::Forwarded => Some(Err(error)),
+            CancelOutcome::Closing => {
+                if context.pending_bridge_failure.is_none() {
+                    *context.pending_bridge_failure = Some(error);
+                }
+                None
+            }
+            CancelOutcome::ConnectionLost => Some(Err(NodeRunnerError::ConnectionLost)),
         },
-    )
+    }
+}
+
+enum CancelOutcome {
+    Forwarded,
+    Closing,
+    ConnectionLost,
 }
 
 async fn forward_cancel(
     runtime: &ProxyRuntime,
     reference: &ExecutionRef,
     connection_loss: &mut watch::Receiver<bool>,
-) -> Result<(), NodeRunnerError> {
-    if control_rpc(
-        runtime.channel.cancel(reference),
-        connection_loss,
-        runtime.control_timeout,
-    )
-    .await
-    {
-        Ok(())
-    } else {
+    closing: &mut watch::Receiver<bool>,
+) -> CancelOutcome {
+    let cancel = runtime.channel.cancel(reference);
+    tokio::pin!(cancel);
+    let outcome = tokio::select! {
+        biased;
+        () = wait_for_signal(connection_loss) => CancelOutcome::ConnectionLost,
+        () = wait_for_signal(closing) => CancelOutcome::Closing,
+        result = &mut cancel => if result.is_ok() {
+            CancelOutcome::Forwarded
+        } else {
+            CancelOutcome::ConnectionLost
+        },
+        () = tokio::time::sleep(runtime.control_timeout) => CancelOutcome::ConnectionLost,
+    };
+    if matches!(outcome, CancelOutcome::ConnectionLost) {
         runtime.loss.promote();
-        Err(NodeRunnerError::ConnectionLost)
     }
+    outcome
 }
 
 async fn control_rpc<F>(
@@ -301,7 +388,7 @@ where
     tokio::pin!(operation);
     tokio::select! {
         biased;
-        () = wait_for_connection_loss(connection_loss) => false,
+        () = wait_for_signal(connection_loss) => false,
         result = &mut operation => result.is_ok(),
         () = tokio::time::sleep(timeout) => false,
     }
@@ -309,82 +396,4 @@ where
 
 fn connection_is_lost(receiver: &watch::Receiver<bool>) -> bool {
     *receiver.borrow() || receiver.has_changed().is_err()
-}
-
-async fn wait_for_connection_loss(receiver: &mut watch::Receiver<bool>) {
-    while !*receiver.borrow_and_update() {
-        if receiver.changed().await.is_err() {
-            return;
-        }
-    }
-}
-
-#[derive(Clone, Default)]
-struct ProxyActivity {
-    entries: Arc<Mutex<Vec<ProxyExecution>>>,
-}
-
-struct ProxyExecution {
-    reference: ExecutionRef,
-    loss: watch::Sender<bool>,
-    done: watch::Receiver<bool>,
-}
-
-impl ProxyActivity {
-    async fn register(&self, reference: ExecutionRef) -> ProxyRegistration {
-        let (loss, loss_receiver) = watch::channel(false);
-        let (done_sender, done) = watch::channel(false);
-        self.entries.lock().await.push(ProxyExecution {
-            reference,
-            loss,
-            done,
-        });
-        ProxyRegistration {
-            loss: loss_receiver,
-            done: done_sender,
-        }
-    }
-
-    async fn finish(&self, reference: &ExecutionRef) {
-        let mut entries = self.entries.lock().await;
-        if let Some(index) = entries
-            .iter()
-            .position(|entry| &entry.reference == reference)
-        {
-            entries.swap_remove(index);
-        }
-    }
-
-    async fn lose_run(&self, run_id: &RunId) {
-        let entries = self.entries.lock().await;
-        for entry in entries
-            .iter()
-            .filter(|entry| &entry.reference.run_id == run_id)
-        {
-            let _ = entry.loss.send(true);
-        }
-    }
-
-    async fn wait_run(&self, run_id: &RunId) {
-        let mut completions = {
-            let entries = self.entries.lock().await;
-            entries
-                .iter()
-                .filter(|entry| &entry.reference.run_id == run_id)
-                .map(|entry| entry.done.clone())
-                .collect::<Vec<_>>()
-        };
-        for completion in &mut completions {
-            while !*completion.borrow_and_update() {
-                if completion.changed().await.is_err() {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-struct ProxyRegistration {
-    loss: watch::Receiver<bool>,
-    done: watch::Sender<bool>,
 }

--- a/zeroshot-rust/src/native_v2_capsule/remote/activity.rs
+++ b/zeroshot-rust/src/native_v2_capsule/remote/activity.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+
+use openengine_cluster_protocol::RunId;
+use tokio::sync::{Mutex, watch};
+
+use crate::native_v2_contract::ExecutionRef;
+
+#[derive(Clone, Default)]
+pub(super) struct ProxyActivity {
+    state: Arc<Mutex<ProxyActivityState>>,
+}
+
+#[derive(Default)]
+struct ProxyActivityState {
+    entries: Vec<ProxyExecution>,
+    closed_runs: std::collections::BTreeSet<RunId>,
+}
+
+struct ProxyExecution {
+    reference: ExecutionRef,
+    cancellation: watch::Sender<bool>,
+    closing: watch::Sender<bool>,
+    closed: watch::Sender<bool>,
+    done: watch::Receiver<bool>,
+}
+
+impl ProxyActivity {
+    pub(super) async fn register(
+        &self,
+        reference: ExecutionRef,
+        cancellation: watch::Sender<bool>,
+    ) -> Result<ProxyRegistration, crate::native_v2_runner::NodeRunnerError> {
+        let (closing, closing_receiver) = watch::channel(false);
+        let (closed, closed_receiver) = watch::channel(false);
+        let (done_sender, done) = watch::channel(false);
+        let mut state = self.state.lock().await;
+        if state.closed_runs.contains(&reference.run_id) {
+            return Err(crate::native_v2_runner::NodeRunnerError::RunClosed);
+        }
+        if state
+            .entries
+            .iter()
+            .any(|entry| entry.reference == reference)
+        {
+            return Err(crate::native_v2_runner::NodeRunnerError::ExecutionActive);
+        }
+        state.entries.push(ProxyExecution {
+            reference,
+            cancellation,
+            closing,
+            closed,
+            done,
+        });
+        Ok(ProxyRegistration {
+            closing: closing_receiver,
+            closed: closed_receiver,
+            done: done_sender,
+        })
+    }
+
+    pub(super) async fn accept_start(
+        &self,
+        reference: &ExecutionRef,
+        done: &watch::Sender<bool>,
+        acceptance: tokio::sync::oneshot::Sender<()>,
+    ) -> Result<(), crate::native_v2_runner::NodeRunnerError> {
+        let expected = done.subscribe();
+        let state = self.state.lock().await;
+        if state.closed_runs.contains(&reference.run_id) {
+            return Err(crate::native_v2_runner::NodeRunnerError::RunClosed);
+        }
+        if !state
+            .entries
+            .iter()
+            .any(|entry| entry.reference == *reference && entry.done.same_channel(&expected))
+        {
+            return Err(crate::native_v2_runner::NodeRunnerError::Cancelled);
+        }
+        acceptance
+            .send(())
+            .map_err(|_| crate::native_v2_runner::NodeRunnerError::Cancelled)
+    }
+
+    pub(super) async fn finish(&self, reference: &ExecutionRef, done: &watch::Sender<bool>) {
+        let expected = done.subscribe();
+        let mut state = self.state.lock().await;
+        if let Some(index) = state
+            .entries
+            .iter()
+            .position(|entry| &entry.reference == reference && entry.done.same_channel(&expected))
+        {
+            state.entries.swap_remove(index);
+        }
+        done.send_replace(true);
+    }
+
+    pub(super) async fn begin_close(&self, run_id: &RunId) {
+        let mut state = self.state.lock().await;
+        state.closed_runs.insert(run_id.clone());
+        signal_run(&state.entries, run_id, RunSignal::Closing);
+    }
+
+    pub(super) async fn complete_close(&self, run_id: &RunId) {
+        self.signal_run(run_id, RunSignal::Closed).await;
+    }
+
+    async fn signal_run(&self, run_id: &RunId, signal: RunSignal) {
+        let state = self.state.lock().await;
+        signal_run(&state.entries, run_id, signal);
+    }
+
+    pub(super) async fn wait_run(&self, run_id: &RunId) {
+        let mut completions = {
+            let state = self.state.lock().await;
+            state
+                .entries
+                .iter()
+                .filter(|entry| &entry.reference.run_id == run_id)
+                .map(|entry| entry.done.clone())
+                .collect::<Vec<_>>()
+        };
+        for completion in &mut completions {
+            while !*completion.borrow_and_update() {
+                if completion.changed().await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn signal_run(entries: &[ProxyExecution], run_id: &RunId, signal: RunSignal) {
+    for entry in entries
+        .iter()
+        .filter(|entry| &entry.reference.run_id == run_id)
+    {
+        signal.send(entry);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RunSignal {
+    Closing,
+    Closed,
+}
+
+impl RunSignal {
+    fn send(self, execution: &ProxyExecution) {
+        match self {
+            Self::Closing => {
+                execution.closing.send_replace(true);
+                execution.cancellation.send_replace(true);
+            }
+            Self::Closed => {
+                execution.closed.send_replace(true);
+            }
+        }
+    }
+}
+
+pub(super) struct ProxyRegistration {
+    pub(super) closing: watch::Receiver<bool>,
+    pub(super) closed: watch::Receiver<bool>,
+    pub(super) done: watch::Sender<bool>,
+}

--- a/zeroshot-rust/src/native_v2_capsule/remote/execution.rs
+++ b/zeroshot-rust/src/native_v2_capsule/remote/execution.rs
@@ -1,0 +1,139 @@
+use super::*;
+
+struct RemoteInputAction<'a> {
+    runtime: &'a ProxyRuntime,
+    reference: &'a ExecutionRef,
+    bridge: &'a mut RemoteNodeHandleBridge,
+    connection_loss: &'a mut watch::Receiver<bool>,
+    closing_signal: &'a mut watch::Receiver<bool>,
+    closing: &'a mut bool,
+    cancellation_handled: &'a mut bool,
+    acceptance: &'a mut Option<oneshot::Receiver<()>>,
+    pending_bridge_failure: &'a mut Option<NodeRunnerError>,
+}
+
+pub(super) async fn drive_remote_execution(task: RemoteExecutionTask) {
+    let RemoteExecutionTask {
+        runtime,
+        reference,
+        mut stream,
+        mut bridge,
+        registration,
+        mut acceptance,
+    } = task;
+    let mut closing_signal = registration.closing;
+    let mut closed_signal = registration.closed;
+    let mut closing = false;
+    let mut cancellation_handled = false;
+    let mut pending_bridge_failure = None;
+    let mut connection_loss = runtime.connection_loss.clone();
+    let result = loop {
+        let next = next_remote_input(RemoteInputContext {
+            stream: &mut stream,
+            bridge: &mut bridge,
+            connection_loss: &mut connection_loss,
+            closing_signal: &mut closing_signal,
+            closed_signal: &mut closed_signal,
+            closing,
+            cancellation_handled,
+            acceptance: &mut acceptance,
+        })
+        .await;
+        let finished = apply_remote_input(
+            next,
+            RemoteInputAction {
+                runtime: &runtime,
+                reference: &reference,
+                bridge: &mut bridge,
+                connection_loss: &mut connection_loss,
+                closing_signal: &mut closing_signal,
+                closing: &mut closing,
+                cancellation_handled: &mut cancellation_handled,
+                acceptance: &mut acceptance,
+                pending_bridge_failure: &mut pending_bridge_failure,
+            },
+        )
+        .await;
+        if let Some(result) = finished {
+            break result;
+        }
+    };
+    let result = prefer_pending_bridge_failure(result, pending_bridge_failure);
+    settle_remote_acceptance(&mut acceptance, &mut connection_loss, &mut closing_signal).await;
+    bridge.finish(result);
+    runtime
+        .activity
+        .finish(&reference, &registration.done)
+        .await;
+}
+
+async fn apply_remote_input(
+    input: RemoteInput,
+    mut context: RemoteInputAction<'_>,
+) -> Option<Result<NodeCompletion, NodeRunnerError>> {
+    match input {
+        RemoteInput::Lost => Some(Err(NodeRunnerError::ConnectionLost)),
+        RemoteInput::Closed => {
+            context.acceptance.take();
+            Some(Err(if connection_is_lost(context.connection_loss) {
+                NodeRunnerError::ConnectionLost
+            } else {
+                NodeRunnerError::Cancelled
+            }))
+        }
+        RemoteInput::Closing => {
+            context.acceptance.take();
+            *context.closing = true;
+            *context.cancellation_handled = true;
+            None
+        }
+        RemoteInput::Cancel => cancel_remote_input(&mut context).await,
+        RemoteInput::Acceptance(result) => {
+            context.acceptance.take();
+            if result.is_err() {
+                cancel_remote_input(&mut context).await
+            } else {
+                None
+            }
+        }
+        RemoteInput::Event(event) => {
+            handle_remote_event(
+                event,
+                RemoteEventContext {
+                    runtime: context.runtime,
+                    reference: context.reference,
+                    bridge: context.bridge,
+                    connection_loss: context.connection_loss,
+                    closing: context.closing_signal,
+                    pending_bridge_failure: context.pending_bridge_failure,
+                },
+            )
+            .await
+        }
+    }
+}
+
+fn prefer_pending_bridge_failure(
+    result: Result<NodeCompletion, NodeRunnerError>,
+    pending: Option<NodeRunnerError>,
+) -> Result<NodeCompletion, NodeRunnerError> {
+    match result {
+        Err(NodeRunnerError::ConnectionLost) => Err(NodeRunnerError::ConnectionLost),
+        result => pending.map_or(result, Err),
+    }
+}
+
+async fn cancel_remote_input(
+    context: &mut RemoteInputAction<'_>,
+) -> Option<Result<NodeCompletion, NodeRunnerError>> {
+    context.acceptance.take();
+    *context.cancellation_handled = true;
+    handle_remote_cancel(RemoteCancelContext {
+        runtime: context.runtime,
+        reference: context.reference,
+        connection_loss: context.connection_loss,
+        closing_signal: context.closing_signal,
+        closing: context.closing,
+    })
+    .await
+}

--- a/zeroshot-rust/src/native_v2_capsule/remote/start.rs
+++ b/zeroshot-rust/src/native_v2_capsule/remote/start.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+pub(super) async fn remote_start(
+    runner: &RemoteCapsuleNodeRunner,
+    request: NodeRunRequest,
+) -> Result<NodeHandle, NodeRunnerError> {
+    if connection_is_lost(&runner.connection_loss) {
+        return Err(NodeRunnerError::ConnectionLost);
+    }
+    let reference = request.invocation.reference.clone();
+    let (handle, bridge) = remote_node_handle(reference.clone());
+    let registration = runner
+        .activity
+        .register(reference.clone(), bridge.cancellation_signal())
+        .await?;
+    let registration_identity = registration.done.clone();
+    let (ready, readiness) = oneshot::channel();
+    let pending_reference = reference.clone();
+    tokio::spawn(establish_remote_execution(
+        PendingRemoteStart {
+            runner: runner.clone(),
+            request,
+            reference: pending_reference,
+            bridge,
+            registration,
+        },
+        ready,
+    ));
+    #[cfg(test)]
+    pause_before_start_readiness(runner.start_readiness_pause.as_ref()).await;
+    let acceptance = readiness.await.unwrap_or(Err(NodeRunnerError::Driver))?;
+    if let Err(error) = runner
+        .activity
+        .accept_start(&reference, &registration_identity, acceptance)
+        .await
+    {
+        if connection_is_lost(&runner.connection_loss) {
+            return Err(NodeRunnerError::ConnectionLost);
+        }
+        return Err(error);
+    }
+    Ok(handle)
+}
+
+struct PendingRemoteStart {
+    runner: RemoteCapsuleNodeRunner,
+    request: NodeRunRequest,
+    reference: ExecutionRef,
+    bridge: RemoteNodeHandleBridge,
+    registration: ProxyRegistration,
+}
+
+async fn establish_remote_execution(
+    pending: PendingRemoteStart,
+    ready: oneshot::Sender<Result<oneshot::Sender<()>, NodeRunnerError>>,
+) {
+    let stream = match await_remote_start(&pending).await {
+        Ok(stream) => stream,
+        Err(error) => {
+            pending
+                .runner
+                .activity
+                .finish(&pending.reference, &pending.registration.done)
+                .await;
+            let _ = ready.send(Err(error));
+            #[cfg(test)]
+            mark_start_readiness_sent(pending.runner.start_readiness_pause.as_ref());
+            return;
+        }
+    };
+    let runtime = ProxyRuntime {
+        channel: pending.runner.channel.clone(),
+        connection_loss: pending.runner.connection_loss.clone(),
+        loss: pending.runner.loss.clone(),
+        activity: pending.runner.activity.clone(),
+        control_timeout: pending.runner.control_timeout,
+    };
+    let (accept, acceptance) = oneshot::channel();
+    let task = RemoteExecutionTask {
+        runtime,
+        reference: pending.reference,
+        stream,
+        bridge: pending.bridge,
+        registration: pending.registration,
+        acceptance: Some(acceptance),
+    };
+    let _ = ready.send(Ok(accept));
+    #[cfg(test)]
+    mark_start_readiness_sent(pending.runner.start_readiness_pause.as_ref());
+    drive_remote_execution(task).await;
+}
+
+async fn await_remote_start(
+    pending: &PendingRemoteStart,
+) -> Result<CapsuleExecutionStream, NodeRunnerError> {
+    let mut connection_loss = pending.runner.connection_loss.clone();
+    let mut closed = pending.registration.closed.clone();
+    let start = pending.runner.channel.start(pending.request.clone());
+    tokio::pin!(start);
+    tokio::select! {
+        biased;
+        result = &mut start => match result {
+            Ok(stream) => Ok(stream),
+            Err(CapsuleConnectionError::Lost) => {
+                pending.runner.loss.promote();
+                Err(NodeRunnerError::ConnectionLost)
+            }
+            Err(CapsuleConnectionError::Rejected(failure)) => Err(failure.into_runner()),
+        },
+        () = wait_for_signal(&mut connection_loss) => Err(NodeRunnerError::ConnectionLost),
+        () = wait_for_signal(&mut closed) => Err(NodeRunnerError::RunClosed),
+    }
+}

--- a/zeroshot-rust/src/native_v2_capsule/tests.rs
+++ b/zeroshot-rust/src/native_v2_capsule/tests.rs
@@ -74,7 +74,11 @@ impl NodeRunner for TestRunner {
             match result {
                 Result::Complete => {
                     bridge
-                        .emit(LiveOutput::new(LiveOutputStream::Output, "working").assert_value())
+                        .emit_at(
+                            LiveOutput::new(LiveOutputStream::Output, "working").assert_value(),
+                            UnixTimestampMillis::new(1_234_567).assert_value(),
+                        )
+                        .await
                         .assert_value();
                     bridge
                         .record_token_usage(Some(TokenUsageDelta {
@@ -83,6 +87,7 @@ impl NodeRunner for TestRunner {
                             cache_read_input_tokens: Some(TokenCount::new(20).assert_value()),
                             cache_creation_input_tokens: None,
                         }))
+                        .await
                         .assert_value();
                     bridge.finish(Ok(NodeCompletion {
                         reference,
@@ -114,10 +119,14 @@ async fn proxy_preserves_durable_live_and_normalized_completion() {
     let mut live = handle.attach();
     local.proceed.notify_one();
 
-    let durable_output = durable.recv_output().await.assert_value();
+    let (durable_output, timestamp) = match durable.recv().await.assert_value() {
+        DurableNodeEvent::Output { output, timestamp } => (output, timestamp),
+        DurableNodeEvent::TokenUsage(_) => None.assert_value(),
+    };
     let live_output = live.recv().await.assert_value();
     assert_eq!(durable_output.text, "working");
     assert_eq!(live_output, durable_output);
+    assert_eq!(timestamp.get(), 1_234_567);
     let usage = durable.recv_usage().await.assert_value().assert_value();
     assert_eq!(usage.input_tokens.get(), 31);
     assert_eq!(usage.output_tokens.get(), 7);
@@ -193,7 +202,7 @@ impl CapsuleNodeChannel for BrokenChannel {
         &self,
         _request: NodeRunRequest,
     ) -> Result<CapsuleExecutionStream, CapsuleConnectionError> {
-        let (events, receiver) = mpsc::unbounded_channel();
+        let (events, receiver) = mpsc::channel(1);
         drop(events);
         Ok(CapsuleExecutionStream::from_receiver(receiver))
     }
@@ -274,7 +283,7 @@ async fn start_loss_promotes_the_runner_loss_signal() {
 #[derive(Clone)]
 struct HangingControlChannel {
     loss: watch::Sender<bool>,
-    streams: Arc<StdMutex<Vec<mpsc::UnboundedSender<CapsuleNodeEvent>>>>,
+    streams: Arc<StdMutex<Vec<mpsc::Sender<CapsuleNodeEvent>>>>,
 }
 
 impl HangingControlChannel {
@@ -293,7 +302,7 @@ impl CapsuleNodeChannel for HangingControlChannel {
         &self,
         _request: NodeRunRequest,
     ) -> Result<CapsuleExecutionStream, CapsuleConnectionError> {
-        let (events, receiver) = mpsc::unbounded_channel();
+        let (events, receiver) = mpsc::channel(1);
         self.streams.lock().assert_value().push(events);
         Ok(CapsuleExecutionStream::from_receiver(receiver))
     }
@@ -314,6 +323,7 @@ impl CapsuleNodeChannel for HangingControlChannel {
 fn hanging_proxy() -> RemoteCapsuleNodeRunner {
     RemoteCapsuleNodeRunner::new(Arc::new(HangingControlChannel::new()))
         .with_control_timeout(Duration::from_millis(20))
+        .with_close_timeout(Duration::from_millis(20))
 }
 
 #[tokio::test]
@@ -353,7 +363,11 @@ async fn hanging_close_is_bounded_and_promotes_loss() {
 
 static TEMP_ID: AtomicU64 = AtomicU64::new(1);
 
+#[path = "tests/backpressure.rs"]
+mod backpressure;
 #[path = "tests/filesystem.rs"]
 mod filesystem;
+#[path = "tests/start_close.rs"]
+mod start_close;
 
 use openengine_cluster_testkit::assertions::{AssertValue, AssertError};

--- a/zeroshot-rust/src/native_v2_capsule/tests/backpressure.rs
+++ b/zeroshot-rust/src/native_v2_capsule/tests/backpressure.rs
@@ -1,0 +1,436 @@
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{RunId, TokenCount};
+use tokio::sync::{Notify, mpsc, oneshot};
+
+use super::request;
+use super::super::*;
+use crate::native_v2_contract::TokenUsageDelta;
+use crate::native_v2_runner::{
+    AttachReceiveError, DURABLE_OUTPUT_CAPACITY, DurableOutput, ReadOnlyAttach, remote_node_handle,
+};
+
+use openengine_cluster_testkit::assertions::AssertValue;
+
+#[derive(Default)]
+struct SaturatingRunner {
+    saturated: Arc<Notify>,
+    cleaned: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl NodeRunner for SaturatingRunner {
+    async fn start(&self, request: NodeRunRequest) -> Result<NodeHandle, NodeRunnerError> {
+        let reference = request.invocation.reference;
+        let (handle, bridge) = remote_node_handle(reference);
+        let saturated = self.saturated.clone();
+        let cleaned = self.cleaned.clone();
+        tokio::spawn(async move {
+            for index in 0.. {
+                if index == DURABLE_OUTPUT_CAPACITY * 2 + 1 {
+                    saturated.notify_one();
+                }
+                let output =
+                    LiveOutput::new(LiveOutputStream::Output, index.to_string()).assert_value();
+                if bridge.emit(output).await.is_err() {
+                    break;
+                }
+            }
+            bridge
+                .record_token_usage(Some(TokenUsageDelta {
+                    input_tokens: TokenCount::new(21).assert_value(),
+                    output_tokens: TokenCount::new(8).assert_value(),
+                    cache_read_input_tokens: None,
+                    cache_creation_input_tokens: None,
+                }))
+                .await
+                .assert_value();
+            cleaned.store(true, Ordering::SeqCst);
+            bridge.finish(Err(NodeRunnerError::Cancelled));
+        });
+        Ok(handle)
+    }
+
+    async fn close_run(&self, _run_id: &RunId) {}
+}
+
+#[tokio::test]
+async fn full_capsule_queue_cancels_cleanly_and_retains_usage() {
+    let runner = Arc::new(SaturatingRunner::default());
+    let endpoint = NativeCapsuleNodeEndpoint::new(runner.clone());
+    let run_id = RunId::new("bounded-capsule");
+    let mut stream = endpoint
+        .start(request(run_id.as_str(), 1))
+        .await
+        .assert_value();
+    tokio::time::timeout(Duration::from_secs(1), runner.saturated.notified())
+        .await
+        .assert_value();
+
+    tokio::time::timeout(Duration::from_secs(1), endpoint.close_run(&run_id))
+        .await
+        .assert_value()
+        .assert_value();
+    assert!(runner.cleaned.load(Ordering::SeqCst));
+
+    let mut outputs = 0;
+    let mut usage = None;
+    let mut failed = false;
+    let mut unexpected = Vec::new();
+    while let Some(event) = stream.recv().await {
+        match event {
+            CapsuleNodeEvent::Output { .. } => outputs += 1,
+            CapsuleNodeEvent::TokenUsage { usage: observed } => usage = observed,
+            CapsuleNodeEvent::Failed {
+                failure: CapsuleNodeFailure::Cancelled,
+            } => failed = true,
+            event => unexpected.push(event),
+        }
+    }
+    assert_eq!(outputs, DURABLE_OUTPUT_CAPACITY);
+    assert_eq!(usage.assert_value().input_tokens.get(), 21);
+    assert!(failed);
+    assert!(unexpected.is_empty(), "unexpected events: {unexpected:?}");
+}
+
+#[tokio::test]
+async fn cancelling_a_receive_does_not_lose_the_terminal_event() {
+    let (events, receiver) = mpsc::channel(1);
+    let (terminal, terminal_receiver) = oneshot::channel();
+    let mut stream = CapsuleExecutionStream::from_bounded_receiver(receiver, terminal_receiver);
+    drop(events);
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), stream.recv())
+            .await
+            .is_err()
+    );
+    terminal
+        .send(vec![CapsuleNodeEvent::Failed {
+            failure: CapsuleNodeFailure::Cancelled,
+        }])
+        .assert_value();
+    assert!(matches!(
+        stream.recv().await,
+        Some(CapsuleNodeEvent::Failed {
+            failure: CapsuleNodeFailure::Cancelled
+        })
+    ));
+}
+
+#[derive(Clone)]
+struct SaturatingChannel {
+    release: Arc<Notify>,
+    loss: watch::Sender<bool>,
+    events: Arc<StdMutex<Vec<RemoteEventSink>>>,
+    cancel_calls: Arc<AtomicUsize>,
+    close_calls: Arc<AtomicUsize>,
+    hold_close: Arc<AtomicBool>,
+    close_started: Arc<Notify>,
+    close_release: Arc<Notify>,
+}
+
+type RemoteEventSink = (ExecutionRef, mpsc::Sender<CapsuleNodeEvent>);
+
+impl SaturatingChannel {
+    fn new() -> Self {
+        let (loss, _) = watch::channel(false);
+        Self {
+            release: Arc::new(Notify::new()),
+            loss,
+            events: Arc::new(StdMutex::new(Vec::new())),
+            cancel_calls: Arc::new(AtomicUsize::new(0)),
+            close_calls: Arc::new(AtomicUsize::new(0)),
+            hold_close: Arc::new(AtomicBool::new(false)),
+            close_started: Arc::new(Notify::new()),
+            close_release: Arc::new(Notify::new()),
+        }
+    }
+
+    fn lose_connection(&self) {
+        self.loss.send_replace(true);
+    }
+
+    fn hold_close(&self) {
+        self.hold_close.store(true, Ordering::SeqCst);
+    }
+
+    async fn wait_for_close(&self) {
+        self.close_started.notified().await;
+    }
+
+    fn release_close(&self) {
+        self.close_release.notify_one();
+    }
+
+    async fn send_cancelled(&self, matches: impl Fn(&ExecutionRef) -> bool) {
+        let streams = self
+            .events
+            .lock()
+            .assert_value()
+            .iter()
+            .filter(|(reference, _)| matches(reference))
+            .map(|(_, events)| events.clone())
+            .collect::<Vec<_>>();
+        for events in streams {
+            let usage = TokenUsageDelta {
+                input_tokens: TokenCount::new(1).assert_value(),
+                output_tokens: TokenCount::new(1).assert_value(),
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+            };
+            let _ = events
+                .send(CapsuleNodeEvent::TokenUsage { usage: Some(usage) })
+                .await;
+            let _ = events
+                .send(CapsuleNodeEvent::Failed {
+                    failure: CapsuleNodeFailure::Cancelled,
+                })
+                .await;
+        }
+    }
+}
+
+#[async_trait]
+impl CapsuleNodeChannel for SaturatingChannel {
+    async fn start(
+        &self,
+        request: NodeRunRequest,
+    ) -> Result<CapsuleExecutionStream, CapsuleConnectionError> {
+        let (events, receiver) = mpsc::channel(DURABLE_OUTPUT_CAPACITY);
+        self.events
+            .lock()
+            .assert_value()
+            .push((request.invocation.reference, events.clone()));
+        let release = self.release.clone();
+        tokio::spawn(async move {
+            release.notified().await;
+            for index in 0..=DURABLE_OUTPUT_CAPACITY {
+                let output =
+                    LiveOutput::new(LiveOutputStream::Output, index.to_string()).assert_value();
+                if events
+                    .send(CapsuleNodeEvent::Output {
+                        output: output.into(),
+                        timestamp: openengine_cluster_protocol::UnixTimestampMillis::new(1)
+                            .assert_value(),
+                    })
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        });
+        Ok(CapsuleExecutionStream::from_receiver(receiver))
+    }
+
+    async fn cancel(&self, reference: &ExecutionRef) -> Result<(), CapsuleConnectionError> {
+        self.cancel_calls.fetch_add(1, Ordering::SeqCst);
+        self.send_cancelled(|candidate| candidate == reference)
+            .await;
+        Ok(())
+    }
+
+    async fn close_run(&self, run_id: &RunId) -> Result<(), CapsuleConnectionError> {
+        self.close_calls.fetch_add(1, Ordering::SeqCst);
+        if self.hold_close.load(Ordering::SeqCst) {
+            self.close_started.notify_one();
+            self.close_release.notified().await;
+        }
+        self.send_cancelled(|reference| &reference.run_id == run_id)
+            .await;
+        Ok(())
+    }
+
+    fn connection_loss(&self) -> watch::Receiver<bool> {
+        self.loss.subscribe()
+    }
+}
+
+async fn saturate_remote_bridge(
+    channel: &SaturatingChannel,
+    live: &mut ReadOnlyAttach,
+) -> Result<(), AttachReceiveError> {
+    channel.release.notify_one();
+    let last = (DURABLE_OUTPUT_CAPACITY - 1).to_string();
+    loop {
+        match tokio::time::timeout(Duration::from_secs(1), live.recv())
+            .await
+            .assert_value()
+        {
+            Ok(output) if output.text == last => break,
+            Ok(_) | Err(AttachReceiveError::Lagged) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    tokio::task::yield_now().await;
+    Ok(())
+}
+
+async fn saturated_remote(
+    run_id: &str,
+    control_timeout: Option<Duration>,
+) -> (
+    Arc<SaturatingChannel>,
+    RemoteCapsuleNodeRunner,
+    NodeHandle,
+    DurableOutput,
+) {
+    let channel = Arc::new(SaturatingChannel::new());
+    let mut proxy = RemoteCapsuleNodeRunner::new(channel.clone());
+    if let Some(timeout) = control_timeout {
+        proxy = proxy.with_control_timeout(timeout);
+    }
+    let mut handle = proxy.start(request(run_id, 1)).await.assert_value();
+    let durable = handle.take_initial_output().assert_value();
+    let mut live = handle.attach();
+    saturate_remote_bridge(&channel, &mut live)
+        .await
+        .assert_value();
+    (channel, proxy, handle, durable)
+}
+
+#[tokio::test]
+async fn saturated_remote_cancel_is_forwarded_once_and_preserves_usage() {
+    let (channel, _proxy, mut handle, mut durable) = saturated_remote("remote-cancel", None).await;
+
+    handle.cancel();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), handle.completion())
+            .await
+            .assert_value(),
+        Err(NodeRunnerError::Cancelled)
+    );
+    assert_eq!(channel.cancel_calls.load(Ordering::SeqCst), 1);
+
+    let mut usage = None;
+    while let Ok(event) = durable.recv().await {
+        if let DurableNodeEvent::TokenUsage(observed) = event {
+            usage = observed;
+        }
+    }
+    assert_eq!(usage.assert_value().input_tokens.get(), 1);
+}
+
+async fn assert_ordered_cancelled_output(mut durable: DurableOutput) {
+    let mut outputs = 0;
+    let mut usage = None;
+    while let Ok(event) = durable.recv().await {
+        match event {
+            DurableNodeEvent::Output { output, .. } => {
+                assert!(usage.is_none(), "output arrived after terminal usage");
+                assert_eq!(output.text, outputs.to_string());
+                outputs += 1;
+            }
+            DurableNodeEvent::TokenUsage(observed) => {
+                assert!(usage.is_none(), "terminal usage was duplicated");
+                usage = observed;
+            }
+        }
+    }
+    assert_eq!(outputs, DURABLE_OUTPUT_CAPACITY);
+    assert_eq!(usage.assert_value().input_tokens.get(), 1);
+}
+
+#[tokio::test]
+async fn connection_loss_interrupts_a_saturated_remote_send() {
+    let (channel, _proxy, mut handle, _durable) = saturated_remote("remote-loss", None).await;
+
+    channel.lose_connection();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), handle.completion())
+            .await
+            .assert_value(),
+        Err(NodeRunnerError::ConnectionLost)
+    );
+}
+
+#[tokio::test]
+async fn close_run_interrupts_a_saturated_remote_send() {
+    let (channel, proxy, mut handle, durable) =
+        saturated_remote("remote-close", Some(Duration::from_millis(20))).await;
+    let loss = proxy.connection_loss();
+
+    tokio::time::timeout(
+        Duration::from_secs(1),
+        proxy.close_run(&RunId::new("remote-close")),
+    )
+    .await
+    .assert_value();
+    assert_eq!(channel.close_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(channel.cancel_calls.load(Ordering::SeqCst), 0);
+    assert!(!*loss.borrow());
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), handle.completion())
+            .await
+            .assert_value(),
+        Err(NodeRunnerError::Cancelled)
+    );
+
+    assert_ordered_cancelled_output(durable).await;
+}
+
+#[tokio::test]
+async fn close_run_does_not_interrupt_an_unrelated_execution() {
+    let (channel, proxy, mut closing, durable) =
+        saturated_remote("closing-run", Some(Duration::from_millis(20))).await;
+    channel.hold_close();
+    let mut unrelated = proxy
+        .start(request("unrelated-run", 2))
+        .await
+        .assert_value();
+    let loss = proxy.connection_loss();
+
+    let close_proxy = proxy.clone();
+    let mut close = tokio::spawn(async move {
+        close_proxy.close_run(&RunId::new("closing-run")).await;
+    });
+    tokio::time::timeout(Duration::from_secs(1), channel.wait_for_close())
+        .await
+        .assert_value();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(60), &mut close)
+            .await
+            .is_err(),
+        "close_run used the shorter 20ms control timeout"
+    );
+    assert!(!*loss.borrow());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), unrelated.completion())
+            .await
+            .is_err(),
+        "slow close_run completed an execution from another run"
+    );
+
+    channel.release_close();
+    tokio::time::timeout(Duration::from_secs(1), close)
+        .await
+        .assert_value()
+        .assert_value();
+
+    assert_eq!(closing.completion().await, Err(NodeRunnerError::Cancelled));
+    assert!(!*loss.borrow());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), unrelated.completion())
+            .await
+            .is_err(),
+        "close_run completed an execution from another run"
+    );
+    assert_ordered_cancelled_output(durable).await;
+
+    unrelated.cancel();
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), unrelated.completion())
+            .await
+            .assert_value(),
+        Err(NodeRunnerError::Cancelled)
+    );
+    assert_eq!(channel.close_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(channel.cancel_calls.load(Ordering::SeqCst), 1);
+}
+
+#[path = "backpressure/endpoint_metadata.rs"]
+mod endpoint_metadata;

--- a/zeroshot-rust/src/native_v2_capsule/tests/backpressure/endpoint_metadata.rs
+++ b/zeroshot-rust/src/native_v2_capsule/tests/backpressure/endpoint_metadata.rs
@@ -1,0 +1,162 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{RunId, TokenCount};
+use tokio::sync::Notify;
+
+use super::super::request;
+use crate::native_v2_capsule::{
+    CapsuleNodeChannel, CapsuleNodeEvent, CapsuleNodeFailure, NativeCapsuleNodeEndpoint,
+    RemoteCapsuleNodeRunner,
+};
+use crate::native_v2_contract::TokenUsageDelta;
+use crate::native_v2_runner::{
+    DURABLE_OUTPUT_CAPACITY, NodeHandle, NodeRunRequest, NodeRunner, NodeRunnerError,
+    remote_node_handle,
+};
+use openengine_cluster_testkit::assertions::AssertValue;
+
+const KNOWN_USAGE_RECORDS: usize = DURABLE_OUTPUT_CAPACITY * 3 + 17;
+
+fn unit_usage() -> TokenUsageDelta {
+    TokenUsageDelta {
+        input_tokens: TokenCount::new(1).assert_value(),
+        output_tokens: TokenCount::new(2).assert_value(),
+        cache_read_input_tokens: None,
+        cache_creation_input_tokens: None,
+    }
+}
+
+#[derive(Default)]
+struct UsageBurstRunner {
+    saturated: Arc<Notify>,
+    cleaned: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl NodeRunner for UsageBurstRunner {
+    async fn start(&self, request: NodeRunRequest) -> Result<NodeHandle, NodeRunnerError> {
+        let (handle, bridge) = remote_node_handle(request.invocation.reference);
+        let saturated = self.saturated.clone();
+        let cleaned = self.cleaned.clone();
+        tokio::spawn(async move {
+            let usage = unit_usage();
+            for index in 0..KNOWN_USAGE_RECORDS {
+                if index == DURABLE_OUTPUT_CAPACITY * 2 + 1 {
+                    saturated.notify_one();
+                }
+                bridge.record_token_usage(Some(usage)).await.assert_value();
+                tokio::task::yield_now().await;
+            }
+            bridge.record_token_usage(None).await.assert_value();
+            cleaned.store(true, Ordering::SeqCst);
+            let completion = Err(NodeRunnerError::Cancelled);
+            bridge.finish(completion);
+        });
+        Ok(handle)
+    }
+
+    async fn close_run(&self, _: &RunId) {}
+}
+
+async fn wait_for_usage_saturation(runner: &UsageBurstRunner) {
+    tokio::time::timeout(Duration::from_secs(5), runner.saturated.notified())
+        .await
+        .assert_value();
+}
+
+#[tokio::test]
+async fn unread_stream_compacts_post_cancellation_usage_without_losing_totals() {
+    let runner = Arc::new(UsageBurstRunner::default());
+    let endpoint = NativeCapsuleNodeEndpoint::new(runner.clone());
+    let run_id = RunId::new("bounded-cancelled-metadata");
+    let mut stream = endpoint
+        .start(request(run_id.as_str(), 1))
+        .await
+        .assert_value();
+
+    wait_for_usage_saturation(&runner).await;
+    tokio::time::timeout(Duration::from_secs(5), endpoint.close_run(&run_id))
+        .await
+        .assert_value()
+        .assert_value();
+    assert!(runner.cleaned.load(Ordering::SeqCst));
+
+    let mut known_events = 0;
+    let mut input_tokens = 0;
+    let mut output_tokens = 0;
+    let mut incomplete_events = 0;
+    let mut cancelled = false;
+    let mut unexpected = Vec::new();
+    while let Some(event) = stream.recv().await {
+        match event {
+            CapsuleNodeEvent::TokenUsage { usage: Some(usage) } => {
+                known_events += 1;
+                input_tokens += usage.input_tokens.get();
+                output_tokens += usage.output_tokens.get();
+            }
+            CapsuleNodeEvent::TokenUsage { usage: None } => incomplete_events += 1,
+            CapsuleNodeEvent::Failed {
+                failure: CapsuleNodeFailure::Cancelled,
+            } => cancelled = true,
+            event => unexpected.push(event),
+        }
+    }
+
+    assert_eq!(known_events, DURABLE_OUTPUT_CAPACITY + 1);
+    assert_eq!(input_tokens, KNOWN_USAGE_RECORDS as u64);
+    assert_eq!(output_tokens, (KNOWN_USAGE_RECORDS * 2) as u64);
+    assert_eq!(incomplete_events, 1);
+    assert!(cancelled);
+    assert!(unexpected.is_empty(), "unexpected events: {unexpected:?}");
+}
+
+#[tokio::test]
+async fn proxy_terminal_lane_overflow_is_sticky_and_marks_usage_incomplete() {
+    let runner = Arc::new(UsageBurstRunner::default());
+    let endpoint = Arc::new(NativeCapsuleNodeEndpoint::new(runner.clone()));
+    let proxy = RemoteCapsuleNodeRunner::new(endpoint);
+    let run_id = RunId::new("proxy-terminal-overflow");
+    let mut handle = proxy
+        .start(request(run_id.as_str(), 1))
+        .await
+        .assert_value();
+    let mut durable = handle.take_initial_output().assert_value();
+
+    wait_for_usage_saturation(&runner).await;
+    tokio::time::timeout(Duration::from_secs(5), proxy.close_run(&run_id))
+        .await
+        .assert_value();
+    assert!(runner.cleaned.load(Ordering::SeqCst));
+    assert!(matches!(
+        handle.completion().await,
+        Err(NodeRunnerError::DriverDetail(_))
+    ));
+
+    let mut known_events = 0;
+    let mut input_tokens = 0;
+    let mut output_tokens = 0;
+    let mut incomplete_events = 0;
+    let mut unexpected_outputs = 0;
+    while let Ok(event) = durable.recv().await {
+        match event {
+            crate::native_v2_runner::DurableNodeEvent::TokenUsage(Some(usage)) => {
+                known_events += 1;
+                input_tokens += usage.input_tokens.get();
+                output_tokens += usage.output_tokens.get();
+            }
+            crate::native_v2_runner::DurableNodeEvent::TokenUsage(None) => {
+                incomplete_events += 1;
+            }
+            crate::native_v2_runner::DurableNodeEvent::Output { .. } => unexpected_outputs += 1,
+        }
+    }
+
+    assert_eq!(known_events, DURABLE_OUTPUT_CAPACITY * 2);
+    assert_eq!(input_tokens, known_events as u64);
+    assert_eq!(output_tokens, (known_events * 2) as u64);
+    assert_eq!(incomplete_events, 1);
+    assert_eq!(unexpected_outputs, 0);
+}

--- a/zeroshot-rust/src/native_v2_capsule/tests/start_close.rs
+++ b/zeroshot-rust/src/native_v2_capsule/tests/start_close.rs
@@ -1,0 +1,72 @@
+use std::{future::Future, sync::Arc, time::Duration};
+
+use openengine_cluster_protocol::TokenCount;
+use tokio::{sync::Notify, task::JoinHandle};
+
+use super::super::StartReadinessPause;
+use crate::native_v2_contract::TokenUsageDelta;
+use openengine_cluster_testkit::assertions::AssertValue;
+
+#[derive(Clone, Default)]
+struct Gate {
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+impl Gate {
+    async fn enter(&self) {
+        self.entered.notify_one();
+        self.release.notified().await;
+    }
+
+    async fn wait(&self) {
+        self.entered.notified().await;
+    }
+
+    fn open(&self) {
+        self.release.notify_one();
+    }
+}
+
+async fn within_one_second<F>(future: F) -> F::Output
+where
+    F: Future,
+{
+    tokio::time::timeout(Duration::from_secs(1), future)
+        .await
+        .assert_value()
+}
+
+async fn join_test_task<T>(task: JoinHandle<T>) -> T {
+    within_one_second(task).await.assert_value()
+}
+
+async fn spawn_at_readiness<F>(
+    future: F,
+    gate: &Gate,
+    pause: &StartReadinessPause,
+) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let task = tokio::spawn(future);
+    gate.wait().await;
+    gate.open();
+    within_one_second(pause.wait_until_sent()).await;
+    task
+}
+
+fn token_usage() -> TokenUsageDelta {
+    TokenUsageDelta {
+        input_tokens: TokenCount::new(3).assert_value(),
+        output_tokens: TokenCount::new(2).assert_value(),
+        cache_read_input_tokens: None,
+        cache_creation_input_tokens: None,
+    }
+}
+
+#[path = "start_close/endpoint.rs"]
+mod endpoint;
+#[path = "start_close/remote.rs"]
+mod remote;

--- a/zeroshot-rust/src/native_v2_capsule/tests/start_close/endpoint.rs
+++ b/zeroshot-rust/src/native_v2_capsule/tests/start_close/endpoint.rs
@@ -1,0 +1,272 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::RunId;
+use tokio::sync::Notify;
+
+use super::{Gate, join_test_task, spawn_at_readiness, token_usage, within_one_second};
+use super::super::request;
+use super::super::super::*;
+use crate::native_v2_runner::remote_node_handle;
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
+
+#[derive(Default)]
+struct DelayedRunner {
+    start: Gate,
+    close: Gate,
+    cancelled: Arc<Notify>,
+    finish: Arc<Notify>,
+    start_calls: AtomicUsize,
+}
+
+#[async_trait]
+impl NodeRunner for DelayedRunner {
+    async fn start(&self, request: NodeRunRequest) -> Result<NodeHandle, NodeRunnerError> {
+        self.start_calls.fetch_add(1, Ordering::SeqCst);
+        self.start.enter().await;
+        let (handle, mut bridge) = remote_node_handle(request.invocation.reference);
+        let cancelled = self.cancelled.clone();
+        let finish = self.finish.clone();
+        tokio::spawn(async move {
+            bridge.cancelled().await;
+            bridge
+                .record_token_usage(Some(token_usage()))
+                .await
+                .assert_value();
+            cancelled.notify_one();
+            finish.notified().await;
+            bridge.finish(Err(NodeRunnerError::Cancelled));
+        });
+        Ok(handle)
+    }
+
+    async fn close_run(&self, _run_id: &RunId) {
+        self.close.enter().await;
+    }
+}
+
+struct PausedEndpointStart {
+    runner: Arc<DelayedRunner>,
+    endpoint: Arc<NativeCapsuleNodeEndpoint>,
+    pause: StartReadinessPause,
+    start: tokio::task::JoinHandle<Result<CapsuleExecutionStream, CapsuleConnectionError>>,
+}
+
+impl PausedEndpointStart {
+    async fn begin(run_id: &str) -> Self {
+        let runner = Arc::new(DelayedRunner::default());
+        let pause = StartReadinessPause::default();
+        let endpoint = Arc::new(
+            NativeCapsuleNodeEndpoint::new(runner.clone())
+                .with_start_readiness_pause(pause.clone()),
+        );
+        let start_endpoint = endpoint.clone();
+        let run_id = run_id.to_owned();
+        let start = spawn_at_readiness(
+            async move { start_endpoint.start(request(&run_id, 1)).await },
+            &runner.start,
+            &pause,
+        )
+        .await;
+        Self {
+            runner,
+            endpoint,
+            pause,
+            start,
+        }
+    }
+}
+
+async fn complete_delayed_runner_close(
+    runner: &DelayedRunner,
+    close: &mut tokio::task::JoinHandle<Result<(), CapsuleConnectionError>>,
+) {
+    within_one_second(runner.cancelled.notified()).await;
+    runner.close.open();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut *close)
+            .await
+            .is_err(),
+        "endpoint close returned before reserved execution cleanup"
+    );
+    runner.finish.notify_one();
+    within_one_second(close).await.assert_value().assert_value();
+}
+
+#[tokio::test]
+async fn endpoint_close_waits_for_an_active_start_and_preserves_usage() {
+    let runner = Arc::new(DelayedRunner::default());
+    let endpoint = Arc::new(NativeCapsuleNodeEndpoint::new(runner.clone()));
+    let loss = endpoint.connection_loss();
+
+    let start_endpoint = endpoint.clone();
+    let start =
+        tokio::spawn(async move { start_endpoint.start(request("endpoint-race", 1)).await });
+    runner.start.wait().await;
+    assert!(matches!(
+        endpoint.start(request("endpoint-race", 1)).await,
+        Err(CapsuleConnectionError::Rejected(
+            CapsuleNodeFailure::ExecutionActive
+        ))
+    ));
+    assert_eq!(runner.start_calls.load(Ordering::SeqCst), 1);
+
+    runner.start.open();
+    let mut stream = join_test_task(start).await.assert_value();
+    let close_endpoint = endpoint.clone();
+    let close =
+        tokio::spawn(async move { close_endpoint.close_run(&RunId::new("endpoint-race")).await });
+    runner.close.wait().await;
+    let mut close = close;
+    complete_delayed_runner_close(&runner, &mut close).await;
+
+    let usage = stream.recv().await.assert_value();
+    assert!(matches!(
+        usage,
+        CapsuleNodeEvent::TokenUsage { usage: Some(usage) }
+            if usage.input_tokens.get() == 3 && usage.output_tokens.get() == 2
+    ));
+    assert!(matches!(
+        stream.recv().await.assert_value(),
+        CapsuleNodeEvent::Failed {
+            failure: CapsuleNodeFailure::Cancelled
+        }
+    ));
+    assert!(stream.recv().await.is_none());
+    assert!(matches!(
+        endpoint.start(request("endpoint-race", 2)).await,
+        Err(CapsuleConnectionError::Rejected(
+            CapsuleNodeFailure::RunClosed
+        ))
+    ));
+    assert_eq!(runner.start_calls.load(Ordering::SeqCst), 1);
+    assert!(!*loss.borrow());
+}
+
+#[tokio::test]
+async fn dropping_endpoint_start_does_not_strand_its_reservation() {
+    let runner = Arc::new(DelayedRunner::default());
+    let endpoint = Arc::new(NativeCapsuleNodeEndpoint::new(runner.clone()));
+    let start_endpoint = endpoint.clone();
+    let start =
+        tokio::spawn(async move { start_endpoint.start(request("endpoint-drop", 1)).await });
+    runner.start.wait().await;
+    start.abort();
+    assert!(start.await.assert_error().is_cancelled());
+
+    let close_endpoint = endpoint.clone();
+    let close =
+        tokio::spawn(async move { close_endpoint.close_run(&RunId::new("endpoint-drop")).await });
+    runner.close.wait().await;
+    runner.start.open();
+    let mut close = close;
+    complete_delayed_runner_close(&runner, &mut close).await;
+    assert!(matches!(
+        endpoint.start(request("endpoint-drop", 2)).await,
+        Err(CapsuleConnectionError::Rejected(
+            CapsuleNodeFailure::RunClosed
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn repeated_endpoint_cancellation_is_coalesced_while_cleanup_is_blocked() {
+    let runner = Arc::new(DelayedRunner::default());
+    let endpoint = NativeCapsuleNodeEndpoint::new(runner.clone());
+    let run = request("endpoint-repeated-cancel", 1);
+    let reference = run.invocation.reference.clone();
+    let start_endpoint = endpoint.clone();
+    let start = tokio::spawn(async move { start_endpoint.start(run).await });
+    runner.start.wait().await;
+    runner.start.open();
+    let mut stream = join_test_task(start).await.assert_value();
+
+    for _ in 0..4_096 {
+        endpoint.cancel(&reference).await.assert_value();
+    }
+    within_one_second(runner.cancelled.notified()).await;
+    runner.finish.notify_one();
+
+    assert!(matches!(
+        stream.recv().await,
+        Some(CapsuleNodeEvent::TokenUsage { usage: Some(_) })
+    ));
+    assert!(matches!(
+        stream.recv().await,
+        Some(CapsuleNodeEvent::Failed {
+            failure: CapsuleNodeFailure::Cancelled
+        })
+    ));
+    assert!(stream.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn endpoint_close_rejects_readiness_sent_before_the_caller_can_receive_it() {
+    let PausedEndpointStart {
+        runner,
+        endpoint,
+        pause,
+        start,
+    } = PausedEndpointStart::begin("endpoint-ready-close").await;
+    let loss = endpoint.connection_loss();
+    assert!(!start.is_finished());
+
+    let close_endpoint = endpoint.clone();
+    let close = tokio::spawn(async move {
+        close_endpoint
+            .close_run(&RunId::new("endpoint-ready-close"))
+            .await
+    });
+    runner.close.wait().await;
+    let mut close = close;
+    complete_delayed_runner_close(&runner, &mut close).await;
+    assert!(!start.is_finished());
+
+    pause.release();
+    assert!(matches!(
+        join_test_task(start).await,
+        Err(CapsuleConnectionError::Rejected(
+            CapsuleNodeFailure::RunClosed
+        ))
+    ));
+    assert!(!*loss.borrow());
+}
+
+#[tokio::test]
+async fn aborting_endpoint_start_after_readiness_cancels_and_drains_the_execution() {
+    let PausedEndpointStart {
+        runner,
+        endpoint,
+        pause,
+        start,
+    } = PausedEndpointStart::begin("endpoint-ready-abort").await;
+    let loss = endpoint.connection_loss();
+    start.abort();
+    assert!(start.await.assert_error().is_cancelled());
+    within_one_second(runner.cancelled.notified()).await;
+
+    let close_endpoint = endpoint.clone();
+    let mut close = tokio::spawn(async move {
+        close_endpoint
+            .close_run(&RunId::new("endpoint-ready-abort"))
+            .await
+    });
+    runner.close.wait().await;
+    runner.close.open();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut close)
+            .await
+            .is_err(),
+        "endpoint close returned before abandoned execution cleanup"
+    );
+    runner.finish.notify_one();
+    within_one_second(close).await.assert_value().assert_value();
+    pause.release();
+    assert!(!*loss.borrow());
+}

--- a/zeroshot-rust/src/native_v2_capsule/tests/start_close/remote.rs
+++ b/zeroshot-rust/src/native_v2_capsule/tests/start_close/remote.rs
@@ -1,0 +1,313 @@
+use std::{
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::RunId;
+use tokio::sync::{Notify, mpsc, watch};
+
+use super::{Gate, join_test_task, spawn_at_readiness, token_usage, within_one_second};
+use super::super::request;
+use super::super::super::*;
+use crate::native_v2_contract::ExecutionRef;
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
+
+#[derive(Clone)]
+struct DelayedChannel {
+    start: Gate,
+    close: Gate,
+    fail_close: Arc<std::sync::atomic::AtomicBool>,
+    loss: watch::Sender<bool>,
+    events: Arc<StdMutex<Option<EventSender>>>,
+    cancel_calls: Arc<AtomicUsize>,
+    cancelled: Arc<Notify>,
+    usage_sent: Arc<Notify>,
+    failure_release: Arc<Notify>,
+    start_calls: Arc<AtomicUsize>,
+}
+
+type EventSender = mpsc::Sender<CapsuleNodeEvent>;
+
+impl DelayedChannel {
+    fn new() -> Self {
+        let (loss, _) = watch::channel(false);
+        Self {
+            start: Gate::default(),
+            close: Gate::default(),
+            fail_close: Arc::default(),
+            loss,
+            events: Arc::default(),
+            cancel_calls: Arc::default(),
+            cancelled: Arc::default(),
+            usage_sent: Arc::default(),
+            failure_release: Arc::default(),
+            start_calls: Arc::default(),
+        }
+    }
+
+    fn fail_close(&self) {
+        self.fail_close.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl CapsuleNodeChannel for DelayedChannel {
+    async fn start(
+        &self,
+        _request: NodeRunRequest,
+    ) -> Result<CapsuleExecutionStream, CapsuleConnectionError> {
+        self.start_calls.fetch_add(1, Ordering::SeqCst);
+        self.start.enter().await;
+        let (events, receiver) = mpsc::channel(DURABLE_OUTPUT_CAPACITY);
+        *self.events.lock().assert_value() = Some(events);
+        Ok(CapsuleExecutionStream::from_receiver(receiver))
+    }
+
+    async fn cancel(&self, _reference: &ExecutionRef) -> Result<(), CapsuleConnectionError> {
+        self.cancel_calls.fetch_add(1, Ordering::SeqCst);
+        let events = self.events.lock().assert_value().clone().assert_value();
+        events
+            .send(CapsuleNodeEvent::Failed {
+                failure: CapsuleNodeFailure::Cancelled,
+            })
+            .await
+            .assert_value();
+        self.cancelled.notify_one();
+        Ok(())
+    }
+
+    async fn close_run(&self, _run_id: &RunId) -> Result<(), CapsuleConnectionError> {
+        if self.fail_close.load(Ordering::SeqCst) {
+            return Err(CapsuleConnectionError::Lost);
+        }
+        self.close.enter().await;
+        let events = self.events.lock().assert_value().clone().assert_value();
+        events
+            .send(CapsuleNodeEvent::TokenUsage {
+                usage: Some(token_usage()),
+            })
+            .await
+            .assert_value();
+        self.usage_sent.notify_one();
+        self.failure_release.notified().await;
+        events
+            .send(CapsuleNodeEvent::Failed {
+                failure: CapsuleNodeFailure::Cancelled,
+            })
+            .await
+            .assert_value();
+        Ok(())
+    }
+
+    fn connection_loss(&self) -> watch::Receiver<bool> {
+        self.loss.subscribe()
+    }
+}
+
+struct PausedRemoteStart {
+    channel: Arc<DelayedChannel>,
+    proxy: RemoteCapsuleNodeRunner,
+    pause: StartReadinessPause,
+    start: tokio::task::JoinHandle<Result<NodeHandle, NodeRunnerError>>,
+}
+
+impl PausedRemoteStart {
+    async fn begin(run_id: &str) -> Self {
+        let channel = Arc::new(DelayedChannel::new());
+        let pause = StartReadinessPause::default();
+        let proxy =
+            RemoteCapsuleNodeRunner::new(channel.clone()).with_start_readiness_pause(pause.clone());
+        let start_proxy = proxy.clone();
+        let run_id = run_id.to_owned();
+        let start = spawn_at_readiness(
+            async move { start_proxy.start(request(&run_id, 1)).await },
+            &channel.start,
+            &pause,
+        )
+        .await;
+        Self {
+            channel,
+            proxy,
+            pause,
+            start,
+        }
+    }
+}
+
+async fn begin_remote_close(
+    proxy: &RemoteCapsuleNodeRunner,
+    channel: &DelayedChannel,
+    run_id: &str,
+) -> tokio::task::JoinHandle<()> {
+    let close_proxy = proxy.clone();
+    let run_id = RunId::new(run_id);
+    let close = tokio::spawn(async move {
+        close_proxy.close_run(&run_id).await;
+    });
+    channel.close.wait().await;
+    channel.close.open();
+    within_one_second(channel.usage_sent.notified()).await;
+    close
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn failed_remote_close_always_classifies_active_execution_as_connection_loss() {
+    for execution in 1..=128 {
+        let channel = Arc::new(DelayedChannel::new());
+        channel.start.open();
+        channel.fail_close();
+        let proxy = RemoteCapsuleNodeRunner::new(channel.clone());
+        let mut handle = proxy
+            .start(request("proxy-close-failure", execution))
+            .await
+            .assert_value();
+
+        proxy.close_run(&RunId::new("proxy-close-failure")).await;
+
+        let completion = handle.completion().await;
+        assert_eq!(
+            completion,
+            Err(NodeRunnerError::ConnectionLost),
+            "cancel calls: {}",
+            channel.cancel_calls.load(Ordering::SeqCst)
+        );
+        assert!(*proxy.connection_loss().borrow());
+    }
+}
+
+#[tokio::test]
+async fn remote_proxy_close_waits_for_an_active_start_and_preserves_usage() {
+    let channel = Arc::new(DelayedChannel::new());
+    let proxy = RemoteCapsuleNodeRunner::new(channel.clone());
+    let loss = proxy.connection_loss();
+
+    let start_proxy = proxy.clone();
+    let start = tokio::spawn(async move { start_proxy.start(request("proxy-race", 1)).await });
+    channel.start.wait().await;
+    assert!(matches!(
+        proxy.start(request("proxy-race", 1)).await,
+        Err(NodeRunnerError::ExecutionActive)
+    ));
+    assert_eq!(channel.start_calls.load(Ordering::SeqCst), 1);
+
+    channel.start.open();
+    let mut handle = join_test_task(start).await.assert_value();
+    let mut durable = handle.take_initial_output().assert_value();
+    let close = begin_remote_close(&proxy, &channel, "proxy-race").await;
+    let usage = within_one_second(durable.recv()).await.assert_value();
+    assert!(matches!(
+        usage,
+        DurableNodeEvent::TokenUsage(Some(usage))
+            if usage.input_tokens.get() == 3 && usage.output_tokens.get() == 2
+    ));
+    let mut close = close;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut close)
+            .await
+            .is_err(),
+        "proxy close returned before the reserved start finished cleanup"
+    );
+    channel.failure_release.notify_one();
+    within_one_second(close).await.assert_value();
+    assert_eq!(handle.completion().await, Err(NodeRunnerError::Cancelled));
+    assert!(!*loss.borrow());
+    assert_eq!(channel.cancel_calls.load(Ordering::SeqCst), 0);
+    assert!(matches!(
+        proxy.start(request("proxy-race", 2)).await,
+        Err(NodeRunnerError::RunClosed)
+    ));
+    assert_eq!(channel.start_calls.load(Ordering::SeqCst), 1);
+
+    channel.start.open();
+    let unrelated = proxy.start(request("proxy-unrelated", 2)).await;
+    assert!(unrelated.is_ok());
+    assert_eq!(channel.start_calls.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn dropping_remote_start_does_not_strand_its_reservation() {
+    let channel = Arc::new(DelayedChannel::new());
+    let proxy = RemoteCapsuleNodeRunner::new(channel.clone());
+    let start_proxy = proxy.clone();
+    let start = tokio::spawn(async move { start_proxy.start(request("proxy-drop", 1)).await });
+    channel.start.wait().await;
+    start.abort();
+    assert!(start.await.assert_error().is_cancelled());
+
+    let close_proxy = proxy.clone();
+    let close = tokio::spawn(async move {
+        close_proxy.close_run(&RunId::new("proxy-drop")).await;
+    });
+    channel.close.wait().await;
+    channel.start.open();
+    channel.close.open();
+    within_one_second(channel.usage_sent.notified()).await;
+    let mut close = close;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut close)
+            .await
+            .is_err(),
+        "proxy close returned before abandoned-start cleanup"
+    );
+    channel.failure_release.notify_one();
+    within_one_second(close).await.assert_value();
+    assert!(matches!(
+        proxy.start(request("proxy-drop", 2)).await,
+        Err(NodeRunnerError::RunClosed)
+    ));
+    assert!(!*proxy.connection_loss().borrow());
+}
+
+#[tokio::test]
+async fn remote_close_rejects_readiness_sent_before_the_caller_can_receive_it() {
+    let PausedRemoteStart {
+        channel,
+        proxy,
+        pause,
+        start,
+    } = PausedRemoteStart::begin("proxy-ready-close").await;
+    let loss = proxy.connection_loss();
+    assert!(!start.is_finished());
+
+    let mut close = begin_remote_close(&proxy, &channel, "proxy-ready-close").await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut close)
+            .await
+            .is_err(),
+        "proxy close returned before terminal usage and cleanup completed"
+    );
+    channel.failure_release.notify_one();
+    within_one_second(close).await.assert_value();
+    assert!(!start.is_finished());
+
+    pause.release();
+    assert!(matches!(
+        join_test_task(start).await,
+        Err(NodeRunnerError::RunClosed)
+    ));
+    assert_eq!(channel.cancel_calls.load(Ordering::SeqCst), 0);
+    assert!(!*loss.borrow());
+}
+
+#[tokio::test]
+async fn aborting_remote_start_after_readiness_cancels_and_drains_the_execution() {
+    let PausedRemoteStart {
+        channel,
+        proxy,
+        pause,
+        start,
+    } = PausedRemoteStart::begin("proxy-ready-abort").await;
+    let run_id = RunId::new("proxy-ready-abort");
+    start.abort();
+    assert!(start.await.assert_error().is_cancelled());
+    within_one_second(channel.cancelled.notified()).await;
+    within_one_second(proxy.wait_for_test_run_settled(&run_id)).await;
+
+    pause.release();
+    assert_eq!(channel.cancel_calls.load(Ordering::SeqCst), 1);
+    assert!(!*proxy.connection_loss().borrow());
+}

--- a/zeroshot-rust/src/native_v2_claude.rs
+++ b/zeroshot-rust/src/native_v2_claude.rs
@@ -10,6 +10,8 @@ mod command;
 mod session;
 #[path = "native_v2_claude/transcript.rs"]
 mod transcript;
+#[path = "native_v2_claude/turn_process.rs"]
+mod turn_process;
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -17,24 +19,24 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 
-use crate::execution::process::{HostedProcessPool, LocalProcessRunner, ProcessSessionCommand};
+use crate::execution::process::{HostedProcessPool, ProcessSessionCommand, ProcessStdout};
 use crate::native_v2_capsule::provider_process::{
     ClosedSessionFailure, ProviderProcessRunners, process_scope, redaction_values,
-    validate_process_cleanup, validate_process_output,
+    with_driver_detail,
 };
 use crate::native_v2_contract::{ClaudeProvider, NodeRuntimeBinding};
 use crate::native_v2_runner::{
-    AgentResponse, render_agent_prompt, resolve_agent_response, DriverControl, DriverInvocation,
-    LiveOutput, LiveOutputStream, NodeRunnerError, ProviderSchemaDialect, ResolvedEnvironment,
+    AgentResponse, resolve_agent_response, DriverControl, DriverInvocation, LiveOutput,
+    LiveOutputStream, NodeRunnerError, ProviderSchemaDialect, ResolvedEnvironment,
 };
 use command::{
     ClaudeTurnArguments, claude_arguments, configure_openrouter, extend_declared_environment,
-    reject_provider_controls, workspace_access,
+    prompt, reject_provider_controls, workspace_access,
 };
-use session::ClaudeSession;
-use transcript::{ClaudeAttempt, ClaudeTranscript};
+use session::{ClaudeSession, attempt_session_id, observe_session};
+use transcript::{ClaudeAttempt, ClaudeEmission, ClaudeTranscript};
+use turn_process::ClaudeProcessStart;
 
-const MAX_PROMPT_BYTES: usize = 64 * 1024;
 const MINIMAL_ENVIRONMENT_NAMES: [&str; 6] = ["HOME", "LANG", "LC_ALL", "PATH", "TERM", "TMPDIR"];
 
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
@@ -62,7 +64,7 @@ impl ClaudeProcessEnvironment {
                     name.clone(),
                 ));
             }
-            if value.contains('\0') || name.len().saturating_add(value.len()) > 16 * 1024 {
+            if value.contains('\0') {
                 return Err(ClaudeAdapterConfigError::InvalidEnvironment);
             }
         }
@@ -162,14 +164,6 @@ impl ClaudeAdapter {
         Self::new_local(configuration)
     }
 
-    fn turn_process(
-        &self,
-        invocation: &DriverInvocation,
-    ) -> Result<(LocalProcessRunner, PathBuf), NodeRunnerError> {
-        let scope = process_scope(invocation)?;
-        self.runners.turn_process(&self.runtime_home, scope)
-    }
-
     fn command(
         &self,
         turn: &ClaudeTurn<'_>,
@@ -177,7 +171,9 @@ impl ClaudeAdapter {
     ) -> Result<ProcessSessionCommand, NodeRunnerError> {
         let invocation = turn.invocation;
         let NodeRuntimeBinding::Agent { model, effort, .. } = &invocation.node.binding else {
-            return Err(NodeRunnerError::Driver);
+            return Err(NodeRunnerError::DriverDetail(
+                "Claude command requires an agent runtime binding".to_owned(),
+            ));
         };
         let argv = claude_arguments(
             self.prefix_arguments.clone(),
@@ -191,18 +187,30 @@ impl ClaudeAdapter {
                         .response
                         .provider_schema(ProviderSchemaDialect::Standard),
                 )
-                .map_err(|_| NodeRunnerError::Driver)?,
-                prompt: input.prompt,
+                .map_err(|_| {
+                    NodeRunnerError::DriverDetail(
+                        "Claude response schema could not be serialized".to_owned(),
+                    )
+                })?,
             },
-        )?;
+        )
+        .map_err(|error| {
+            with_driver_detail(error, "Claude command rejected the selected node role")
+        })?;
 
         Ok(ProcessSessionCommand {
             program: self.executable.clone(),
             argv,
-            environment: self.process_environment(&invocation.environment, input.runtime_home)?,
+            environment: self
+                .process_environment(&invocation.environment, input.runtime_home)
+                .map_err(|error| {
+                    with_driver_detail(error, "Claude provider environment is invalid")
+                })?,
             workspace: crate::execution::driver::WorkspaceCapability {
                 current_dir: self.workspace.clone(),
-                mode: workspace_access(invocation.role)?,
+                mode: workspace_access(invocation.role).map_err(|error| {
+                    with_driver_detail(error, "Claude workspace policy rejected the node role")
+                })?,
             },
             deadline: turn.deadline,
         })
@@ -217,7 +225,11 @@ impl ClaudeAdapter {
         let runtime_home = runtime_home
             .to_str()
             .filter(|value| !value.is_empty())
-            .ok_or(NodeRunnerError::Driver)?;
+            .ok_or_else(|| {
+                NodeRunnerError::DriverDetail(
+                    "Claude runtime home is not a valid non-empty platform path".to_owned(),
+                )
+            })?;
         let provider_home = self
             .local_user_home
             .as_deref()
@@ -228,10 +240,25 @@ impl ClaudeAdapter {
         // Hosted targets may expose a read-only or root-owned shared `/tmp`. Keep Claude's
         // sockets and temporary files inside the same provider-private session home instead.
         environment.insert("TMPDIR".to_owned(), runtime_home.to_owned());
-        extend_declared_environment(&mut environment, resolved)?;
-        reject_provider_controls(&environment)?;
+        extend_declared_environment(&mut environment, resolved).map_err(|error| {
+            with_driver_detail(
+                error,
+                "Claude declared environment conflicts with reserved process configuration",
+            )
+        })?;
+        reject_provider_controls(&environment).map_err(|error| {
+            with_driver_detail(
+                error,
+                "Claude declared environment contains a provider-owned control variable",
+            )
+        })?;
         if self.provider == ClaudeProvider::OpenRouter {
-            configure_openrouter(&mut environment)?;
+            configure_openrouter(&mut environment).map_err(|error| {
+                with_driver_detail(
+                    error,
+                    "Claude OpenRouter credentials are missing or conflict with Anthropic credentials",
+                )
+            })?;
         }
         Ok(environment)
     }
@@ -250,8 +277,13 @@ impl ClaudeAdapter {
         let attempt = self
             .execute_turn(turn, resume_id.as_deref(), prompt)
             .await?;
-        observe_session(resume_id, attempt_session_id(&attempt))?;
-        resolve_claude_attempt(turn, resume_id, attempt)
+        if let Err(diagnostic) = observe_session(resume_id, attempt_session_id(&attempt)) {
+            return Ok(ClaudeTurnAdvance::ProviderFailure {
+                retryable: false,
+                diagnostic: diagnostic.to_owned(),
+            });
+        }
+        resolve_claude_attempt(turn, resume_id, attempt).await
     }
 
     async fn execute_turn(
@@ -260,62 +292,41 @@ impl ClaudeAdapter {
         resume_id: Option<&str>,
         prompt: String,
     ) -> Result<ClaudeAttempt, NodeRunnerError> {
-        let mut process = self.open_turn_process(turn, resume_id, prompt).await?;
-        let mut transcript = ClaudeTranscript::new(redaction_values(
+        let mut process = match self.open_turn_process(turn, resume_id).await? {
+            ClaudeProcessStart::Ready(process) => process,
+            ClaudeProcessStart::Failed(attempt) => return Ok(attempt),
+        };
+        let transcript = ClaudeTranscript::new(redaction_values(
             turn.invocation.environment.iter().map(|(_, value)| value),
         ));
-        let collected = collect_transcript(&mut process, &mut transcript, turn.control).await;
-        let process_output = if collected.is_ok() {
-            process.wait().await
-        } else {
-            process.release().await
-        };
-        turn.control.record_token_usage(transcript.token_usage())?;
-        let process_output = process_output.map_err(|_| NodeRunnerError::Driver)?;
-        validate_process_cleanup(&process_output, turn.control)?;
-        collected?;
-        let attempt = transcript.finish()?;
-        if matches!(attempt, ClaudeAttempt::Complete(_)) {
-            validate_process_output(&process_output, turn.control)?;
-        }
-        Ok(attempt)
+        turn_process::finish_process(&mut process, prompt.as_bytes(), transcript, turn.control)
+            .await
     }
 
     async fn open_turn_process(
         &self,
         turn: &ClaudeTurn<'_>,
         resume_id: Option<&str>,
-        prompt: String,
-    ) -> Result<crate::execution::process::ProcessSession, NodeRunnerError> {
-        let (runner, runtime_home) = self.turn_process(turn.invocation)?;
+    ) -> Result<ClaudeProcessStart, NodeRunnerError> {
+        let scope = process_scope(turn.invocation).map_err(|error| {
+            with_driver_detail(error, "Claude process scope requires an agent node role")
+        })?;
+        let (runner, runtime_home) = match self.runners.turn_process(&self.runtime_home, scope) {
+            Ok(process) => process,
+            Err(error) => return turn_process::failed_before_start(error, turn.control),
+        };
         let command = self.command(
             turn,
             ClaudeCommandInput {
                 resume_id,
                 runtime_home: &runtime_home,
-                prompt,
             },
         )?;
-        let mut process = runner
-            .open(command, turn.control.cancellation())
-            .await
-            .map_err(|_| NodeRunnerError::Driver)?;
-        if process.close_stdin().await.is_err() {
-            let _ = process.release().await;
-            return Err(NodeRunnerError::Driver);
-        }
-        Ok(process)
+        turn_process::open(runner, command, turn.control).await
     }
 }
 
-fn attempt_session_id(attempt: &ClaudeAttempt) -> Option<&str> {
-    match attempt {
-        ClaudeAttempt::Complete(result) => result.session_id.as_deref(),
-        ClaudeAttempt::Failed(failure) => failure.session_id.as_deref(),
-    }
-}
-
-fn resolve_claude_attempt(
+async fn resolve_claude_attempt(
     turn: &ClaudeTurn<'_>,
     resume_id: &Option<String>,
     attempt: ClaudeAttempt,
@@ -332,12 +343,19 @@ fn resolve_claude_attempt(
     let response = resolve_agent_response(&turn.invocation.response, &result.message)?;
     if matches!(response, AgentResponse::Correction(_)) {
         if resume_id.is_none() {
-            return Err(NodeRunnerError::Driver);
+            return Ok(ClaudeTurnAdvance::ProviderFailure {
+                retryable: false,
+                diagnostic:
+                    "Claude output did not provide a session identifier required for correction"
+                        .to_owned(),
+            });
         }
-        turn.control.emit(LiveOutput::new(
-            LiveOutputStream::System,
-            "Claude final output rejected; requesting correction",
-        )?)?;
+        turn.control
+            .emit(LiveOutput::new(
+                LiveOutputStream::System,
+                "Claude final output rejected; requesting correction",
+            )?)
+            .await?;
     }
     Ok(ClaudeTurnAdvance::Response(response))
 }
@@ -357,47 +375,37 @@ enum ClaudeTurnAdvance {
 struct ClaudeCommandInput<'a> {
     resume_id: Option<&'a str>,
     runtime_home: &'a Path,
-    prompt: String,
 }
 
 async fn collect_transcript(
-    process: &mut crate::execution::process::ProcessSession,
+    mut stdout: ProcessStdout,
     transcript: &mut ClaudeTranscript,
     control: &DriverControl,
 ) -> Result<(), NodeRunnerError> {
-    while let Some(chunk) = process.recv_stdout().await {
-        transcript.push(chunk.as_slice(), control)?;
-    }
-    transcript.finish_stream()
-}
-
-fn observe_session(
-    retained: &mut Option<String>,
-    observed: Option<&str>,
-) -> Result<(), NodeRunnerError> {
-    let Some(observed) = observed else {
-        return Ok(());
-    };
-    match retained.as_deref() {
-        Some(existing) if existing != observed => Err(NodeRunnerError::Driver),
-        Some(_) => Ok(()),
-        None => {
-            *retained = Some(observed.to_owned());
-            Ok(())
+    let mut delivery_error = None;
+    while let Some(chunk) = stdout.recv().await {
+        let emissions = transcript.push(chunk.as_slice());
+        if delivery_error.is_none() {
+            delivery_error = emit_claude(control, emissions).await.err();
         }
     }
+    let emissions = transcript.finish_stream();
+    if delivery_error.is_none() {
+        delivery_error = emit_claude(control, emissions).await.err();
+    }
+    delivery_error.map_or(Ok(()), Err)
 }
 
-fn prompt(invocation: &DriverInvocation) -> Result<String, NodeRunnerError> {
-    let value = render_agent_prompt(
-        invocation.agent_instructions()?,
-        &invocation.node.input,
-        &invocation.response,
-    )?;
-    if value.len() > MAX_PROMPT_BYTES || value.contains('\0') {
-        return Err(NodeRunnerError::Driver);
+async fn emit_claude(
+    control: &DriverControl,
+    emissions: Vec<ClaudeEmission>,
+) -> Result<(), NodeRunnerError> {
+    for emission in emissions {
+        control
+            .emit(LiveOutput::new(emission.stream, emission.text)?)
+            .await?;
     }
-    Ok(value)
+    Ok(())
 }
 
 #[cfg(test)]

--- a/zeroshot-rust/src/native_v2_claude/command.rs
+++ b/zeroshot-rust/src/native_v2_claude/command.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeMap;
 
 use crate::execution::WorkspaceAccessMode;
-use crate::native_v2_capsule::provider_process::effort_token;
-use crate::native_v2_runner::{NodeRole, NodeRunnerError, ResolvedEnvironment};
+use crate::native_v2_capsule::provider_process::{effort_token, with_driver_detail};
+use crate::native_v2_runner::{
+    render_agent_prompt, DriverInvocation, NodeRole, NodeRunnerError, ResolvedEnvironment,
+};
 use crate::worker_catalog::ReasoningEffort;
 
 pub(super) const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api";
@@ -17,7 +19,6 @@ pub(super) struct ClaudeTurnArguments<'a> {
     pub(super) role: NodeRole,
     pub(super) resume_id: Option<&'a str>,
     pub(super) json_schema: String,
-    pub(super) prompt: String,
 }
 
 pub(super) fn claude_arguments(
@@ -50,7 +51,6 @@ pub(super) fn claude_arguments(
     if let Some(resume_id) = turn.resume_id {
         argv.extend(["--resume".to_owned(), resume_id.to_owned()]);
     }
-    argv.push(turn.prompt);
     Ok(argv)
 }
 
@@ -113,4 +113,13 @@ pub(super) fn configure_openrouter(
         OPENROUTER_BASE_URL.to_owned(),
     );
     Ok(())
+}
+
+pub(super) fn prompt(invocation: &DriverInvocation) -> Result<String, NodeRunnerError> {
+    render_agent_prompt(
+        invocation.agent_instructions()?,
+        &invocation.node.input,
+        &invocation.response,
+    )
+    .map_err(|error| with_driver_detail(error, "Claude prompt could not be serialized"))
 }

--- a/zeroshot-rust/src/native_v2_claude/session.rs
+++ b/zeroshot-rust/src/native_v2_claude/session.rs
@@ -16,7 +16,10 @@ use crate::native_v2_runner::{
     NodeRunnerError, NodeSession, ResolvedEnvironment, SessionFactory,
 };
 
-use super::{ClaudeAdapter, ClaudeTurn, ClaudeTurnAdvance, observe_session, prompt};
+use super::{ClaudeAdapter, ClaudeAttempt, ClaudeTurn, ClaudeTurnAdvance, prompt};
+
+const MISSING_REUSABLE_SESSION: &str =
+    "Claude output did not provide a session identifier for reusable session";
 
 pub(super) struct ClaudeSession {
     pub(super) core: ProviderSessionCore,
@@ -92,16 +95,25 @@ impl ClaudeAdapter {
             )
             .await
         {
-            Ok(ClaudeTurnAdvance::Response(response)) => state.accept_response(control, response),
+            Ok(ClaudeTurnAdvance::Response(response)) => {
+                if requires_session(&turn.invocation.node) && state.resume_id.is_none() {
+                    state
+                        .retry_provider_failure(turn, false, MISSING_REUSABLE_SESSION)
+                        .await?;
+                }
+                state.accept_response(control, response).await
+            }
             Ok(ClaudeTurnAdvance::ProviderFailure {
                 retryable,
                 diagnostic,
             }) => {
-                state.retry_provider_failure(turn, retryable, &diagnostic)?;
+                state
+                    .retry_provider_failure(turn, retryable, &diagnostic)
+                    .await?;
                 Ok(None)
             }
             Err(error) => {
-                state.emit_terminal_error(control, &error)?;
+                state.emit_terminal_error(control, &error).await?;
                 Err(error)
             }
         }
@@ -128,39 +140,42 @@ impl ClaudeRunState {
         })
     }
 
-    fn accept_response(
+    async fn accept_response(
         &mut self,
         control: &DriverControl,
         response: AgentResponse,
     ) -> Result<Option<WorkerOutcome>, NodeRunnerError> {
-        self.response.accept("Claude", control, response)
+        self.response.accept("Claude", control, response).await
     }
 
-    fn retry_provider_failure(
+    async fn retry_provider_failure(
         &mut self,
         turn: &ClaudeTurn<'_>,
         retryable: bool,
         detail: &str,
     ) -> Result<(), NodeRunnerError> {
-        let prompt = self.retry.after_failure(
-            turn.control,
-            ProviderFailure {
-                detail: Some(detail),
-                retryable,
-                has_session: self.resume_id.is_some(),
-                deadline: turn.deadline,
-            },
-        )?;
+        let prompt = self
+            .retry
+            .after_failure(
+                turn.control,
+                ProviderFailure {
+                    detail: Some(detail),
+                    retryable,
+                    has_session: self.resume_id.is_some(),
+                    deadline: turn.deadline,
+                },
+            )
+            .await?;
         self.response.replace_prompt(prompt);
         Ok(())
     }
 
-    fn emit_terminal_error(
+    async fn emit_terminal_error(
         &self,
         control: &DriverControl,
         error: &NodeRunnerError,
     ) -> Result<(), NodeRunnerError> {
-        self.retry.report_terminal(control, error)
+        self.retry.report_terminal(control, error).await
     }
 }
 
@@ -169,16 +184,46 @@ async fn retain_session(
     session: &ClaudeSession,
     observed: Option<&str>,
 ) -> Result<(), NodeRunnerError> {
-    if !matches!(
+    if !requires_session(invocation) {
+        return Ok(());
+    }
+    let observed = observed.ok_or(NodeRunnerError::Driver)?;
+    let mut retained = session.resume_id.lock().await;
+    observe_session(&mut retained, Some(observed)).map_err(|_| NodeRunnerError::Driver)
+}
+
+fn requires_session(invocation: &NodeInvocation) -> bool {
+    matches!(
         invocation.binding,
         NodeRuntimeBinding::Agent {
             session_scope: SessionScope::NodeInstance,
             ..
         }
-    ) {
-        return Ok(());
+    )
+}
+
+pub(super) fn attempt_session_id(attempt: &ClaudeAttempt) -> Option<&str> {
+    match attempt {
+        ClaudeAttempt::Complete(result) => result.session_id.as_deref(),
+        ClaudeAttempt::Failed(failure) => failure.session_id.as_deref(),
     }
-    let observed = observed.ok_or(NodeRunnerError::Driver)?;
-    let mut retained = session.resume_id.lock().await;
-    observe_session(&mut retained, Some(observed))
+}
+
+pub(super) fn observe_session(
+    retained: &mut Option<String>,
+    observed: Option<&str>,
+) -> Result<(), &'static str> {
+    let Some(observed) = observed else {
+        return Ok(());
+    };
+    match retained.as_deref() {
+        Some(existing) if existing != observed => {
+            Err("Claude output changed session identifier across turns")
+        }
+        Some(_) => Ok(()),
+        None => {
+            *retained = Some(observed.to_owned());
+            Ok(())
+        }
+    }
 }

--- a/zeroshot-rust/src/native_v2_claude/tests.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests.rs
@@ -1,9 +1,15 @@
 #![cfg(unix)]
 
+#[path = "tests/backpressure.rs"]
+mod backpressure;
+#[path = "tests/command.rs"]
+mod command;
 #[path = "tests/correction.rs"]
 mod correction;
 #[path = "tests/environment.rs"]
 mod environment;
+#[path = "tests/limits.rs"]
+mod limits;
 #[path = "tests/local_identity.rs"]
 mod local_identity;
 
@@ -26,7 +32,7 @@ use crate::native_v2_candidate::test_support::{
 };
 use crate::native_v2_contract::{
     ClaudeProvider, DeclaredConnections, DeclaredEnvironment, NodeRuntimeBinding, RunSubmission,
-    RuntimePlan,
+    RuntimePlan, TokenUsageDelta,
 };
 use crate::native_v2_runner::{
     AttachReceiveError, LiveOutputStream, NativeNodeRunner, NodeRunRequest, NodeRunner,
@@ -84,6 +90,51 @@ async fn runner(
     binding: NodeRuntimeBinding,
     verifier: bool,
 ) -> NativeNodeRunner {
+    runner_with_command(
+        workspace,
+        TestRunnerConfig {
+            provider,
+            binding,
+            verifier,
+            command: TestProviderCommand {
+                executable: "/bin/sh".to_owned(),
+                prefix_arguments: vec![
+                    workspace
+                        .path()
+                        .join("fake-claude.sh")
+                        .to_string_lossy()
+                        .into_owned(),
+                ],
+                base_environment: BTreeMap::new(),
+            },
+        },
+    )
+    .await
+}
+
+struct TestProviderCommand {
+    executable: String,
+    prefix_arguments: Vec<String>,
+    base_environment: BTreeMap<String, String>,
+}
+
+struct TestRunnerConfig {
+    provider: ClaudeProvider,
+    binding: NodeRuntimeBinding,
+    verifier: bool,
+    command: TestProviderCommand,
+}
+
+async fn runner_with_command(
+    workspace: &TestDirectory,
+    configuration: TestRunnerConfig,
+) -> NativeNodeRunner {
+    let TestRunnerConfig {
+        provider,
+        binding,
+        verifier,
+        command,
+    } = configuration;
     let runtime = RuntimePlan::Claude {
         provider,
         size: RunSize::Medium,
@@ -103,25 +154,20 @@ async fn runner(
         submission_key: IdempotencyKey::new("claude-test").assert_value(),
     })
     .await;
-    let base_environment = ClaudeProcessEnvironment::new(BTreeMap::from([
+    let mut base_environment = BTreeMap::from([
         (
             "HOME".to_owned(),
             workspace.path().to_string_lossy().into_owned(),
         ),
         ("PATH".to_owned(), "/usr/bin:/bin".to_owned()),
-    ]))
-    .assert_value();
+    ]);
+    base_environment.extend(command.base_environment);
+    let base_environment = ClaudeProcessEnvironment::new(base_environment).assert_value();
     let adapter = Arc::new(
         ClaudeAdapter::new_for_test(ClaudeAdapterConfig {
             provider,
-            executable: "/bin/sh".to_owned(),
-            prefix_arguments: vec![
-                workspace
-                    .path()
-                    .join("fake-claude.sh")
-                    .to_string_lossy()
-                    .into_owned(),
-            ],
+            executable: command.executable,
+            prefix_arguments: command.prefix_arguments,
             workspace: workspace.path().to_owned(),
             runtime_home: workspace.path().to_owned(),
             local_user_home: None,
@@ -153,20 +199,85 @@ fn request(binding: NodeRuntimeBinding, execution: u64, values: &[(&str, &str)])
     .into_request()
 }
 
+async fn anthropic_runner(
+    workspace: &TestDirectory,
+    model: &str,
+    effort: Option<ReasoningEffort>,
+    scope: SessionScope,
+) -> (NativeNodeRunner, NodeRuntimeBinding) {
+    let binding = agent_binding(model, effort, scope, &[ANTHROPIC_KEY]);
+    let runtime = runner(workspace, ClaudeProvider::Anthropic, binding.clone(), false).await;
+    (runtime, binding)
+}
+
+async fn start_anthropic(
+    workspace: &TestDirectory,
+    model: &str,
+    effort: Option<ReasoningEffort>,
+) -> crate::native_v2_runner::NodeHandle {
+    let (runtime, binding) =
+        anthropic_runner(workspace, model, effort, SessionScope::Execution).await;
+    runtime
+        .start(request(binding, 1, &[(ANTHROPIC_KEY, "anthropic-fake")]))
+        .await
+        .assert_value()
+}
+
+fn assert_token_usage(usage: Option<TokenUsageDelta>, expected: [u64; 4]) {
+    let usage = usage.assert_value();
+    assert_eq!(usage.input_tokens.get(), expected[0]);
+    assert_eq!(usage.output_tokens.get(), expected[1]);
+    assert_eq!(
+        usage.cache_read_input_tokens.assert_value().get(),
+        expected[2]
+    );
+    assert_eq!(
+        usage.cache_creation_input_tokens.assert_value().get(),
+        expected[3]
+    );
+}
+
+async fn cancel_and_assert_reaped(
+    mut handle: crate::native_v2_runner::NodeHandle,
+    workspace: &TestDirectory,
+    child_pid: u32,
+) {
+    handle.cancel();
+    assert_eq!(handle.completion().await, Err(NodeRunnerError::Cancelled));
+    let process = format!("/proc/{child_pid}");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while Path::new(&process).exists() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .assert_value_with("provider child remained alive after cancellation");
+    assert!(!workspace.child("survivor.txt").exists());
+}
+
 async fn complete_two_turns(runner: &NativeNodeRunner, binding: &NodeRuntimeBinding) {
     for execution in [1, 2] {
-        runner
-            .start(request(
-                binding.clone(),
-                execution,
-                &[(ANTHROPIC_KEY, "anthropic-fake")],
-            ))
-            .await
-            .assert_value()
-            .completion()
-            .await
-            .assert_value();
+        complete_turn(runner, binding, execution).await;
     }
+}
+
+async fn complete_turn(
+    runner: &NativeNodeRunner,
+    binding: &NodeRuntimeBinding,
+    execution: u64,
+) -> WorkerOutcome {
+    runner
+        .start(request(
+            binding.clone(),
+            execution,
+            &[(ANTHROPIC_KEY, "anthropic-fake")],
+        ))
+        .await
+        .assert_value()
+        .completion()
+        .await
+        .assert_value()
+        .outcome
 }
 
 async fn two_turn_workspace(
@@ -196,14 +307,15 @@ fn assert_resumed_session(arguments: &str) {
 
 const SUCCESS_SCRIPT: &str = r#"
 set -eu
-target=initial.args
+target=initial
 previous=
 for argument in "$@"; do
-  if [ "$previous" = "--resume" ]; then target=resumed.args; fi
+  if [ "$previous" = "--resume" ]; then target=resumed; fi
   previous=$argument
 done
-: > "$target"
-for argument in "$@"; do printf '%s\n' "$argument" >> "$target"; done
+: > "$target.args"
+for argument in "$@"; do printf '%s\n' "$argument" >> "$target.args"; done
+cat > "$target.prompt"
 printf '%s\n' "${ANTHROPIC_API_KEY-unset}" > anthropic-key.txt
 printf '%s\n' "${ANTHROPIC_AUTH_TOKEN-unset}" > anthropic-token.txt
 printf '%s\n' "${ANTHROPIC_BASE_URL-unset}" > anthropic-base-url.txt
@@ -214,7 +326,7 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-1"}'
 printf '%s%s\n' \
   '{"type":"stream_event","event":{"type":"content_block_delta",' \
   '"delta":{"type":"text_delta","text":"visible sentinel-secret"}}}'
-if [ "${CORRECT_OUTPUT-false}" = true ] && [ "$target" = initial.args ]; then
+if [ "${CORRECT_OUTPUT-false}" = true ] && [ "$target" = initial ]; then
   result=done
 else
   result='{\"response\":\"done\"}'
@@ -225,87 +337,6 @@ printf '%s%s%s%s\n' \
   '","session_id":"session-1","usage":{"input_tokens":11,"output_tokens":4,' \
   '"cache_read_input_tokens":6,"cache_creation_input_tokens":2}}'
 "#;
-
-#[tokio::test]
-async fn scripted_anthropic_and_openrouter_commands_are_exact_and_ambient_free() {
-    for provider in [ClaudeProvider::Anthropic, ClaudeProvider::OpenRouter] {
-        let workspace = TestDirectory::new("claude-command");
-        workspace.write("fake-claude.sh", SUCCESS_SCRIPT);
-        let (provider_name, provider_value) = match provider {
-            ClaudeProvider::Anthropic => (ANTHROPIC_KEY, "anthropic-fake"),
-            ClaudeProvider::OpenRouter => (OPENROUTER_KEY, "openrouter-fake"),
-        };
-        let model = match provider {
-            ClaudeProvider::Anthropic => "claude-sonnet-5",
-            ClaudeProvider::OpenRouter => "anthropic/provider-owned-model",
-        };
-        let binding = agent_binding(
-            model,
-            Some(ReasoningEffort::Max),
-            SessionScope::Execution,
-            &[provider_name, "TEST_SECRET"],
-        );
-        let runner = runner(&workspace, provider, binding.clone(), false).await;
-        let mut handle = runner
-            .start(request(
-                binding,
-                1,
-                &[
-                    (provider_name, provider_value),
-                    ("TEST_SECRET", "sentinel-secret"),
-                ],
-            ))
-            .await
-            .assert_value();
-        let mut attach = handle.take_initial_output().assert_value();
-        let (live, completion) = tokio::join!(attach.recv_output(), handle.completion());
-        assert_eq!(live.assert_value().text, "visible [REDACTED]");
-        assert_eq!(
-            completion.assert_value().outcome,
-            WorkerOutcome::Verified {
-                output: json!("done"),
-                artifacts: Vec::new(),
-            }
-        );
-        let usage = attach.recv_usage().await.assert_value().assert_value();
-        assert_eq!(
-            [
-                usage.input_tokens.get(),
-                usage.output_tokens.get(),
-                usage.cache_read_input_tokens.assert_value().get(),
-                usage.cache_creation_input_tokens.assert_value().get(),
-            ],
-            [11, 4, 6, 2]
-        );
-        assert_eq!(attach.recv().await, Err(AttachReceiveError::Closed));
-        let arguments = workspace.read("initial.args");
-        let expected_prefix = format!(
-            concat!(
-                "--print\n--input-format\ntext\n--output-format\nstream-json\n",
-                "--verbose\n--include-partial-messages\n--model\n{}\n--json-schema\n",
-            ),
-            model
-        );
-        assert!(arguments.starts_with(&expected_prefix));
-        let schema = arguments
-            .lines()
-            .skip_while(|line| *line != "--json-schema")
-            .nth(1)
-            .and_then(|line| serde_json::from_str::<Value>(line).ok())
-            .assert_value();
-        assert_eq!(
-            schema.pointer("/properties/response").assert_value(),
-            &json!({"type":"string"})
-        );
-        assert!(arguments.contains("--effort\nmax\n--dangerously-skip-permissions\n"));
-        assert!(!arguments.contains("--setting-sources"));
-        assert!(arguments.contains("Authored instructions:\nExercise the Claude adapter."));
-        assert!(arguments.contains("Input JSON:\n\"perform the node task\""));
-        assert!(arguments.contains("Runtime-owned response contract:\n{\"kind\":\"worker\""));
-        assert_eq!(workspace.read("ambient.txt").trim(), "unset");
-        assert_provider_environment(&workspace, provider, provider_value);
-    }
-}
 
 fn assert_provider_environment(
     workspace: &TestDirectory,
@@ -393,6 +424,7 @@ async fn verifier_result_is_normalized_to_the_closed_worker_outcome() {
         "fake-claude.sh",
         r#"
 set -eu
+cat > verifier.prompt
 printf '%s\n' "$@" > verifier.args
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"verifier-session"}'
 printf '%s%s%s%s\n' \
@@ -433,7 +465,11 @@ printf '%s%s%s%s\n' \
     assert!(!arguments.contains("--tools"));
     assert!(!arguments.contains("--setting-sources"));
     assert!(!arguments.contains("--dangerously-skip-permissions"));
-    assert!(arguments.contains("\"signals\":{\"verdict\":[\"accepted\",\"rejected\"]}"));
+    assert!(
+        workspace
+            .read("verifier.prompt")
+            .contains("\"signals\":{\"verdict\":[\"accepted\",\"rejected\"]}")
+    );
 }
 
 #[tokio::test]
@@ -443,6 +479,7 @@ async fn cancellation_reaps_the_script_and_its_child_before_completion() {
         "fake-claude.sh",
         r#"
 set -eu
+cat >/dev/null
 (sleep 30; printf survived > survivor.txt) &
 printf '%s' "$!" > child.pid
 printf '%s%s\n' \
@@ -451,30 +488,11 @@ printf '%s%s\n' \
 wait
 "#,
     );
-    let binding = agent_binding(
-        "claude-haiku-4-5",
-        None,
-        SessionScope::Execution,
-        &[ANTHROPIC_KEY],
-    );
-    let runner = runner(
-        &workspace,
-        ClaudeProvider::Anthropic,
-        binding.clone(),
-        false,
-    )
-    .await;
-    let mut handle = runner
-        .start(request(binding, 1, &[(ANTHROPIC_KEY, "anthropic-fake")]))
-        .await
-        .assert_value();
+    let mut handle = start_anthropic(&workspace, "claude-haiku-4-5", None).await;
     let mut attach = handle.take_initial_output().assert_value();
     assert_eq!(attach.recv_output().await.assert_value().text, "started");
     let child_pid: u32 = workspace.read("child.pid").parse().assert_value();
-    handle.cancel();
-    assert_eq!(handle.completion().await, Err(NodeRunnerError::Cancelled));
-    assert!(!Path::new(&format!("/proc/{child_pid}")).exists());
-    assert!(!workspace.child("survivor.txt").exists());
+    cancel_and_assert_reaped(handle, &workspace, child_pid).await;
 }
 
 #[path = "tests/failure.rs"]

--- a/zeroshot-rust/src/native_v2_claude/tests/backpressure.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/backpressure.rs
@@ -1,0 +1,55 @@
+use super::*;
+
+#[tokio::test]
+async fn cancellation_wins_after_durable_output_closes_and_reaps_the_process() {
+    let workspace = TestDirectory::new("claude-closed-durable-cancellation");
+    workspace.write(
+        "fake-claude.sh",
+        r#"
+set -eu
+cat >/dev/null
+(sleep 30; printf survived > survivor.txt) &
+printf '%s' "$!" > child.pid
+while [ ! -e emit-output ]; do sleep 0.01; done
+printf '%s%s\n' \
+  '{"type":"stream_event","event":{"type":"content_block_delta",' \
+  '"delta":{"type":"text_delta","text":"started"}}}'
+: > output-emitted
+wait
+"#,
+    );
+    let mut handle = start_anthropic(&workspace, "claude-haiku-4-5", None).await;
+    drop(handle.take_initial_output().assert_value());
+    let child_pid = wait_for_child_pid(&workspace).await;
+    workspace.write("emit-output", "go");
+    let _ = wait_for_file(&workspace, "output-emitted").await;
+    cancel_and_assert_reaped(handle, &workspace, child_pid).await;
+}
+
+async fn wait_for_child_pid(workspace: &TestDirectory) -> u32 {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if workspace.child("child.pid").exists() {
+                if let Ok(pid) = workspace.read("child.pid").trim().parse() {
+                    return pid;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .assert_value()
+}
+
+async fn wait_for_file(workspace: &TestDirectory, name: &str) -> String {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            if workspace.child(name).exists() {
+                return workspace.read(name);
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .assert_value()
+}

--- a/zeroshot-rust/src/native_v2_claude/tests/command.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/command.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+#[tokio::test]
+async fn scripted_anthropic_and_openrouter_commands_are_exact_and_ambient_free() {
+    for provider in [ClaudeProvider::Anthropic, ClaudeProvider::OpenRouter] {
+        let workspace = TestDirectory::new("claude-command");
+        workspace.write("fake-claude.sh", SUCCESS_SCRIPT);
+        let (provider_name, provider_value) = match provider {
+            ClaudeProvider::Anthropic => (ANTHROPIC_KEY, "anthropic-fake"),
+            ClaudeProvider::OpenRouter => (OPENROUTER_KEY, "openrouter-fake"),
+        };
+        let model = match provider {
+            ClaudeProvider::Anthropic => "claude-sonnet-5",
+            ClaudeProvider::OpenRouter => "anthropic/provider-owned-model",
+        };
+        let binding = agent_binding(
+            model,
+            Some(ReasoningEffort::Max),
+            SessionScope::Execution,
+            &[provider_name, "TEST_SECRET"],
+        );
+        let runner = runner(&workspace, provider, binding.clone(), false).await;
+        let mut handle = runner
+            .start(request(
+                binding,
+                1,
+                &[
+                    (provider_name, provider_value),
+                    ("TEST_SECRET", "sentinel-secret"),
+                ],
+            ))
+            .await
+            .assert_value();
+        let mut attach = handle.take_initial_output().assert_value();
+        let (live, completion) = tokio::join!(attach.recv_output(), handle.completion());
+        assert_eq!(live.assert_value().text, "visible [REDACTED]");
+        assert_eq!(
+            completion.assert_value().outcome,
+            WorkerOutcome::Verified {
+                output: json!("done"),
+                artifacts: Vec::new(),
+            }
+        );
+        assert_token_usage(attach.recv_usage().await.assert_value(), [11, 4, 6, 2]);
+        assert_eq!(attach.recv().await, Err(AttachReceiveError::Closed));
+        let arguments = workspace.read("initial.args");
+        let expected_prefix = format!(
+            concat!(
+                "--print\n--input-format\ntext\n--output-format\nstream-json\n",
+                "--verbose\n--include-partial-messages\n--model\n{}\n--json-schema\n",
+            ),
+            model
+        );
+        assert!(arguments.starts_with(&expected_prefix));
+        let schema = arguments
+            .lines()
+            .skip_while(|line| *line != "--json-schema")
+            .nth(1)
+            .and_then(|line| serde_json::from_str::<Value>(line).ok())
+            .assert_value();
+        assert_eq!(
+            schema.pointer("/properties/response").assert_value(),
+            &json!({"type":"string"})
+        );
+        assert!(arguments.contains("--effort\nmax\n--dangerously-skip-permissions\n"));
+        assert!(!arguments.contains("--setting-sources"));
+        assert!(!arguments.contains("perform the node task"));
+        let prompt = workspace.read("initial.prompt");
+        assert!(prompt.contains("Authored instructions:\nExercise the Claude adapter."));
+        assert!(prompt.contains("Input JSON:\n\"perform the node task\""));
+        assert!(prompt.contains("Runtime-owned response contract:\n{\"kind\":\"worker\""));
+        assert_eq!(workspace.read("ambient.txt").trim(), "unset");
+        assert_provider_environment(&workspace, provider, provider_value);
+    }
+}

--- a/zeroshot-rust/src/native_v2_claude/tests/correction.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/correction.rs
@@ -44,10 +44,10 @@ async fn invalid_output_is_corrected_in_the_same_claude_session() {
         completion.outcome,
         WorkerOutcome::Verified { output, .. } if output == json!("done")
     ));
-    let resumed = workspace.read("resumed.args");
-    assert_resumed_session(&resumed);
-    assert!(resumed.contains("Your previous final response was rejected mechanically"));
-    assert!(resumed.contains("provider response must be exactly an object containing response"));
+    assert_resumed_session(&workspace.read("resumed.args"));
+    let prompt = workspace.read("resumed.prompt");
+    assert!(prompt.contains("Your previous final response was rejected mechanically"));
+    assert!(prompt.contains("provider response must be exactly an object containing response"));
 }
 
 #[tokio::test]
@@ -57,6 +57,7 @@ async fn malformed_output_stops_after_two_claude_correction_turns() {
         &workspace,
         r#"
 set -eu
+cat >/dev/null
 printf '%s\n' "$@" >> attempts.args
 printf '%s\n' '---' >> attempts.args
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"malformed-session"}'

--- a/zeroshot-rust/src/native_v2_claude/tests/environment.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/environment.rs
@@ -6,12 +6,27 @@ use openengine_cluster_testkit::assertions::AssertValue;
 use super::super::ClaudeProcessEnvironment;
 
 #[test]
-fn base_environment_is_explicit_bounded_and_non_secret_by_name() {
+fn base_environment_is_explicit_non_secret_and_allows_large_values() {
     assert!(ClaudeProcessEnvironment::new(BTreeMap::new()).is_ok());
     assert!(
         ClaudeProcessEnvironment::new(BTreeMap::from([(
             "OPENAI_API_KEY".to_owned(),
             "not-allowed".to_owned(),
+        )]))
+        .is_err()
+    );
+    let long_locale = "x".repeat(20 * 1024);
+    let environment =
+        ClaudeProcessEnvironment::new(BTreeMap::from([("LANG".to_owned(), long_locale.clone())]))
+            .assert_value();
+    assert_eq!(
+        environment.clone_values().get("LANG").map(String::as_str),
+        Some(long_locale.as_str())
+    );
+    assert!(
+        ClaudeProcessEnvironment::new(BTreeMap::from([(
+            "LANG".to_owned(),
+            "invalid\0value".to_owned(),
         )]))
         .is_err()
     );

--- a/zeroshot-rust/src/native_v2_claude/tests/failure.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/failure.rs
@@ -1,19 +1,22 @@
 use super::*;
+use crate::native_v2_contract::TokenUsageDelta;
+use crate::native_v2_runner::DurableNodeEvent;
 
-#[tokio::test]
-async fn unsuccessful_result_emits_one_redacted_durable_error_and_fails() {
-    let workspace = TestDirectory::new("claude-error-result");
-    workspace.write(
-        "fake-claude.sh",
-        r#"
-set -eu
-printf '%s\n' '{"type":"system","subtype":"init","session_id":"error-session"}'
-printf '%s%s\n' \
-  '{"type":"result","subtype":"success","is_error":true,' \
-  '"result":"provider rejected sentinel-secret and anthropic-fake","session_id":"error-session"}'
-exit 1
-"#,
-    );
+#[path = "failure/duplex.rs"]
+mod duplex;
+#[path = "failure/retry.rs"]
+mod retry;
+
+type ClaudeHandle = crate::native_v2_runner::NodeHandle;
+type CompletionResult = Result<crate::native_v2_contract::NodeCompletion, NodeRunnerError>;
+type DurableOutput = crate::native_v2_runner::DurableOutput;
+
+async fn scripted_failure(
+    label: &str,
+    script: &str,
+) -> (TestDirectory, ClaudeHandle, DurableOutput) {
+    let workspace = TestDirectory::new(label);
+    workspace.write("fake-claude.sh", script);
     let binding = agent_binding(
         "claude-sonnet-5",
         Some(ReasoningEffort::Max),
@@ -38,181 +41,410 @@ exit 1
         ))
         .await
         .assert_value();
+    let durable = handle.take_initial_output().assert_value();
+    (workspace, handle, durable)
+}
+
+async fn collect_logs(durable: &mut DurableOutput) -> Vec<String> {
+    collect_durable(durable).await.logs
+}
+
+struct CapturedDurable {
+    logs: Vec<String>,
+    usages: Vec<Option<TokenUsageDelta>>,
+}
+
+async fn collect_durable(durable: &mut DurableOutput) -> CapturedDurable {
+    let mut logs = Vec::new();
+    let mut usages = Vec::new();
+    while let Ok(event) = durable.recv().await {
+        match event {
+            DurableNodeEvent::Output { output, .. } => logs.push(output.text),
+            DurableNodeEvent::TokenUsage(usage) => usages.push(usage),
+        }
+    }
+    CapturedDurable { logs, usages }
+}
+
+async fn complete_with_durable(mut handle: ClaudeHandle) -> (CapturedDurable, CompletionResult) {
     let mut durable = handle.take_initial_output().assert_value();
+    tokio::join!(collect_durable(&mut durable), handle.completion())
+}
+
+async fn start_anthropic_input(workspace: &TestDirectory, input: Value) -> ClaudeHandle {
+    let (runtime, binding) = anthropic_runner(
+        workspace,
+        "claude-sonnet-5",
+        Some(ReasoningEffort::Max),
+        SessionScope::Execution,
+    )
+    .await;
+    let mut invocation = request(binding, 1, &[(ANTHROPIC_KEY, "anthropic-fake")]);
+    invocation.invocation.input = input;
+    runtime.start(invocation).await.assert_value()
+}
+
+fn assert_verified_completion(completion: CompletionResult, expected: Value) {
+    assert!(matches!(
+        completion.assert_value().outcome,
+        WorkerOutcome::Verified { output, .. } if output == expected
+    ));
+}
+
+async fn run_failure(
+    runner: &NativeNodeRunner,
+    binding: NodeRuntimeBinding,
+    input: Option<Value>,
+) -> String {
+    run_failure_capture(runner, binding, input).await.0
+}
+
+async fn run_failure_capture(
+    runner: &NativeNodeRunner,
+    binding: NodeRuntimeBinding,
+    input: Option<Value>,
+) -> (String, Vec<Option<TokenUsageDelta>>) {
+    let mut invocation = request(binding, 1, &[(ANTHROPIC_KEY, "anthropic-fake")]);
+    if let Some(input) = input {
+        invocation.invocation.input = input;
+    }
+    let handle = runner.start(invocation).await.assert_value();
+    let (captured, completion) = complete_with_durable(handle).await;
+    let logs = driver_failure_logs(&captured, completion);
+    (logs, captured.usages)
+}
+
+fn driver_failure_logs(captured: &CapturedDurable, completion: CompletionResult) -> String {
+    assert_eq!(completion, Err(NodeRunnerError::Driver));
+    captured.logs.join("\n")
+}
+
+async fn command_failure(label: &str, command: TestProviderCommand) -> String {
+    let workspace = TestDirectory::new(label);
+    let binding = agent_binding(
+        "claude-sonnet-5",
+        Some(ReasoningEffort::Max),
+        SessionScope::Execution,
+        &[ANTHROPIC_KEY],
+    );
+    let runtime = runner_with_command(
+        &workspace,
+        TestRunnerConfig {
+            provider: ClaudeProvider::Anthropic,
+            binding: binding.clone(),
+            verifier: false,
+            command,
+        },
+    )
+    .await;
+    run_failure(&runtime, binding, None).await
+}
+
+async fn anthropic_failure(
+    workspace: &TestDirectory,
+    scope: SessionScope,
+    input: Option<Value>,
+) -> String {
+    let (runtime, binding) = anthropic_runner(
+        workspace,
+        "claude-sonnet-5",
+        Some(ReasoningEffort::Max),
+        scope,
+    )
+    .await;
+    run_failure(&runtime, binding, input).await
+}
+
+async fn anthropic_failure_capture(
+    workspace: &TestDirectory,
+    scope: SessionScope,
+    input: Option<Value>,
+) -> (String, Vec<Option<TokenUsageDelta>>) {
+    let (runtime, binding) = anthropic_runner(
+        workspace,
+        "claude-sonnet-5",
+        Some(ReasoningEffort::Max),
+        scope,
+    )
+    .await;
+    run_failure_capture(&runtime, binding, input).await
+}
+
+async fn assert_missing_terminal_failure(
+    label: &str,
+    script: &str,
+    expected_stderr: &str,
+    expected_process_failure: Option<&str>,
+) -> Option<TokenUsageDelta> {
+    let (_workspace, mut handle, mut durable) = scripted_failure(label, script).await;
+    let (mut captured, completion) =
+        tokio::join!(collect_durable(&mut durable), handle.completion());
+
+    let rendered = driver_failure_logs(&captured, completion);
+    assert!(
+        rendered.contains("Claude output ended without a terminal result"),
+        "unexpected diagnostic: {rendered}"
+    );
+    assert!(rendered.contains(expected_stderr));
+    if let Some(expected) = expected_process_failure {
+        assert!(rendered.contains(expected));
+    }
+    assert!(!rendered.contains("execution failed without provider detail"));
+    assert!(!rendered.contains("sentinel-secret"));
+    assert!(!rendered.contains("anthropic-fake"));
+    assert_eq!(captured.usages.len(), 1);
+    captured.usages.pop().assert_value()
+}
+
+#[tokio::test]
+async fn unsuccessful_result_emits_one_redacted_durable_error_and_fails() {
+    let (_workspace, mut handle, mut durable) = scripted_failure(
+        "claude-error-result",
+        r#"
+set -eu
+cat >/dev/null
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"error-session"}'
+printf '%s%s\n' \
+  '{"type":"result","subtype":"success","is_error":true,' \
+  '"result":"provider rejected sentinel-secret and anthropic-fake","session_id":"error-session"}'
+exit 1
+"#,
+    )
+    .await;
 
     let (output, completion) = tokio::join!(durable.recv_output(), handle.completion());
     let output = output.assert_value();
     assert_eq!(output.stream, LiveOutputStream::Error);
     assert_eq!(
         output.text,
-        "Claude provider failure: provider rejected [REDACTED] and [REDACTED]"
+        concat!(
+            "Claude provider failure: provider rejected [REDACTED] and [REDACTED]; ",
+            "provider process exited with status 1"
+        )
     );
     assert_eq!(completion, Err(NodeRunnerError::Driver));
     assert_eq!(durable.recv_output().await, Err(AttachReceiveError::Closed));
 }
 
-const RETRY_SCRIPT: &str = r#"
+#[tokio::test]
+async fn missing_terminal_result_preserves_process_and_stderr_detail() {
+    let usage = assert_missing_terminal_failure(
+        "claude-missing-result-detail",
+        r#"
 set -eu
-if [ -e retry.state ]; then attempt=2; else attempt=1; : > retry.state; fi
-prompt=
-for argument in "$@"; do
-  prompt=$argument
-  printf '%s\n' "$argument" >> "attempt-$attempt.args"
-done
-printf '%s' "$prompt" > "attempt-$attempt.prompt"
-if [ "$attempt" = 1 ]; then
-  if [ "${NO_FIRST_SESSION-false}" != true ]; then
-    printf '%s\n' '{"type":"system","subtype":"init","session_id":"retry-session"}'
-  fi
-  printf '%s%s\n' \
-    '{"type":"system","subtype":"api_retry","attempt":1,"max_retries":3,' \
-    '"error":"overloaded sentinel-secret"}'
-  if [ "${FAIL_WITHOUT_RESULT-false}" = true ]; then exit 1; fi
-  if [ "${NO_FIRST_SESSION-false}" = true ]; then
-    printf '%s%s\n' \
-      '{"type":"result","subtype":"error_during_execution","is_error":true,' \
-      '"result":"provider lost sentinel-secret"}'
-  else
-    printf '%s%s%s\n' \
-      '{"type":"result","subtype":"error_during_execution","is_error":true,' \
-      '"result":"provider lost sentinel-secret",' \
-      '"session_id":"retry-session"}'
-  fi
-  exit 1
-fi
-printf '%s\n' '{"type":"system","subtype":"init","session_id":"retry-session"}'
-if [ "${FAIL_TWICE-false}" = true ]; then
-  printf '%s%s\n' \
-    '{"type":"system","subtype":"api_retry","attempt":2,"max_retries":3,' \
-    '"error":"still overloaded"}'
-  printf '%s%s%s\n' \
-    '{"type":"result","subtype":"error_during_execution","is_error":true,' \
-    '"result":"provider still unavailable",' \
-    '"session_id":"retry-session"}'
-  exit 1
-fi
+cat >/dev/null
 printf '%s%s\n' \
-  '{"type":"result","subtype":"success","is_error":false,' \
-  '"result":"{\"response\":\"done\"}","session_id":"retry-session"}'
-"#;
-
-async fn retry_runner(workspace: &TestDirectory) -> (NativeNodeRunner, NodeRuntimeBinding) {
-    workspace.write("fake-claude.sh", RETRY_SCRIPT);
-    let binding = agent_binding(
-        "claude-sonnet-5",
-        Some(ReasoningEffort::Max),
-        SessionScope::Execution,
-        &[
-            ANTHROPIC_KEY,
-            "FAIL_TWICE",
-            "FAIL_WITHOUT_RESULT",
-            "NO_FIRST_SESSION",
-            "TEST_SECRET",
-        ],
-    );
-    let runtime = runner(workspace, ClaudeProvider::Anthropic, binding.clone(), false).await;
-    (runtime, binding)
-}
-
-fn retry_values(
-    fail_twice: bool,
-    fail_without_result: bool,
-    no_first_session: bool,
-) -> [(&'static str, &'static str); 5] {
-    [
-        (ANTHROPIC_KEY, "anthropic-fake"),
-        ("FAIL_TWICE", if fail_twice { "true" } else { "false" }),
-        (
-            "FAIL_WITHOUT_RESULT",
-            if fail_without_result { "true" } else { "false" },
-        ),
-        (
-            "NO_FIRST_SESSION",
-            if no_first_session { "true" } else { "false" },
-        ),
-        ("TEST_SECRET", "sentinel-secret"),
-    ]
+  '{"type":"stream_event","event":{"type":"content_block_delta",' \
+  '"delta":{"type":"thinking_delta","thinking":"finished work"}}}'
+printf '%s%s%s\n' \
+  '{"type":"assistant","session_id":"usage-session","message":{"content":[],' \
+  '"usage":{"input_tokens":321,"output_tokens":45,' \
+  '"cache_read_input_tokens":89,"cache_creation_input_tokens":13}}}'
+printf '%s\n' 'upstream broke sentinel-secret anthropic-fake' >&2
+exit 17
+"#,
+        "stderr: upstream broke [REDACTED] [REDACTED]",
+        Some("provider process exited with status 17"),
+    )
+    .await;
+    assert_token_usage(usage, [321, 45, 89, 13]);
 }
 
 #[tokio::test]
-async fn api_retry_signal_continues_once_in_the_same_claude_session() {
-    let workspace = TestDirectory::new("claude-provider-retry");
-    let (runner, binding) = retry_runner(&workspace).await;
-    let mut handle = runner
-        .start(request(binding, 1, &retry_values(false, false, false)))
-        .await
-        .assert_value();
-    let mut durable = handle.take_initial_output().assert_value();
-    let (logs, completion) = tokio::join!(
-        async {
-            let mut logs = Vec::new();
-            while let Ok(entry) = durable.recv_output().await {
-                logs.push(entry.text);
-            }
-            logs
+async fn missing_terminal_result_with_successful_exit_preserves_stderr_detail() {
+    let usage = assert_missing_terminal_failure(
+        "claude-missing-result-successful-exit-detail",
+        r#"
+set -eu
+cat >/dev/null
+printf '%s%s\n' \
+  '{"type":"stream_event","event":{"type":"content_block_delta",' \
+  '"delta":{"type":"thinking_delta","thinking":"finished work"}}}'
+printf '%s\n' 'provider warning sentinel-secret anthropic-fake' >&2
+exit 0
+"#,
+        "stderr: provider warning [REDACTED] [REDACTED]",
+        None,
+    )
+    .await;
+    assert!(usage.is_none());
+}
+
+#[tokio::test]
+async fn preterminal_session_conflict_records_authoritative_result_usage() {
+    let workspace = TestDirectory::new("claude-preterminal-session-conflict-usage");
+    workspace.write(
+        "fake-claude.sh",
+        r#"
+set -eu
+cat >/dev/null
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-one"}'
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-two"}'
+printf '%s%s%s\n' \
+  '{"type":"result","subtype":"success","is_error":false,"session_id":"session-one",' \
+  '"structured_output":{"response":"done"},"usage":{"input_tokens":41,"output_tokens":17,' \
+  '"cache_read_input_tokens":11,"cache_creation_input_tokens":7}}'
+"#,
+    );
+
+    let (rendered, usages) =
+        anthropic_failure_capture(&workspace, SessionScope::Execution, None).await;
+    assert!(rendered.contains("Claude output changed session identifier during one turn"));
+    assert!(!rendered.contains("without a terminal result"));
+    assert_eq!(usages.len(), 1);
+    assert_token_usage(usages.first().copied().flatten(), [41, 17, 11, 7]);
+}
+
+#[tokio::test]
+async fn nonexistent_executable_emits_a_specific_nonretryable_launch_failure() {
+    let rendered = command_failure(
+        "claude-missing-executable",
+        TestProviderCommand {
+            executable: "/missing-zeroshot-claude-executable".to_owned(),
+            prefix_arguments: Vec::new(),
+            base_environment: BTreeMap::new(),
         },
-        handle.completion()
+    )
+    .await;
+    assert!(rendered.contains("process launch failed before start"));
+    assert!(rendered.contains("process spawn failed"));
+    assert!(!rendered.contains("execution failed without provider detail"));
+    assert!(!rendered.contains("continuing once"));
+}
+
+#[tokio::test]
+async fn environment_above_the_old_process_bound_reaches_the_provider() {
+    let rendered = command_failure(
+        "claude-process-environment-bound",
+        TestProviderCommand {
+            executable: "/bin/true".to_owned(),
+            prefix_arguments: Vec::new(),
+            base_environment: BTreeMap::from([("LANG".to_owned(), "x".repeat(70 * 1024))]),
+        },
+    )
+    .await;
+    assert!(
+        rendered.contains("process I/O failed after launch")
+            || rendered.contains("Claude output ended without a terminal result"),
+        "unexpected diagnostic: {rendered}"
     );
-
-    assert!(matches!(
-        completion.assert_value().outcome,
-        WorkerOutcome::Verified { output, .. } if output == json!("done")
-    ));
-    assert_eq!(workspace.read("attempt-2.prompt"), "Continue");
-    let rendered = logs.join("\n");
-    assert!(rendered.contains("Claude API retry 1/3: overloaded [REDACTED]"));
-    assert!(rendered.contains("Claude provider failure: provider lost [REDACTED]"));
-    assert!(rendered.contains("Claude provider failed; continuing once"));
-    assert!(!rendered.contains("sentinel-secret"));
-    let resumed = workspace.read("attempt-2.args");
-    assert!(resumed.lines().any(|line| line == "--resume"));
-    assert!(resumed.lines().any(|line| line == "retry-session"));
+    assert!(!rendered.contains("invalid process command"));
+    assert!(!rendered.contains("execution failed without provider detail"));
+    assert!(!rendered.contains("continuing once"));
 }
 
 #[tokio::test]
-async fn claude_without_a_session_retries_the_original_prompt_once() {
-    let workspace = TestDirectory::new("claude-provider-retry-no-session");
-    let (runner, binding) = retry_runner(&workspace).await;
-    let completion = runner
-        .start(request(binding, 1, &retry_values(false, false, true)))
-        .await
-        .assert_value()
-        .completion()
-        .await
-        .assert_value();
-
-    assert!(matches!(completion.outcome, WorkerOutcome::Verified { .. }));
-    assert_eq!(
-        workspace.read("attempt-1.prompt"),
-        workspace.read("attempt-2.prompt")
+async fn early_exit_while_sending_stdin_emits_detail_without_retrying() {
+    let workspace = TestDirectory::new("claude-early-stdin-exit");
+    workspace.write(
+        "fake-claude.sh",
+        "set -eu\nprintf x >> invocations.txt\nexit 23\n",
     );
-    assert!(!workspace.read("attempt-2.args").contains("--resume"));
+    let (rendered, usages) = anthropic_failure_capture(
+        &workspace,
+        SessionScope::Execution,
+        Some(json!("x".repeat(1024 * 1024))),
+    )
+    .await;
+    assert!(rendered.contains("process I/O failed after launch"));
+    assert!(!rendered.contains("execution failed without provider detail"));
+    assert!(!rendered.contains("continuing once"));
+    assert_eq!(workspace.read("invocations.txt"), "x");
+    assert_eq!(usages, [None]);
 }
 
 #[tokio::test]
-async fn retryable_claude_failure_is_retried_only_once() {
-    let workspace = TestDirectory::new("claude-provider-retry-limit");
-    let (runner, binding) = retry_runner(&workspace).await;
-    let mut handle = runner
-        .start(request(binding, 1, &retry_values(true, false, false)))
-        .await
-        .assert_value();
+async fn cancelled_input_failure_records_one_incomplete_usage_event() {
+    let workspace = TestDirectory::new("claude-cancel-input-failure");
+    workspace.write(
+        "fake-claude.sh",
+        "set -eu\nexec 0<&-\nprintf '%s\\n' \"$$\" > input-failure.pid\nsleep 30\n",
+    );
+    let mut handle =
+        start_anthropic_input(&workspace, json!({"task":"x".repeat(8 * 1024 * 1024)})).await;
+    let mut durable = handle.take_initial_output().assert_value();
+    let marker = workspace.child("input-failure.pid");
+    for _ in 0..100 {
+        if marker.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(marker.exists());
 
-    assert_eq!(handle.completion().await, Err(NodeRunnerError::Driver));
-    assert!(workspace.child("attempt-2.prompt").exists());
-    assert!(!workspace.child("attempt-3.prompt").exists());
+    handle.cancel();
+    let (captured, completion) = tokio::join!(collect_durable(&mut durable), handle.completion());
+    assert_eq!(completion, Err(NodeRunnerError::Cancelled));
+    assert_eq!(captured.usages, [None]);
 }
 
 #[tokio::test]
-async fn api_retry_signal_survives_a_missing_terminal_result() {
-    let workspace = TestDirectory::new("claude-provider-retry-truncated");
-    let (runner, binding) = retry_runner(&workspace).await;
-    let mut handle = runner
-        .start(request(binding, 1, &retry_values(false, true, false)))
-        .await
-        .assert_value();
-    let completion = handle.completion().await.assert_value();
+async fn changed_session_across_retry_attempts_emits_a_specific_failure() {
+    let workspace = TestDirectory::new("claude-changed-retry-session");
+    workspace.write(
+        "fake-claude.sh",
+        r#"
+set -eu
+cat >/dev/null
+if [ -e first-attempt ]; then
+  : > second-attempt
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-two"}'
+  printf '%s%s\n' \
+    '{"type":"result","subtype":"success","is_error":false,' \
+    '"result":"{\"response\":\"done\"}","session_id":"session-two"}'
+  exit 0
+fi
+: > first-attempt
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-one"}'
+printf '%s\n' '{"type":"system","subtype":"api_retry","attempt":1,"max_retries":3,"error":"overloaded"}'
+printf '%s%s\n' \
+  '{"type":"result","subtype":"error_during_execution","is_error":true,' \
+  '"result":"retry","session_id":"session-one"}'
+exit 1
+"#,
+    );
+    let rendered = anthropic_failure(&workspace, SessionScope::Execution, None).await;
+    assert!(rendered.contains("Claude output changed session identifier across turns"));
+    assert!(!rendered.contains("execution failed without provider detail"));
+    assert!(workspace.child("second-attempt").exists());
+}
 
-    assert!(matches!(completion.outcome, WorkerOutcome::Verified { .. }));
-    assert_eq!(workspace.read("attempt-2.prompt"), "Continue");
+#[tokio::test]
+async fn correction_requires_a_provider_session_identifier() {
+    let workspace = TestDirectory::new("claude-missing-correction-session");
+    workspace.write(
+        "fake-claude.sh",
+        concat!(
+            "set -eu\ncat >/dev/null\n",
+            "printf '%s%s\\n' \\\n",
+            "  '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,' \\\n",
+            "  '\"result\":\"done\"}'\n",
+        ),
+    );
+    let rendered = anthropic_failure(&workspace, SessionScope::Execution, None).await;
+    assert!(
+        rendered
+            .contains("Claude output did not provide a session identifier required for correction")
+    );
+    assert!(!rendered.contains("execution failed without provider detail"));
+}
+
+#[tokio::test]
+async fn reusable_session_requires_a_provider_session_identifier() {
+    let workspace = TestDirectory::new("claude-missing-reusable-session");
+    workspace.write(
+        "fake-claude.sh",
+        concat!(
+            "set -eu\ncat >/dev/null\n",
+            "printf '%s%s\\n' \\\n",
+            "  '{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,' \\\n",
+            "  '\"result\":\"{\\\"response\\\":\\\"done\\\"}\"}'\n",
+        ),
+    );
+    let rendered = anthropic_failure(&workspace, SessionScope::NodeInstance, None).await;
+    assert!(
+        rendered
+            .contains("Claude output did not provide a session identifier for reusable session")
+    );
+    assert!(!rendered.contains("execution failed without provider detail"));
 }

--- a/zeroshot-rust/src/native_v2_claude/tests/failure/duplex.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/failure/duplex.rs
@@ -1,0 +1,82 @@
+use super::*;
+
+const LARGE_INPUT_BYTES: usize = 9 * 1024 * 1024;
+
+const INPUT_FAILURE_FIRST: &str = r#"
+set -eu
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"duplex-session"}'
+printf '%s%s%s%s\n' \
+  '{"type":"result","subtype":"success","is_error":false,' \
+  '"session_id":"duplex-session","structured_output":{"response":"ignored"},' \
+  '"usage":{"input_tokens":23,"output_tokens":9,' \
+  '"cache_read_input_tokens":17,"cache_creation_input_tokens":5}}'
+exec 0<&-
+/usr/bin/sleep 30
+"#;
+
+const OUTPUT_FAILURE_FIRST: &str = r#"
+set -eu
+if [ ! -e duplex.state ]; then
+  : > duplex.state
+  printf '%s\n' '{"type":"system","subtype":"init","session_id":"duplex-session"}'
+  printf '%s\n' '{"type":"system","subtype":"api_retry","attempt":1,"max_retries":3,"error":"overloaded"}'
+  printf '%s%s%s%s\n' \
+    '{"type":"result","subtype":"success","is_error":false,' \
+    '"session_id":"duplex-session","structured_output":{"response":"ignored"},' \
+    '"usage":{"input_tokens":23,"output_tokens":9,' \
+    '"cache_read_input_tokens":17,"cache_creation_input_tokens":5}}'
+  exec 1>&-
+  /usr/bin/sleep 1
+  exec 0<&-
+  /usr/bin/sleep 30
+fi
+cat > retry.prompt
+for argument in "$@"; do printf '%s\n' "$argument" >> retry.args; done
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"duplex-session"}'
+printf '%s%s\n' \
+  '{"type":"result","subtype":"success","is_error":false,"session_id":"duplex-session",' \
+  '"structured_output":{"response":"done"},"usage":{},"modelUsage":null}'
+"#;
+
+#[tokio::test]
+async fn input_failure_wins_while_the_unfinished_transcript_is_drained() {
+    let workspace = TestDirectory::new("claude-duplex-input-first");
+    workspace.write("fake-claude.sh", INPUT_FAILURE_FIRST);
+    let (logs, usages) = anthropic_failure_capture(
+        &workspace,
+        SessionScope::Execution,
+        Some(json!("x".repeat(LARGE_INPUT_BYTES))),
+    )
+    .await;
+
+    assert!(logs.contains("provider process input failed"));
+    assert_eq!(usages.len(), 1);
+    assert_token_usage(usages.first().copied().flatten(), [23, 9, 17, 5]);
+}
+
+#[tokio::test]
+async fn completed_output_cannot_mask_input_failure_and_retry_metadata() {
+    let workspace = TestDirectory::new("claude-duplex-output-first");
+    workspace.write("fake-claude.sh", OUTPUT_FAILURE_FIRST);
+    let handle = start_anthropic_input(&workspace, json!("x".repeat(LARGE_INPUT_BYTES))).await;
+    let (captured, completion) = complete_with_durable(handle).await;
+
+    assert_verified_completion(completion, json!("done"));
+    assert!(
+        captured
+            .logs
+            .join("\n")
+            .contains("provider process input failed")
+    );
+    assert_eq!(captured.usages.len(), 2);
+    assert_token_usage(captured.usages.first().copied().flatten(), [23, 9, 17, 5]);
+    assert_eq!(captured.usages.get(1).copied().flatten(), None);
+    assert_eq!(workspace.read("retry.prompt"), "Continue");
+    let arguments = workspace.read("retry.args");
+    assert!(arguments.lines().any(|argument| argument == "--resume"));
+    assert!(
+        arguments
+            .lines()
+            .any(|argument| argument == "duplex-session")
+    );
+}

--- a/zeroshot-rust/src/native_v2_claude/tests/failure/retry.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/failure/retry.rs
@@ -1,0 +1,154 @@
+use super::*;
+
+const RETRY_SCRIPT: &str = r#"
+set -eu
+if [ -e retry.state ]; then attempt=2; else attempt=1; : > retry.state; fi
+prompt=$(cat)
+for argument in "$@"; do
+  printf '%s\n' "$argument" >> "attempt-$attempt.args"
+done
+printf '%s' "$prompt" > "attempt-$attempt.prompt"
+if [ "$attempt" = 1 ]; then
+  if [ "${NO_FIRST_SESSION-false}" != true ]; then
+    printf '%s\n' '{"type":"system","subtype":"init","session_id":"retry-session"}'
+  fi
+  printf '%s%s\n' \
+    '{"type":"system","subtype":"api_retry","attempt":1,"max_retries":3,' \
+    '"error":"overloaded sentinel-secret"}'
+  if [ "${FAIL_WITHOUT_RESULT-false}" = true ]; then exit 1; fi
+  if [ "${NO_FIRST_SESSION-false}" = true ]; then
+    printf '%s%s\n' \
+      '{"type":"result","subtype":"error_during_execution","is_error":true,' \
+      '"result":"provider lost sentinel-secret"}'
+  else
+    printf '%s%s%s\n' \
+      '{"type":"result","subtype":"error_during_execution","is_error":true,' \
+      '"result":"provider lost sentinel-secret",' \
+      '"session_id":"retry-session"}'
+  fi
+  exit 1
+fi
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"retry-session"}'
+if [ "${FAIL_TWICE-false}" = true ]; then
+  printf '%s%s\n' \
+    '{"type":"system","subtype":"api_retry","attempt":2,"max_retries":3,' \
+    '"error":"still overloaded"}'
+  printf '%s%s%s\n' \
+    '{"type":"result","subtype":"error_during_execution","is_error":true,' \
+    '"result":"provider still unavailable",' \
+    '"session_id":"retry-session"}'
+  exit 1
+fi
+printf '%s%s\n' \
+  '{"type":"result","subtype":"success","is_error":false,' \
+  '"result":"{\"response\":\"done\"}","session_id":"retry-session"}'
+"#;
+
+async fn retry_runner(workspace: &TestDirectory) -> (NativeNodeRunner, NodeRuntimeBinding) {
+    workspace.write("fake-claude.sh", RETRY_SCRIPT);
+    let binding = agent_binding(
+        "claude-sonnet-5",
+        Some(ReasoningEffort::Max),
+        SessionScope::Execution,
+        &[
+            ANTHROPIC_KEY,
+            "FAIL_TWICE",
+            "FAIL_WITHOUT_RESULT",
+            "NO_FIRST_SESSION",
+            "TEST_SECRET",
+        ],
+    );
+    let runtime = runner(workspace, ClaudeProvider::Anthropic, binding.clone(), false).await;
+    (runtime, binding)
+}
+
+fn retry_values(
+    fail_twice: bool,
+    fail_without_result: bool,
+    no_first_session: bool,
+) -> [(&'static str, &'static str); 5] {
+    [
+        (ANTHROPIC_KEY, "anthropic-fake"),
+        ("FAIL_TWICE", if fail_twice { "true" } else { "false" }),
+        (
+            "FAIL_WITHOUT_RESULT",
+            if fail_without_result { "true" } else { "false" },
+        ),
+        (
+            "NO_FIRST_SESSION",
+            if no_first_session { "true" } else { "false" },
+        ),
+        ("TEST_SECRET", "sentinel-secret"),
+    ]
+}
+
+#[tokio::test]
+async fn api_retry_signal_continues_once_in_the_same_claude_session() {
+    let workspace = TestDirectory::new("claude-provider-retry");
+    let (runner, binding) = retry_runner(&workspace).await;
+    let mut handle = runner
+        .start(request(binding, 1, &retry_values(false, false, false)))
+        .await
+        .assert_value();
+    let mut durable = handle.take_initial_output().assert_value();
+    let (logs, completion) = tokio::join!(collect_logs(&mut durable), handle.completion());
+
+    assert_verified_completion(completion, json!("done"));
+    assert_eq!(workspace.read("attempt-2.prompt"), "Continue");
+    let rendered = logs.join("\n");
+    assert!(rendered.contains("Claude API retry 1/3: overloaded [REDACTED]"));
+    assert!(rendered.contains("Claude provider failure: provider lost [REDACTED]"));
+    assert!(rendered.contains("Claude provider failed; continuing once"));
+    assert!(!rendered.contains("sentinel-secret"));
+    let resumed = workspace.read("attempt-2.args");
+    assert!(resumed.lines().any(|line| line == "--resume"));
+    assert!(resumed.lines().any(|line| line == "retry-session"));
+}
+
+#[tokio::test]
+async fn claude_without_a_session_retries_the_original_prompt_once() {
+    let workspace = TestDirectory::new("claude-provider-retry-no-session");
+    let (runner, binding) = retry_runner(&workspace).await;
+    let completion = runner
+        .start(request(binding, 1, &retry_values(false, false, true)))
+        .await
+        .assert_value()
+        .completion()
+        .await
+        .assert_value();
+
+    assert!(matches!(completion.outcome, WorkerOutcome::Verified { .. }));
+    assert_eq!(
+        workspace.read("attempt-1.prompt"),
+        workspace.read("attempt-2.prompt")
+    );
+    assert!(!workspace.read("attempt-2.args").contains("--resume"));
+}
+
+#[tokio::test]
+async fn retryable_claude_failure_is_retried_only_once() {
+    let workspace = TestDirectory::new("claude-provider-retry-limit");
+    let (runner, binding) = retry_runner(&workspace).await;
+    let mut handle = runner
+        .start(request(binding, 1, &retry_values(true, false, false)))
+        .await
+        .assert_value();
+
+    assert_eq!(handle.completion().await, Err(NodeRunnerError::Driver));
+    assert!(workspace.child("attempt-2.prompt").exists());
+    assert!(!workspace.child("attempt-3.prompt").exists());
+}
+
+#[tokio::test]
+async fn api_retry_signal_survives_a_missing_terminal_result() {
+    let workspace = TestDirectory::new("claude-provider-retry-truncated");
+    let (runner, binding) = retry_runner(&workspace).await;
+    let mut handle = runner
+        .start(request(binding, 1, &retry_values(false, true, false)))
+        .await
+        .assert_value();
+    let completion = handle.completion().await.assert_value();
+
+    assert!(matches!(completion.outcome, WorkerOutcome::Verified { .. }));
+    assert_eq!(workspace.read("attempt-2.prompt"), "Continue");
+}

--- a/zeroshot-rust/src/native_v2_claude/tests/limits.rs
+++ b/zeroshot-rust/src/native_v2_claude/tests/limits.rs
@@ -1,0 +1,105 @@
+use super::*;
+
+const LARGE_DUPLEX_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+: > initial.args
+for argument in "$@"; do /usr/bin/printf '%s\n' "$argument" >> initial.args; done
+/usr/bin/head -c 5242880 /dev/zero | /usr/bin/tr '\000' x
+/usr/bin/printf '\n'
+/usr/bin/cat > initial.prompt
+/usr/bin/printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-1"}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"result","subtype":"success","is_error":false,' \
+  '"result":"{\"response\":\"done\"}","session_id":"session-1"}'
+"#;
+
+#[tokio::test]
+async fn long_transcript_crossing_all_legacy_parser_caps_completes() {
+    const OLD_TRANSCRIPT_BYTES: usize = 8 * 1024 * 1024;
+    let workspace = TestDirectory::new("claude-long-transcript");
+    workspace.write(
+        "fake-claude.sh",
+        "set -eu\ncat >/dev/null\nexec /bin/cat provider-output.ndjson\n",
+    );
+    let mut provider_output = String::new();
+    provider_output.push('\n');
+    provider_output.push_str(
+        &serde_json::to_string(&json!({
+            "type":"assistant",
+            "session_id":"long-session",
+            "message":{"content":[{
+                "type":"tool_use",
+                "id":"tool-1",
+                "name":"large_tool",
+                "input":{"payload":"x".repeat(80 * 1024)}
+            }]}
+        }))
+        .assert_value(),
+    );
+    provider_output.push('\n');
+    let padding = "p".repeat(2048);
+    for sequence in 0..=4096 {
+        provider_output.push_str(
+            &serde_json::to_string(
+                &json!({"type":"future_progress","sequence":sequence,"padding":padding}),
+            )
+            .assert_value(),
+        );
+        provider_output.push('\n');
+    }
+    assert!(provider_output.len() > OLD_TRANSCRIPT_BYTES);
+    provider_output.push_str(
+        &serde_json::to_string(&json!({
+            "type":"result",
+            "subtype":"success",
+            "is_error":false,
+            "session_id":"long-session",
+            "structured_output":{"response":"done"}
+        }))
+        .assert_value(),
+    );
+    workspace.write("provider-output.ndjson", &provider_output);
+
+    let (runner, binding) = anthropic_runner(
+        &workspace,
+        "claude-sonnet-5",
+        Some(ReasoningEffort::Max),
+        SessionScope::Execution,
+    )
+    .await;
+    let outcome = complete_turn(&runner, &binding, 1).await;
+
+    assert!(matches!(
+        outcome,
+        WorkerOutcome::Verified { output, .. } if output == json!("done")
+    ));
+}
+
+#[tokio::test]
+async fn stdout_is_drained_while_a_multiframe_prompt_is_delivered_in_full() {
+    let workspace = TestDirectory::new("claude-large-prompt");
+    workspace.write("fake-claude.sh", LARGE_DUPLEX_SCRIPT);
+    let (runner, binding) = anthropic_runner(
+        &workspace,
+        "claude-sonnet-5",
+        Some(ReasoningEffort::Max),
+        SessionScope::Execution,
+    )
+    .await;
+    let payload = "p".repeat(8 * 1024 * 1024);
+    let mut invocation = request(binding, 1, &[(ANTHROPIC_KEY, "anthropic-fake")]);
+    invocation.invocation.input = json!({"payload":payload});
+    let completion = runner
+        .start(invocation)
+        .await
+        .assert_value()
+        .completion()
+        .await
+        .assert_value();
+
+    assert!(matches!(completion.outcome, WorkerOutcome::Verified { .. }));
+    let prompt = workspace.read("initial.prompt");
+    assert!(prompt.len() > 8 * 1024 * 1024);
+    assert!(prompt.contains(&payload));
+    assert!(!workspace.read("initial.args").contains(&payload));
+}

--- a/zeroshot-rust/src/native_v2_claude/transcript.rs
+++ b/zeroshot-rust/src/native_v2_claude/transcript.rs
@@ -1,12 +1,24 @@
 use serde_json::Value;
 
-use crate::native_v2_contract::{TokenUsageDelta, parse_token_usage_delta};
-use crate::native_v2_runner::{DriverControl, LiveOutput, LiveOutputStream, NodeRunnerError};
+use crate::native_v2_capsule::provider_json_lines::{ProviderJsonLine, ProviderJsonLines};
+use crate::native_v2_capsule::provider_process::safe_provider_text;
+use crate::native_v2_contract::TokenUsageDelta;
+use crate::native_v2_runner::{LiveOutputStream, NodeRunnerError};
 
-const MAX_EVENTS: usize = 4096;
-const MAX_EVENT_BYTES: usize = 64 * 1024;
-const MAX_TRANSCRIPT_BYTES: usize = 8 * 1024 * 1024;
-const MAX_SESSION_ID_BYTES: usize = 512;
+#[path = "transcript/diagnostic.rs"]
+mod diagnostic;
+#[path = "transcript/session_id.rs"]
+mod session_id;
+#[path = "transcript/usage.rs"]
+mod usage;
+
+use diagnostic::{combine_failure_detail, error_list, record_count};
+use session_id::record_session_id;
+use usage::{
+    ProvisionalUsage, TerminalUsage, UsageKeys, message_identity, parse_terminal_usage,
+    parse_usage_snapshot,
+};
+
 const LIVE_CHUNK_BYTES: usize = 8 * 1024;
 
 pub(super) struct ClaudeResult {
@@ -25,17 +37,39 @@ pub(super) enum ClaudeAttempt {
     Failed(ClaudeFailure),
 }
 
+impl ClaudeAttempt {
+    pub(super) fn process_failure(diagnostic: impl Into<String>) -> Self {
+        Self::Failed(ClaudeFailure {
+            session_id: None,
+            retryable: false,
+            diagnostic: diagnostic.into(),
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct ClaudeEmission {
+    pub(super) stream: LiveOutputStream,
+    pub(super) text: String,
+}
+
+enum ClaudeTerminal {
+    Complete(Value),
+    Failed(String),
+}
+
 pub(super) struct ClaudeTranscript {
-    pending: Vec<u8>,
-    bytes: usize,
-    events: usize,
+    lines: ProviderJsonLines,
     session_id: Option<String>,
-    result: Option<Value>,
-    failure: Option<String>,
+    session_failure: Option<String>,
+    terminal: Option<ClaudeTerminal>,
     retryable_failure_seen: bool,
-    settled: bool,
     visible_text_emitted: bool,
-    token_usage: Option<TokenUsageDelta>,
+    terminal_usage: Option<Option<TokenUsageDelta>>,
+    provisional_usage: ProvisionalUsage,
+    active_stream_message: Option<String>,
+    malformed_records: usize,
+    oversized_records: usize,
     redactions: Vec<String>,
 }
 
@@ -46,72 +80,86 @@ impl ClaudeTranscript {
             .sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
         redactions.dedup();
         Self {
-            pending: Vec::new(),
-            bytes: 0,
-            events: 0,
+            lines: ProviderJsonLines::new(),
             session_id: None,
-            result: None,
-            failure: None,
+            session_failure: None,
+            terminal: None,
             retryable_failure_seen: false,
-            settled: false,
             visible_text_emitted: false,
-            token_usage: None,
+            terminal_usage: None,
+            provisional_usage: ProvisionalUsage::default(),
+            active_stream_message: None,
+            malformed_records: 0,
+            oversized_records: 0,
             redactions,
         }
     }
 
-    pub(super) fn push(
-        &mut self,
-        chunk: &[u8],
-        control: &DriverControl,
-    ) -> Result<(), NodeRunnerError> {
-        self.bytes = self
-            .bytes
-            .checked_add(chunk.len())
-            .filter(|bytes| *bytes <= MAX_TRANSCRIPT_BYTES)
-            .ok_or(NodeRunnerError::Driver)?;
-        self.pending.extend_from_slice(chunk);
-        while let Some(newline) = self.pending.iter().position(|byte| *byte == b'\n') {
-            let remaining = self.pending.split_off(newline + 1);
-            let line = std::mem::replace(&mut self.pending, remaining);
-            self.parse_line(line.get(..newline).ok_or(NodeRunnerError::Driver)?, control)?;
+    pub(super) fn push(&mut self, chunk: &[u8]) -> Vec<ClaudeEmission> {
+        if self.terminal.is_some() {
+            self.lines.discard();
+            return Vec::new();
         }
-        if self.pending.len() > MAX_EVENT_BYTES {
-            return Err(NodeRunnerError::Driver);
-        }
-        Ok(())
+        let records = self.lines.push(chunk);
+        self.accept_records(records)
     }
 
-    pub(super) fn finish_stream(&mut self) -> Result<(), NodeRunnerError> {
-        self.pending
-            .is_empty()
-            .then_some(())
-            .ok_or(NodeRunnerError::Driver)
+    pub(super) fn finish_stream(&mut self) -> Vec<ClaudeEmission> {
+        if self.terminal.is_some() {
+            self.lines.discard();
+            return Vec::new();
+        }
+        self.lines
+            .finish()
+            .map_or_else(Vec::new, |record| self.accept_records([record]))
     }
 
     pub(super) fn token_usage(&self) -> Option<TokenUsageDelta> {
-        self.token_usage
+        self.terminal_usage
+            .unwrap_or_else(|| self.provisional_usage.total())
     }
 
-    pub(super) fn finish(self) -> Result<ClaudeAttempt, NodeRunnerError> {
-        if !self.settled {
-            if self.retryable_failure_seen {
-                return Ok(ClaudeAttempt::Failed(ClaudeFailure {
-                    session_id: self.session_id,
-                    retryable: true,
-                    diagnostic: "Claude execution ended after a retryable API error".to_owned(),
-                }));
+    pub(super) fn is_success(&self) -> bool {
+        self.session_failure.is_none() && matches!(self.terminal, Some(ClaudeTerminal::Complete(_)))
+    }
+
+    pub(super) fn finish(
+        mut self,
+        process_failure: Option<&str>,
+    ) -> Result<ClaudeAttempt, NodeRunnerError> {
+        let process_failure = process_failure.filter(|detail| !detail.trim().is_empty());
+        let missing_terminal = self.missing_terminal_detail();
+        let terminal = self
+            .terminal
+            .take()
+            .unwrap_or(ClaudeTerminal::Failed(missing_terminal));
+        match terminal {
+            ClaudeTerminal::Complete(result) => self.finish_complete(result, process_failure),
+            ClaudeTerminal::Failed(diagnostic) => {
+                Ok(self.finish_failed(diagnostic, process_failure))
             }
-            return Err(NodeRunnerError::Driver);
         }
-        if let Some(diagnostic) = self.failure {
+    }
+
+    fn finish_complete(
+        self,
+        result: Value,
+        process_failure: Option<&str>,
+    ) -> Result<ClaudeAttempt, NodeRunnerError> {
+        if let Some(session_failure) = self.session_failure.as_deref() {
             return Ok(ClaudeAttempt::Failed(ClaudeFailure {
                 session_id: self.session_id,
                 retryable: self.retryable_failure_seen,
-                diagnostic,
+                diagnostic: combine_failure_detail(session_failure, process_failure),
             }));
         }
-        let result = self.result.ok_or(NodeRunnerError::Driver)?;
+        if let Some(process_failure) = process_failure {
+            return Ok(ClaudeAttempt::Failed(ClaudeFailure {
+                session_id: self.session_id,
+                retryable: self.retryable_failure_seen,
+                diagnostic: process_failure.trim().to_owned(),
+            }));
+        }
         let message = match result {
             Value::String(message) => message,
             structured => {
@@ -124,43 +172,89 @@ impl ClaudeTranscript {
         }))
     }
 
-    fn parse_line(&mut self, line: &[u8], control: &DriverControl) -> Result<(), NodeRunnerError> {
-        if line.is_empty() || line.len() > MAX_EVENT_BYTES || self.settled {
-            return Err(NodeRunnerError::Driver);
+    fn finish_failed(self, diagnostic: String, process_failure: Option<&str>) -> ClaudeAttempt {
+        let diagnostic = match self.session_failure {
+            Some(session_failure) => combine_failure_detail(&session_failure, Some(&diagnostic)),
+            None => diagnostic,
+        };
+        ClaudeAttempt::Failed(ClaudeFailure {
+            session_id: self.session_id,
+            retryable: self.retryable_failure_seen,
+            diagnostic: combine_failure_detail(&diagnostic, process_failure),
+        })
+    }
+
+    fn accept_records(
+        &mut self,
+        records: impl IntoIterator<Item = ProviderJsonLine>,
+    ) -> Vec<ClaudeEmission> {
+        let mut emissions = Vec::new();
+        for record in records {
+            if self.terminal.is_some() {
+                self.lines.discard();
+                break;
+            }
+            self.accept_record(record, &mut emissions);
         }
-        self.events = self
-            .events
-            .checked_add(1)
-            .filter(|events| *events <= MAX_EVENTS)
-            .ok_or(NodeRunnerError::Driver)?;
-        let event: Value = serde_json::from_slice(line).map_err(|_| NodeRunnerError::Driver)?;
-        let object = event.as_object().ok_or(NodeRunnerError::Driver)?;
-        record_session_id(object.get("session_id"), &mut self.session_id)?;
-        self.dispatch_event(object, control)
+        emissions
+    }
+
+    fn accept_record(&mut self, record: ProviderJsonLine, emissions: &mut Vec<ClaudeEmission>) {
+        let ProviderJsonLine::Record(line) = record else {
+            self.oversized_records = self.oversized_records.saturating_add(1);
+            return;
+        };
+        if line.iter().all(u8::is_ascii_whitespace) {
+            return;
+        }
+        let Ok(event) = serde_json::from_slice::<Value>(&line) else {
+            self.malformed_records = self.malformed_records.saturating_add(1);
+            return;
+        };
+        let Some(object) = event.as_object() else {
+            self.malformed_records = self.malformed_records.saturating_add(1);
+            return;
+        };
+        let Some(event_type) = object.get("type").and_then(Value::as_str) else {
+            self.malformed_records = self.malformed_records.saturating_add(1);
+            return;
+        };
+        if !matches!(
+            event_type,
+            "system" | "stream_event" | "assistant" | "result"
+        ) {
+            return;
+        }
+        if let Err(diagnostic) = record_session_id(object.get("session_id"), &mut self.session_id) {
+            if self.session_failure.is_none() {
+                self.session_failure = Some(diagnostic.to_owned());
+            }
+        }
+        self.dispatch_event(event_type, object, emissions);
     }
 
     fn dispatch_event(
         &mut self,
+        event_type: &str,
         object: &serde_json::Map<String, Value>,
-        control: &DriverControl,
-    ) -> Result<(), NodeRunnerError> {
-        match object.get("type").and_then(Value::as_str) {
-            Some("system") => self.parse_system(object, control),
-            Some("stream_event") => self.parse_stream_event(object, control),
-            Some("assistant") => self.parse_assistant(object, control),
-            Some("result") => self.parse_result(object, control),
-            Some(_) => Ok(()),
-            None => Err(NodeRunnerError::Driver),
+        emissions: &mut Vec<ClaudeEmission>,
+    ) {
+        match event_type {
+            "system" => self.parse_system(object, emissions),
+            "stream_event" => self.parse_stream_event(object, emissions),
+            "assistant" => self.parse_assistant(object, emissions),
+            "result" => self.parse_result(object),
+            _ => {}
         }
     }
 
     fn parse_system(
         &mut self,
         event: &serde_json::Map<String, Value>,
-        control: &DriverControl,
-    ) -> Result<(), NodeRunnerError> {
+        emissions: &mut Vec<ClaudeEmission>,
+    ) {
         if event.get("subtype").and_then(Value::as_str) != Some("api_retry") {
-            return Ok(());
+            return;
         }
         self.retryable_failure_seen = true;
         let attempt = event.get("attempt").and_then(Value::as_u64).unwrap_or(0);
@@ -173,55 +267,100 @@ impl ClaudeTranscript {
             .and_then(Value::as_str)
             .unwrap_or("unknown");
         self.emit(
-            control,
+            emissions,
             LiveOutputStream::System,
             &format!("Claude API retry {attempt}/{maximum}: {error}"),
-        )
+        );
     }
 
     fn parse_stream_event(
         &mut self,
         event: &serde_json::Map<String, Value>,
-        control: &DriverControl,
-    ) -> Result<(), NodeRunnerError> {
+        emissions: &mut Vec<ClaudeEmission>,
+    ) {
         let Some(inner) = event.get("event").and_then(Value::as_object) else {
-            return Ok(());
+            return;
         };
-        if inner.get("type").and_then(Value::as_str) != Some("content_block_delta") {
-            return Ok(());
+        match inner.get("type").and_then(Value::as_str) {
+            Some("message_start") => self.parse_message_start(inner),
+            Some("message_delta") => self.parse_message_delta(inner),
+            Some("message_stop") => {
+                self.active_stream_message = None;
+            }
+            Some("content_block_delta") => self.parse_content_delta(inner, emissions),
+            _ => {}
         }
-        let Some(delta) = inner.get("delta").and_then(Value::as_object) else {
-            return Ok(());
+    }
+
+    fn parse_content_delta(
+        &mut self,
+        event: &serde_json::Map<String, Value>,
+        emissions: &mut Vec<ClaudeEmission>,
+    ) {
+        let Some(delta) = event.get("delta").and_then(Value::as_object) else {
+            return;
         };
         let (field, stream) = match delta.get("type").and_then(Value::as_str) {
             Some("text_delta") => ("text", LiveOutputStream::Output),
             Some("thinking_delta") => ("thinking", LiveOutputStream::System),
-            _ => return Ok(()),
+            _ => return,
         };
         if let Some(text) = delta.get(field).and_then(Value::as_str) {
             if field == "text" {
                 self.visible_text_emitted = true;
             }
-            self.emit(control, stream, text)?;
+            self.emit(emissions, stream, text);
         }
-        Ok(())
+    }
+
+    fn parse_message_start(&mut self, event: &serde_json::Map<String, Value>) {
+        self.active_stream_message = None;
+        let Some(message) = event.get("message").and_then(Value::as_object) else {
+            return;
+        };
+        let Some(message_id) = message_identity(message) else {
+            if message.contains_key("usage") {
+                self.provisional_usage.invalidate();
+            }
+            return;
+        };
+        self.active_stream_message = Some(message_id.to_owned());
+        if message.contains_key("usage") {
+            match parse_usage_snapshot(message.get("usage"), UsageKeys::CLAUDE_STREAM) {
+                Some(usage) => self.provisional_usage.replace_message(message_id, usage),
+                None => self.provisional_usage.invalidate(),
+            }
+        }
+    }
+
+    fn parse_message_delta(&mut self, event: &serde_json::Map<String, Value>) {
+        if !event.contains_key("usage") {
+            return;
+        }
+        let Some(message_id) = self.active_stream_message.as_deref() else {
+            self.provisional_usage.invalidate();
+            return;
+        };
+        match parse_usage_snapshot(event.get("usage"), UsageKeys::CLAUDE_STREAM) {
+            Some(usage) => self.provisional_usage.merge_message(message_id, usage),
+            None => self.provisional_usage.invalidate(),
+        }
     }
 
     fn parse_assistant(
         &mut self,
         event: &serde_json::Map<String, Value>,
-        control: &DriverControl,
-    ) -> Result<(), NodeRunnerError> {
+        emissions: &mut Vec<ClaudeEmission>,
+    ) {
+        let Some(message) = event.get("message").and_then(Value::as_object) else {
+            return;
+        };
+        self.record_assistant_usage(event, message);
         if self.visible_text_emitted {
-            return Ok(());
+            return;
         }
-        let Some(content) = event
-            .get("message")
-            .and_then(Value::as_object)
-            .and_then(|message| message.get("content"))
-            .and_then(Value::as_array)
-        else {
-            return Ok(());
+        let Some(content) = message.get("content").and_then(Value::as_array) else {
+            return;
         };
         for block in content {
             let Some(block) = block.as_object() else {
@@ -229,24 +368,44 @@ impl ClaudeTranscript {
             };
             if block.get("type").and_then(Value::as_str) == Some("text") {
                 if let Some(text) = block.get("text").and_then(Value::as_str) {
-                    self.emit(control, LiveOutputStream::Output, text)?;
+                    self.emit(emissions, LiveOutputStream::Output, text);
                     self.visible_text_emitted = true;
                 }
             }
         }
-        Ok(())
     }
 
-    fn parse_result(
+    fn record_assistant_usage(
         &mut self,
         event: &serde_json::Map<String, Value>,
-        _control: &DriverControl,
-    ) -> Result<(), NodeRunnerError> {
-        self.token_usage = parse_token_usage_delta(
+        message: &serde_json::Map<String, Value>,
+    ) {
+        if !message.contains_key("usage") {
+            return;
+        }
+        let Some(usage) = parse_usage_snapshot(message.get("usage"), UsageKeys::CLAUDE_STREAM)
+        else {
+            self.provisional_usage.invalidate();
+            return;
+        };
+        let identity = message_identity(message).or_else(|| message_identity(event));
+        if let Some(message_id) = identity {
+            self.provisional_usage.replace_message(message_id, usage);
+        } else {
+            self.provisional_usage.add_anonymous(usage);
+        }
+    }
+
+    fn parse_result(&mut self, event: &serde_json::Map<String, Value>) {
+        match parse_terminal_usage(
+            event.get("modelUsage"),
+            event.get("model_usage"),
             event.get("usage"),
-            Some("cache_read_input_tokens"),
-            Some("cache_creation_input_tokens"),
-        );
+        ) {
+            TerminalUsage::Empty => {}
+            TerminalUsage::Valid(usage) => self.terminal_usage = Some(Some(usage)),
+            TerminalUsage::Malformed => self.terminal_usage = Some(None),
+        }
         let unsuccessful = event.get("subtype").and_then(Value::as_str) != Some("success")
             || event.get("is_error").and_then(Value::as_bool) == Some(true);
         if unsuccessful {
@@ -265,73 +424,48 @@ impl ClaudeTranscript {
                             .unwrap_or("failed")
                     )
                 });
-            self.failure = Some(diagnostic);
-            self.settled = true;
-            return Ok(());
+            self.terminal = Some(ClaudeTerminal::Failed(diagnostic));
+            return;
         }
-        if self.result.is_some() {
-            return Err(NodeRunnerError::Driver);
-        }
-        self.result = Some(
+        self.terminal = Some(ClaudeTerminal::Complete(
             event
                 .get("structured_output")
                 .filter(|value| !value.is_null())
                 .or_else(|| event.get("result"))
                 .cloned()
                 .unwrap_or(Value::Null),
-        );
-        self.settled = true;
-        Ok(())
+        ));
     }
 
-    fn emit(
-        &self,
-        control: &DriverControl,
-        stream: LiveOutputStream,
-        text: &str,
-    ) -> Result<(), NodeRunnerError> {
-        let mut safe = text.to_owned();
-        for value in &self.redactions {
-            safe = safe.replace(value, "[REDACTED]");
-        }
-        if safe.contains('\0') {
-            return Err(NodeRunnerError::UnsafeOutput);
-        }
+    fn emit(&self, emissions: &mut Vec<ClaudeEmission>, stream: LiveOutputStream, text: &str) {
+        let safe = safe_provider_text(text, &self.redactions);
         for chunk in utf8_chunks(&safe, LIVE_CHUNK_BYTES) {
-            control.emit(LiveOutput::new(stream, chunk)?)?;
+            emissions.push(ClaudeEmission {
+                stream,
+                text: chunk,
+            });
         }
-        Ok(())
     }
-}
 
-fn error_list(value: Option<&Value>) -> Option<String> {
-    let errors = value?
-        .as_array()?
-        .iter()
-        .filter_map(Value::as_str)
-        .filter(|error| !error.trim().is_empty())
-        .collect::<Vec<_>>();
-    (!errors.is_empty()).then(|| errors.join("; "))
-}
-
-fn record_session_id(
-    value: Option<&Value>,
-    retained: &mut Option<String>,
-) -> Result<(), NodeRunnerError> {
-    let Some(value) = value else {
-        return Ok(());
-    };
-    let session_id = value.as_str().ok_or(NodeRunnerError::Driver)?.trim();
-    if session_id.is_empty() || session_id.len() > MAX_SESSION_ID_BYTES {
-        return Err(NodeRunnerError::Driver);
-    }
-    match retained.as_deref() {
-        Some(existing) if existing != session_id => Err(NodeRunnerError::Driver),
-        Some(_) => Ok(()),
-        None => {
-            *retained = Some(session_id.to_owned());
-            Ok(())
+    fn missing_terminal_detail(&self) -> String {
+        let mut diagnostic = if self.retryable_failure_seen {
+            "Claude execution ended after a retryable API error without a terminal result"
+                .to_owned()
+        } else {
+            "Claude output ended without a terminal result".to_owned()
+        };
+        let mut discarded = Vec::new();
+        if self.malformed_records > 0 {
+            discarded.push(record_count(self.malformed_records, "malformed"));
         }
+        if self.oversized_records > 0 {
+            discarded.push(record_count(self.oversized_records, "oversized"));
+        }
+        if !discarded.is_empty() {
+            diagnostic.push_str("; discarded ");
+            diagnostic.push_str(&discarded.join(" and "));
+        }
+        diagnostic
     }
 }
 
@@ -353,24 +487,5 @@ fn utf8_chunks(value: &str, max: usize) -> Vec<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::ClaudeTranscript;
-
-    #[test]
-    fn redactions_are_deduplicated_and_longest_first() {
-        let transcript = ClaudeTranscript::new(vec![
-            "secret".to_owned(),
-            "secret-tail".to_owned(),
-            "secret".to_owned(),
-            String::new(),
-        ]);
-        assert_eq!(transcript.redactions, vec!["secret-tail", "secret"]);
-        let safe = transcript
-            .redactions
-            .iter()
-            .fold("value=secret-tail".to_owned(), |safe, value| {
-                safe.replace(value, "[REDACTED]")
-            });
-        assert_eq!(safe, "value=[REDACTED]");
-    }
-}
+#[path = "transcript/tests.rs"]
+mod tests;

--- a/zeroshot-rust/src/native_v2_claude/transcript/diagnostic.rs
+++ b/zeroshot-rust/src/native_v2_claude/transcript/diagnostic.rs
@@ -1,0 +1,25 @@
+use serde_json::Value;
+
+pub(super) fn record_count(count: usize, kind: &str) -> String {
+    format!(
+        "{count} {kind} JSONL record{}",
+        if count == 1 { "" } else { "s" }
+    )
+}
+
+pub(super) fn combine_failure_detail(diagnostic: &str, process_failure: Option<&str>) -> String {
+    process_failure.map_or_else(
+        || diagnostic.to_owned(),
+        |process| format!("{}; {}", diagnostic.trim(), process.trim()),
+    )
+}
+
+pub(super) fn error_list(value: Option<&Value>) -> Option<String> {
+    let errors = value?
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|error| !error.trim().is_empty())
+        .collect::<Vec<_>>();
+    (!errors.is_empty()).then(|| errors.join("; "))
+}

--- a/zeroshot-rust/src/native_v2_claude/transcript/session_id.rs
+++ b/zeroshot-rust/src/native_v2_claude/transcript/session_id.rs
@@ -1,0 +1,26 @@
+use serde_json::Value;
+
+pub(super) fn record_session_id(
+    value: Option<&Value>,
+    retained: &mut Option<String>,
+) -> Result<(), &'static str> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let session_id = value
+        .as_str()
+        .ok_or("Claude output contained an invalid session identifier")?;
+    if session_id.is_empty() || session_id.contains('\0') {
+        return Err("Claude output contained an invalid session identifier");
+    }
+    match retained.as_deref() {
+        Some(existing) if existing != session_id => {
+            Err("Claude output changed session identifier during one turn")
+        }
+        Some(_) => Ok(()),
+        None => {
+            *retained = Some(session_id.to_owned());
+            Ok(())
+        }
+    }
+}

--- a/zeroshot-rust/src/native_v2_claude/transcript/tests.rs
+++ b/zeroshot-rust/src/native_v2_claude/transcript/tests.rs
@@ -1,0 +1,394 @@
+use openengine_cluster_testkit::assertions::AssertValue;
+use serde_json::{Value, json};
+
+use super::*;
+
+#[path = "tests/limits.rs"]
+mod limit_tests;
+#[path = "tests/usage.rs"]
+mod usage_tests;
+
+struct Decoded {
+    attempt: ClaudeAttempt,
+    emissions: Vec<ClaudeEmission>,
+    usage: Option<TokenUsageDelta>,
+}
+
+fn append_event(bytes: &mut Vec<u8>, event: Value) {
+    bytes.extend(serde_json::to_vec(&event).assert_value());
+    bytes.push(b'\n');
+}
+
+fn success(response: Value, session: &str) -> Value {
+    json!({
+        "type":"result",
+        "subtype":"success",
+        "is_error":false,
+        "session_id":session,
+        "structured_output":{"response":response},
+        "usage":{
+            "input_tokens":11,
+            "output_tokens":4,
+            "cache_read_input_tokens":6,
+            "cache_creation_input_tokens":2
+        }
+    })
+}
+
+fn failure(diagnostic: &str, session: &str) -> Value {
+    json!({
+        "type":"result",
+        "subtype":"error_during_execution",
+        "is_error":true,
+        "session_id":session,
+        "result":diagnostic
+    })
+}
+
+fn decode(bytes: &[u8], chunk_bytes: usize, process_failure: Option<&str>) -> Decoded {
+    let mut transcript = ClaudeTranscript::new(Vec::new());
+    let mut emissions = Vec::new();
+    for chunk in bytes.chunks(chunk_bytes.max(1)) {
+        emissions.extend(transcript.push(chunk));
+    }
+    emissions.extend(transcript.finish_stream());
+    let usage = transcript.token_usage();
+    let attempt = transcript.finish(process_failure).assert_value();
+    Decoded {
+        attempt,
+        emissions,
+        usage,
+    }
+}
+
+fn completed_response(attempt: ClaudeAttempt) -> Value {
+    let result = match attempt {
+        ClaudeAttempt::Complete(result) => Some(result),
+        ClaudeAttempt::Failed(_) => None,
+    };
+    let result = result.assert_value();
+    serde_json::from_str::<Value>(&result.message)
+        .assert_value()
+        .get("response")
+        .cloned()
+        .assert_value()
+}
+
+fn failed_attempt(attempt: ClaudeAttempt) -> ClaudeFailure {
+    match attempt {
+        ClaudeAttempt::Complete(_) => None,
+        ClaudeAttempt::Failed(failure) => Some(failure),
+    }
+    .assert_value()
+}
+
+fn session_change_prefix() -> Vec<u8> {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({"type":"system","subtype":"init","session_id":"session-1"}),
+    );
+    append_event(
+        &mut bytes,
+        json!({"type":"system","subtype":"init","session_id":"session-2"}),
+    );
+    bytes
+}
+
+fn assert_failed_with_usage(
+    decoded: Decoded,
+    expected_diagnostic: &str,
+    expected_usage: [u64; 2],
+) -> ClaudeFailure {
+    let failure = failed_attempt(decoded.attempt);
+    assert_eq!(failure.diagnostic, expected_diagnostic);
+    let usage = decoded.usage.assert_value();
+    assert_eq!(
+        [usage.input_tokens.get(), usage.output_tokens.get()],
+        expected_usage
+    );
+    failure
+}
+
+#[test]
+fn redactions_are_deduplicated_and_longest_first() {
+    let mut transcript = ClaudeTranscript::new(vec![
+        "secret".to_owned(),
+        "secret-tail".to_owned(),
+        "secret".to_owned(),
+        String::new(),
+    ]);
+    assert_eq!(transcript.redactions, vec!["secret-tail", "secret"]);
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"stream_event",
+            "event":{
+                "type":"content_block_delta",
+                "delta":{"type":"text_delta","text":"value=secret-tail\u{0}"}
+            }
+        }),
+    );
+    append_event(&mut bytes, success(json!("done"), "session-1"));
+
+    let emissions = transcript.push(&bytes);
+    assert_eq!(emissions.len(), 1);
+    let emission = emissions.first().assert_value();
+    assert_eq!(emission.text, "value=[REDACTED]\u{fffd}");
+    assert!(!emission.text.contains('\0'));
+}
+
+#[test]
+fn malformed_ancillary_records_do_not_hide_a_valid_result() {
+    let mut bytes = b"not-json\n[]\n{}\n{\"type\":1}\n".to_vec();
+    append_event(&mut bytes, success(json!("done"), "session-1"));
+
+    let decoded = decode(&bytes, 13, None);
+    assert_eq!(completed_response(decoded.attempt), json!("done"));
+}
+
+#[test]
+fn unknown_event_types_are_ignored_before_session_validation() {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({"type":"future_progress","session_id":{"future":"shape"}}),
+    );
+    append_event(
+        &mut bytes,
+        json!({"type":"system","subtype":"init","session_id":"session-1"}),
+    );
+    append_event(
+        &mut bytes,
+        json!({"type":"future_progress","session_id":"conflicting-session"}),
+    );
+    append_event(&mut bytes, success(json!("done"), "session-1"));
+
+    assert_eq!(
+        completed_response(decode(&bytes, 11, None).attempt),
+        json!("done")
+    );
+}
+
+#[test]
+fn oversized_ancillary_record_does_not_hide_a_valid_result() {
+    let mut transcript = ClaudeTranscript::new(Vec::new());
+    let result = serde_json::to_vec(&success(json!("done"), "session-1")).assert_value();
+    let emissions = transcript.accept_records([
+        ProviderJsonLine::Oversized,
+        ProviderJsonLine::Record(result),
+    ]);
+    assert!(emissions.is_empty());
+
+    assert_eq!(
+        completed_response(transcript.finish(None).assert_value()),
+        json!("done")
+    );
+}
+
+#[test]
+fn missing_terminal_result_reports_discarded_record_counts() {
+    let mut transcript = ClaudeTranscript::new(Vec::new());
+    let emissions = transcript.accept_records([
+        ProviderJsonLine::Record(b"not-json".to_vec()),
+        ProviderJsonLine::Record(b"[]".to_vec()),
+        ProviderJsonLine::Oversized,
+    ]);
+    assert!(emissions.is_empty());
+
+    let failure = failed_attempt(transcript.finish(None).assert_value());
+    assert!(!failure.retryable);
+    assert_eq!(
+        failure.diagnostic,
+        concat!(
+            "Claude output ended without a terminal result; discarded ",
+            "2 malformed JSONL records and 1 oversized JSONL record"
+        )
+    );
+}
+
+#[test]
+fn truncated_preterminal_record_has_an_actionable_failure() {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({"type":"system","subtype":"init","session_id":"session-1"}),
+    );
+    bytes.extend_from_slice(br#"{"type":"result","subtype":"success"#);
+
+    let failure = failed_attempt(decode(&bytes, 17, None).attempt);
+    assert_eq!(
+        failure.diagnostic,
+        concat!(
+            "Claude output ended without a terminal result; discarded ",
+            "1 malformed JSONL record"
+        )
+    );
+}
+
+#[test]
+fn first_terminal_result_seals_and_ignores_all_trailing_output() {
+    let mut bytes = Vec::new();
+    append_event(&mut bytes, success(json!("first"), "session-1"));
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"system",
+            "subtype":"api_retry",
+            "attempt":1,
+            "max_retries":3,
+            "error":"late"
+        }),
+    );
+    append_event(&mut bytes, failure("late failure", "different-session"));
+    bytes.extend_from_slice(b"not-json\nunterminated");
+
+    let decoded = decode(&bytes, bytes.len(), None);
+    assert_eq!(completed_response(decoded.attempt), json!("first"));
+    assert!(decoded.emissions.is_empty());
+    let usage = decoded.usage.assert_value();
+    assert_eq!(
+        [usage.input_tokens.get(), usage.output_tokens.get()],
+        [11, 4]
+    );
+
+    let mut failure_first = Vec::new();
+    append_event(
+        &mut failure_first,
+        failure("authoritative failure", "session-1"),
+    );
+    append_event(&mut failure_first, success(json!("ignored"), "session-1"));
+    let failure = failed_attempt(decode(&failure_first, failure_first.len(), None).attempt);
+    assert_eq!(failure.diagnostic, "authoritative failure");
+}
+
+#[test]
+fn preterminal_session_change_waits_for_result_and_preserves_terminal_usage() {
+    let mut bytes = session_change_prefix();
+    append_event(&mut bytes, success(json!("ignored"), "session-1"));
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"result",
+            "subtype":"success",
+            "is_error":false,
+            "session_id":"session-1",
+            "result":"trailing",
+            "usage":{"input_tokens":999,"output_tokens":999}
+        }),
+    );
+
+    let decoded = decode(&bytes, 64 * 1024, None);
+    let failure = assert_failed_with_usage(
+        decoded,
+        "Claude output changed session identifier during one turn",
+        [11, 4],
+    );
+    assert!(!failure.retryable);
+    assert_eq!(failure.session_id.as_deref(), Some("session-1"));
+}
+
+#[test]
+fn session_change_on_the_result_still_records_its_usage() {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({"type":"system","subtype":"init","session_id":"session-1"}),
+    );
+    append_event(&mut bytes, success(json!("ignored"), "session-2"));
+
+    let decoded = decode(&bytes, 7, None);
+    let failure = assert_failed_with_usage(
+        decoded,
+        "Claude output changed session identifier during one turn",
+        [11, 4],
+    );
+    assert_eq!(failure.session_id.as_deref(), Some("session-1"));
+}
+
+#[test]
+fn session_change_preserves_later_terminal_failure_detail_and_usage() {
+    let mut bytes = session_change_prefix();
+    let mut terminal = failure("provider terminal detail", "session-1");
+    terminal.as_object_mut().assert_value().insert(
+        "usage".to_owned(),
+        json!({"input_tokens":29,"output_tokens":13}),
+    );
+    append_event(&mut bytes, terminal);
+
+    let decoded = decode(&bytes, 9, None);
+    assert_failed_with_usage(
+        decoded,
+        concat!(
+            "Claude output changed session identifier during one turn; ",
+            "provider terminal detail"
+        ),
+        [29, 13],
+    );
+}
+
+#[test]
+fn session_identifiers_preserve_opaque_whitespace_and_reject_nul() {
+    let session = "  opaque session\nwith tab\t ";
+    let mut bytes = Vec::new();
+    append_event(&mut bytes, success(json!("done"), session));
+    let attempt = decode(&bytes, 23, None).attempt;
+    let result = match attempt {
+        ClaudeAttempt::Complete(result) => Some(result),
+        ClaudeAttempt::Failed(_) => None,
+    }
+    .assert_value();
+    assert_eq!(result.session_id.as_deref(), Some(session));
+
+    let mut invalid = Vec::new();
+    append_event(&mut invalid, success(json!("ignored"), "nul\0session"));
+    let decoded = decode(&invalid, 23, None);
+    assert_failed_with_usage(
+        decoded,
+        "Claude output contained an invalid session identifier",
+        [11, 4],
+    );
+}
+
+#[test]
+fn only_an_api_retry_signal_makes_a_missing_result_retryable() {
+    let ordinary = failed_attempt(decode(b"not-json\n", 64, None).attempt);
+    assert!(!ordinary.retryable);
+
+    let mut retry = Vec::new();
+    append_event(
+        &mut retry,
+        json!({
+            "type":"system",
+            "subtype":"api_retry",
+            "attempt":1,
+            "max_retries":3,
+            "error":"overloaded"
+        }),
+    );
+    let retry = failed_attempt(decode(&retry, 64, None).attempt);
+    assert!(retry.retryable);
+    assert!(retry.diagnostic.contains("retryable API error"));
+}
+
+#[test]
+fn process_failures_are_merged_into_terminal_attempts() {
+    let process = "provider process exited with status 17; stderr: useful detail";
+    let mut complete = Vec::new();
+    append_event(&mut complete, success(json!("ignored"), "session-1"));
+    let complete = failed_attempt(decode(&complete, 64 * 1024, Some(process)).attempt);
+    assert_eq!(complete.diagnostic, process);
+    assert!(!complete.retryable);
+
+    let mut failed = Vec::new();
+    append_event(
+        &mut failed,
+        failure("provider rejected request", "session-1"),
+    );
+    let failed = failed_attempt(decode(&failed, 64 * 1024, Some(process)).attempt);
+    assert_eq!(
+        failed.diagnostic,
+        "provider rejected request; provider process exited with status 17; stderr: useful detail"
+    );
+}

--- a/zeroshot-rust/src/native_v2_claude/transcript/tests/limits.rs
+++ b/zeroshot-rust/src/native_v2_claude/transcript/tests/limits.rs
@@ -1,0 +1,104 @@
+use super::*;
+
+fn finish_success(bytes: &mut Vec<u8>) -> Option<TokenUsageDelta> {
+    append_event(bytes, success(json!("done"), "session-1"));
+    let decoded = decode(bytes, 64 * 1024, None);
+    assert_eq!(completed_response(decoded.attempt), json!("done"));
+    decoded.usage
+}
+
+#[test]
+fn accepts_blank_crlf_and_unterminated_final_records_across_chunks() {
+    let mut bytes = b"\n \t\r\n".to_vec();
+    let mut init =
+        serde_json::to_vec(&json!({"type":"system","subtype":"init","session_id":"session-1"}))
+            .assert_value();
+    init.extend_from_slice(b"\r\n\n");
+    bytes.extend(init);
+    bytes.extend(serde_json::to_vec(&success(json!("done \u{1f642}"), "session-1")).assert_value());
+    bytes.extend_from_slice(b" \t\r");
+
+    let decoded = decode(&bytes, 1, None);
+    assert_eq!(completed_response(decoded.attempt), json!("done \u{1f642}"));
+    assert!(decoded.emissions.is_empty());
+}
+
+#[test]
+fn accepts_records_larger_than_the_old_per_record_limit() {
+    let assistant_text = "a".repeat(80 * 1024);
+    let tool_result = "t".repeat(96 * 1024);
+    let response = "r".repeat(72 * 1024);
+    let session = "s".repeat(1024);
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"assistant",
+            "session_id":session,
+            "message":{"content":[{"type":"text","text":assistant_text}]}
+        }),
+    );
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"user",
+            "session_id":session,
+            "message":{"content":[{
+                "type":"tool_result",
+                "tool_use_id":"tool-1",
+                "content":tool_result
+            }]}
+        }),
+    );
+    append_event(&mut bytes, success(json!(response.clone()), &session));
+
+    let decoded = decode(&bytes, 31 * 1024, None);
+    assert_eq!(completed_response(decoded.attempt), json!(response));
+    assert!(
+        decoded
+            .emissions
+            .iter()
+            .all(|emission| emission.text.len() <= LIVE_CHUNK_BYTES)
+    );
+    assert_eq!(
+        decoded
+            .emissions
+            .iter()
+            .map(|emission| emission.text.as_str())
+            .collect::<String>(),
+        assistant_text
+    );
+}
+
+#[test]
+fn accepts_more_than_the_old_event_limit() {
+    let mut bytes = Vec::new();
+    for sequence in 0..=4096 {
+        append_event(
+            &mut bytes,
+            json!({"type":"future_progress","sequence":sequence}),
+        );
+    }
+    let _ = finish_success(&mut bytes);
+}
+
+#[test]
+fn accepts_more_than_the_old_cumulative_transcript_limit() {
+    const OLD_TRANSCRIPT_BYTES: usize = 8 * 1024 * 1024;
+    let padding = "x".repeat(48 * 1024);
+    let mut bytes = Vec::new();
+    let mut records = 0;
+    while bytes.len() <= OLD_TRANSCRIPT_BYTES {
+        append_event(
+            &mut bytes,
+            json!({"type":"future_progress","padding":padding}),
+        );
+        records += 1;
+    }
+    assert!(records < 4096);
+    let usage = finish_success(&mut bytes).assert_value();
+    assert_eq!(
+        [usage.input_tokens.get(), usage.output_tokens.get()],
+        [11, 4]
+    );
+}

--- a/zeroshot-rust/src/native_v2_claude/transcript/tests/usage.rs
+++ b/zeroshot-rust/src/native_v2_claude/transcript/tests/usage.rs
@@ -1,0 +1,351 @@
+use super::*;
+
+fn usage(input: u64, output: u64, cache_read: u64, cache_creation: u64) -> Value {
+    json!({
+        "input_tokens":input,
+        "output_tokens":output,
+        "cache_read_input_tokens":cache_read,
+        "cache_creation_input_tokens":cache_creation
+    })
+}
+
+fn message_start(message_id: &str, usage: Value) -> Value {
+    json!({
+        "type":"stream_event",
+        "session_id":"session-1",
+        "event":{
+            "type":"message_start",
+            "message":{"id":message_id,"usage":usage}
+        }
+    })
+}
+
+fn assistant_usage(message_id: &str, usage: Value) -> Value {
+    json!({
+        "type":"assistant",
+        "session_id":"session-1",
+        "message":{"id":message_id,"content":[],"usage":usage}
+    })
+}
+
+fn raw_message_usage(output_tokens: Value) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    append_event(&mut bytes, message_start("message-1", usage(23, 0, 17, 5)));
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"stream_event",
+            "session_id":"session-1",
+            "event":{
+                "type":"message_delta",
+                "delta":{"stop_reason":"end_turn"},
+                "usage":{"output_tokens":output_tokens}
+            }
+        }),
+    );
+    bytes
+}
+
+fn usage_values(usage: Option<TokenUsageDelta>) -> [u64; 4] {
+    let usage = usage.assert_value();
+    [
+        usage.input_tokens.get(),
+        usage.output_tokens.get(),
+        usage.cache_read_input_tokens.assert_value().get(),
+        usage.cache_creation_input_tokens.assert_value().get(),
+    ]
+}
+
+fn success_without_terminal_usage() -> Value {
+    json!({
+        "type":"result",
+        "subtype":"success",
+        "is_error":false,
+        "session_id":"session-1",
+        "structured_output":{"response":"done"},
+        "usage":{},
+        "modelUsage":null
+    })
+}
+
+#[test]
+fn assistant_usage_sums_unique_messages_and_replaces_repeated_snapshots() {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"stream_event",
+            "event":{
+                "type":"content_block_delta",
+                "delta":{"type":"text_delta","text":"visible once"}
+            }
+        }),
+    );
+    for (id, input, output, cache_read, cache_creation) in [
+        ("message-1", 11, 2, 6, 2),
+        ("message-1", 11, 4, 6, 2),
+        ("message-2", 7, 3, 5, 1),
+    ] {
+        append_event(
+            &mut bytes,
+            assistant_usage(id, usage(input, output, cache_read, cache_creation)),
+        );
+    }
+
+    let decoded = decode(&bytes, 19, Some("provider process exited with status 17"));
+    assert_eq!(usage_values(decoded.usage), [18, 7, 11, 3]);
+    assert_eq!(
+        decoded
+            .emissions
+            .iter()
+            .map(|emission| emission.text.as_str())
+            .collect::<String>(),
+        "visible once"
+    );
+    assert!(
+        failed_attempt(decoded.attempt)
+            .diagnostic
+            .contains("without a terminal result")
+    );
+}
+
+#[test]
+fn raw_message_usage_survives_a_missing_terminal_result() {
+    let bytes = raw_message_usage(json!(9));
+
+    let decoded = decode(&bytes, 7, Some("provider process exited with status 17"));
+    assert_eq!(usage_values(decoded.usage), [23, 9, 17, 5]);
+    assert!(
+        failed_attempt(decoded.attempt)
+            .diagnostic
+            .contains("without a terminal result")
+    );
+}
+
+#[test]
+fn malformed_raw_usage_is_not_reported_as_complete() {
+    let bytes = raw_message_usage(json!("many"));
+
+    assert!(decode(&bytes, 17, Some("provider exited")).usage.is_none());
+}
+
+#[test]
+fn unidentifiable_message_start_usage_is_incomplete_but_turn_can_succeed() {
+    for message in [
+        json!({"usage":usage(23, 9, 17, 5)}),
+        json!({"id":null,"usage":usage(23, 9, 17, 5)}),
+        json!({"id":"","usage":usage(23, 9, 17, 5)}),
+        json!({"id":17,"usage":usage(23, 9, 17, 5)}),
+    ] {
+        let mut bytes = Vec::new();
+        append_event(
+            &mut bytes,
+            json!({
+                "type":"stream_event",
+                "session_id":"session-1",
+                "event":{
+                    "type":"message_start",
+                    "message":message
+                }
+            }),
+        );
+        append_event(&mut bytes, success_without_terminal_usage());
+
+        let decoded = decode(&bytes, 13, None);
+        assert_eq!(completed_response(decoded.attempt), json!("done"));
+        assert!(decoded.usage.is_none());
+    }
+}
+
+#[test]
+fn unassociated_message_delta_usage_is_incomplete_but_turn_can_succeed() {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"stream_event",
+            "session_id":"session-1",
+            "event":{"type":"message_delta","usage":{"output_tokens":9}}
+        }),
+    );
+    append_event(&mut bytes, success_without_terminal_usage());
+
+    let decoded = decode(&bytes, 17, None);
+    assert_eq!(completed_response(decoded.attempt), json!("done"));
+    assert!(decoded.usage.is_none());
+}
+
+#[test]
+fn assistant_wrapper_replaces_the_same_raw_message_usage() {
+    let mut bytes = Vec::new();
+    append_event(&mut bytes, message_start("message-1", usage(23, 0, 17, 5)));
+    append_event(
+        &mut bytes,
+        assistant_usage("message-1", usage(23, 9, 17, 5)),
+    );
+
+    let decoded = decode(&bytes, 29, Some("provider exited"));
+    assert_eq!(usage_values(decoded.usage), [23, 9, 17, 5]);
+}
+
+#[test]
+fn valid_result_usage_replaces_provisional_assistant_usage() {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"assistant",
+            "session_id":"session-1",
+            "message":{
+                "content":[],
+                "usage":{
+                    "input_tokens":97,
+                    "output_tokens":53,
+                    "cache_read_input_tokens":41,
+                    "cache_creation_input_tokens":29
+                }
+            }
+        }),
+    );
+    append_event(&mut bytes, success(json!("done"), "session-1"));
+
+    let decoded = decode(&bytes, 64, None);
+    assert_eq!(completed_response(decoded.attempt), json!("done"));
+    assert_eq!(usage_values(decoded.usage), [11, 4, 6, 2]);
+}
+
+#[test]
+fn model_usage_sums_all_models_and_overrides_other_usage() {
+    for (model_key, fields) in [
+        (
+            "modelUsage",
+            [
+                ("inputTokens", 13),
+                ("outputTokens", 7),
+                ("cacheReadInputTokens", 11),
+                ("cacheCreationInputTokens", 5),
+            ],
+        ),
+        (
+            "model_usage",
+            [
+                ("input_tokens", 13),
+                ("output_tokens", 7),
+                ("cache_read_input_tokens", 11),
+                ("cache_creation_input_tokens", 5),
+            ],
+        ),
+    ] {
+        let first = fields
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), json!(value)))
+            .collect::<serde_json::Map<_, _>>();
+        let second = fields
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), json!(value + 1)))
+            .collect::<serde_json::Map<_, _>>();
+        let mut event = json!({
+            "type":"result",
+            "subtype":"success",
+            "is_error":false,
+            "session_id":"session-1",
+            "result":"done",
+            "usage":{
+                "input_tokens":999,
+                "output_tokens":999,
+                "cache_read_input_tokens":999,
+                "cache_creation_input_tokens":999
+            }
+        });
+        event.as_object_mut().assert_value().insert(
+            model_key.to_owned(),
+            json!({"model-a":first,"model-b":second}),
+        );
+        let mut bytes = Vec::new();
+        append_event(&mut bytes, event);
+
+        let decoded = decode(&bytes, 31, None);
+        assert_eq!(usage_values(decoded.usage), [27, 15, 23, 11]);
+    }
+}
+
+#[test]
+fn malformed_model_usage_fails_closed_even_with_valid_result_usage() {
+    let mut event = success(json!("done"), "session-1");
+    event.as_object_mut().assert_value().insert(
+        "modelUsage".to_owned(),
+        json!({
+            "model-a":{
+                "inputTokens":"many",
+                "outputTokens":7,
+                "cacheReadInputTokens":11,
+                "cacheCreationInputTokens":5
+            }
+        }),
+    );
+    let mut bytes = Vec::new();
+    append_event(&mut bytes, event);
+
+    assert!(decode(&bytes, 19, None).usage.is_none());
+}
+
+#[test]
+fn empty_terminal_usage_preserves_provisional_usage_on_success_and_failure() {
+    for (subtype, is_error, result) in [
+        ("success", false, "done"),
+        ("error_during_execution", true, "provider failed"),
+    ] {
+        let mut bytes = Vec::new();
+        append_event(
+            &mut bytes,
+            assistant_usage("message-1", usage(23, 9, 17, 5)),
+        );
+        let mut terminal = json!({
+            "type":"result",
+            "subtype":subtype,
+            "is_error":is_error,
+            "session_id":"session-1",
+            "result":result,
+            "usage":{},
+            "modelUsage":null
+        });
+        if !is_error {
+            terminal
+                .as_object_mut()
+                .assert_value()
+                .insert("structured_output".to_owned(), json!({"response":result}));
+        }
+        append_event(&mut bytes, terminal);
+
+        let decoded = decode(&bytes, 29, None);
+        assert_eq!(usage_values(decoded.usage), [23, 9, 17, 5]);
+        if is_error {
+            assert_eq!(failed_attempt(decoded.attempt).diagnostic, result);
+        } else {
+            assert_eq!(completed_response(decoded.attempt), json!(result));
+        }
+    }
+}
+
+#[test]
+fn malformed_terminal_usage_does_not_reuse_provisional_usage() {
+    let mut bytes = Vec::new();
+    append_event(
+        &mut bytes,
+        assistant_usage("message-1", usage(23, 9, 17, 5)),
+    );
+    append_event(
+        &mut bytes,
+        json!({
+            "type":"result",
+            "subtype":"success",
+            "is_error":false,
+            "session_id":"session-1",
+            "result":"done",
+            "modelUsage":{"model-a":{"inputTokens":"many"}},
+            "usage":{"input_tokens":"many","output_tokens":7}
+        }),
+    );
+
+    assert!(decode(&bytes, 23, None).usage.is_none());
+}

--- a/zeroshot-rust/src/native_v2_claude/transcript/usage.rs
+++ b/zeroshot-rust/src/native_v2_claude/transcript/usage.rs
@@ -1,0 +1,274 @@
+use std::collections::BTreeMap;
+
+use openengine_cluster_protocol::TokenCount;
+use serde_json::Value;
+
+use crate::native_v2_contract::TokenUsageDelta;
+
+pub(super) fn message_identity(message: &serde_json::Map<String, Value>) -> Option<&str> {
+    message
+        .get("id")
+        .or_else(|| message.get("uuid"))
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+}
+
+#[derive(Clone, Copy, Default)]
+pub(super) struct UsageSnapshot {
+    input_tokens: Option<TokenCount>,
+    output_tokens: Option<TokenCount>,
+    cache_read_input_tokens: Option<TokenCount>,
+    cache_creation_input_tokens: Option<TokenCount>,
+}
+
+impl UsageSnapshot {
+    fn merge(&mut self, next: Self) {
+        if next.input_tokens.is_some() {
+            self.input_tokens = next.input_tokens;
+        }
+        if next.output_tokens.is_some() {
+            self.output_tokens = next.output_tokens;
+        }
+        if next.cache_read_input_tokens.is_some() {
+            self.cache_read_input_tokens = next.cache_read_input_tokens;
+        }
+        if next.cache_creation_input_tokens.is_some() {
+            self.cache_creation_input_tokens = next.cache_creation_input_tokens;
+        }
+    }
+
+    fn complete(self) -> Option<TokenUsageDelta> {
+        Some(TokenUsageDelta {
+            input_tokens: self.input_tokens?,
+            output_tokens: self.output_tokens?,
+            cache_read_input_tokens: self.cache_read_input_tokens,
+            cache_creation_input_tokens: self.cache_creation_input_tokens,
+        })
+    }
+
+    fn has_value(self) -> bool {
+        self.input_tokens.is_some()
+            || self.output_tokens.is_some()
+            || self.cache_read_input_tokens.is_some()
+            || self.cache_creation_input_tokens.is_some()
+    }
+}
+
+#[derive(Default)]
+pub(super) struct ProvisionalUsage {
+    messages: BTreeMap<String, UsageSnapshot>,
+    anonymous: Option<TokenUsageDelta>,
+    invalid: bool,
+}
+
+impl ProvisionalUsage {
+    pub(super) fn invalidate(&mut self) {
+        self.invalid = true;
+    }
+
+    pub(super) fn replace_message(&mut self, message_id: &str, usage: UsageSnapshot) {
+        self.messages.insert(message_id.to_owned(), usage);
+    }
+
+    pub(super) fn merge_message(&mut self, message_id: &str, usage: UsageSnapshot) {
+        self.messages
+            .entry(message_id.to_owned())
+            .or_default()
+            .merge(usage);
+    }
+
+    pub(super) fn add_anonymous(&mut self, usage: UsageSnapshot) {
+        if self.invalid {
+            return;
+        }
+        let Some(usage) = usage.complete() else {
+            self.invalid = true;
+            return;
+        };
+        self.anonymous = match self.anonymous {
+            Some(current) => match add_usage(current, usage) {
+                Some(total) => Some(total),
+                None => {
+                    self.invalid = true;
+                    None
+                }
+            },
+            None => Some(usage),
+        };
+    }
+
+    pub(super) fn total(&self) -> Option<TokenUsageDelta> {
+        if self.invalid {
+            return None;
+        }
+        let mut total = self.anonymous;
+        for usage in self.messages.values().copied() {
+            let usage = usage.complete()?;
+            total = Some(match total {
+                Some(current) => add_usage(current, usage)?,
+                None => usage,
+            });
+        }
+        total
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct UsageKeys {
+    input: UsageKey,
+    output: UsageKey,
+    cache_read: UsageKey,
+    cache_creation: UsageKey,
+}
+
+#[derive(Clone, Copy)]
+struct UsageKey {
+    primary: &'static str,
+    alternate: Option<&'static str>,
+}
+
+impl UsageKeys {
+    pub(super) const CLAUDE_STREAM: Self = Self {
+        input: UsageKey::single("input_tokens"),
+        output: UsageKey::single("output_tokens"),
+        cache_read: UsageKey::single("cache_read_input_tokens"),
+        cache_creation: UsageKey::single("cache_creation_input_tokens"),
+    };
+    const CLAUDE_MODEL: Self = Self {
+        input: UsageKey::aliased("inputTokens", "input_tokens"),
+        output: UsageKey::aliased("outputTokens", "output_tokens"),
+        cache_read: UsageKey::aliased("cacheReadInputTokens", "cache_read_input_tokens"),
+        cache_creation: UsageKey::aliased(
+            "cacheCreationInputTokens",
+            "cache_creation_input_tokens",
+        ),
+    };
+}
+
+pub(super) enum TerminalUsage {
+    Empty,
+    Valid(TokenUsageDelta),
+    Malformed,
+}
+
+pub(super) fn parse_terminal_usage(
+    camel_model_usage: Option<&Value>,
+    snake_model_usage: Option<&Value>,
+    usage: Option<&Value>,
+) -> TerminalUsage {
+    let model_usage = match aliased_value(camel_model_usage, snake_model_usage) {
+        Ok(value) => classify_usage(value, parse_model_usage),
+        Err(()) => TerminalUsage::Malformed,
+    };
+    match model_usage {
+        TerminalUsage::Empty => classify_usage(usage, |value| {
+            parse_usage_snapshot(value, UsageKeys::CLAUDE_MODEL)?.complete()
+        }),
+        terminal => terminal,
+    }
+}
+
+fn aliased_value<'a>(
+    primary: Option<&'a Value>,
+    alternate: Option<&'a Value>,
+) -> Result<Option<&'a Value>, ()> {
+    match (primary, alternate) {
+        (Some(primary), Some(alternate)) if primary != alternate => Err(()),
+        (Some(value), _) | (None, Some(value)) => Ok(Some(value)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn classify_usage(
+    value: Option<&Value>,
+    parse: impl FnOnce(Option<&Value>) -> Option<TokenUsageDelta>,
+) -> TerminalUsage {
+    match value {
+        None | Some(Value::Null) => TerminalUsage::Empty,
+        Some(Value::Object(object)) if object.is_empty() => TerminalUsage::Empty,
+        value => parse(value).map_or(TerminalUsage::Malformed, TerminalUsage::Valid),
+    }
+}
+
+impl UsageKey {
+    const fn single(primary: &'static str) -> Self {
+        Self {
+            primary,
+            alternate: None,
+        }
+    }
+
+    const fn aliased(primary: &'static str, alternate: &'static str) -> Self {
+        Self {
+            primary,
+            alternate: Some(alternate),
+        }
+    }
+}
+
+pub(super) fn parse_usage_snapshot(
+    value: Option<&Value>,
+    keys: UsageKeys,
+) -> Option<UsageSnapshot> {
+    let usage = value?.as_object()?;
+    let snapshot = UsageSnapshot {
+        input_tokens: optional_count(usage, keys.input)?,
+        output_tokens: optional_count(usage, keys.output)?,
+        cache_read_input_tokens: optional_count(usage, keys.cache_read)?,
+        cache_creation_input_tokens: optional_count(usage, keys.cache_creation)?,
+    };
+    snapshot.has_value().then_some(snapshot)
+}
+
+fn optional_count(
+    usage: &serde_json::Map<String, Value>,
+    key: UsageKey,
+) -> Option<Option<TokenCount>> {
+    let primary = usage.get(key.primary);
+    let alternate = key.alternate.and_then(|name| usage.get(name));
+    match (primary, alternate) {
+        (Some(primary), Some(alternate)) if primary != alternate => None,
+        (Some(value), _) | (None, Some(value)) => {
+            Some(Some(TokenCount::new(value.as_u64()?).ok()?))
+        }
+        (None, None) => Some(None),
+    }
+}
+
+fn parse_model_usage(value: Option<&Value>) -> Option<TokenUsageDelta> {
+    let models = value?.as_object()?;
+    let mut total = None;
+    for model in models.values() {
+        let usage = parse_usage_snapshot(Some(model), UsageKeys::CLAUDE_MODEL)?.complete()?;
+        total = Some(match total {
+            Some(current) => add_usage(current, usage)?,
+            None => usage,
+        });
+    }
+    total
+}
+
+fn add_usage(left: TokenUsageDelta, right: TokenUsageDelta) -> Option<TokenUsageDelta> {
+    Some(TokenUsageDelta {
+        input_tokens: left.input_tokens.checked_add(right.input_tokens)?,
+        output_tokens: left.output_tokens.checked_add(right.output_tokens)?,
+        cache_read_input_tokens: add_optional_tokens(
+            left.cache_read_input_tokens,
+            right.cache_read_input_tokens,
+        )?,
+        cache_creation_input_tokens: add_optional_tokens(
+            left.cache_creation_input_tokens,
+            right.cache_creation_input_tokens,
+        )?,
+    })
+}
+
+fn add_optional_tokens(
+    left: Option<TokenCount>,
+    right: Option<TokenCount>,
+) -> Option<Option<TokenCount>> {
+    match (left, right) {
+        (Some(left), Some(right)) => left.checked_add(right).map(Some),
+        _ => Some(None),
+    }
+}

--- a/zeroshot-rust/src/native_v2_claude/turn_process.rs
+++ b/zeroshot-rust/src/native_v2_claude/turn_process.rs
@@ -1,0 +1,188 @@
+use crate::execution::process::{
+    LocalProcessRunner, ProcessRunnerError, ProcessSession, ProcessSessionCommand,
+    ProcessSessionOutput,
+};
+use crate::native_v2_capsule::provider_process::{
+    ProcessExchange, ProcessInputFailure, exchange_process_io, open_provider_process,
+    process_failure_detail,
+};
+use crate::native_v2_runner::{DriverControl, NodeRunnerError};
+
+use super::transcript::ClaudeTranscript;
+use super::ClaudeAttempt;
+
+pub(super) enum ClaudeProcessStart {
+    Ready(ProcessSession),
+    Failed(ClaudeAttempt),
+}
+
+pub(super) fn failed_before_start(
+    error: ProcessRunnerError,
+    control: &DriverControl,
+) -> Result<ClaudeProcessStart, NodeRunnerError> {
+    if control.is_cancelled() {
+        return Err(NodeRunnerError::Cancelled);
+    }
+    Ok(ClaudeProcessStart::Failed(ClaudeAttempt::process_failure(
+        error.to_string(),
+    )))
+}
+
+pub(super) async fn open(
+    runner: LocalProcessRunner,
+    command: ProcessSessionCommand,
+    control: &DriverControl,
+) -> Result<ClaudeProcessStart, NodeRunnerError> {
+    let process = match open_provider_process(runner, command, control).await? {
+        Ok(process) => process,
+        Err(error) => return failed_before_start(error, control),
+    };
+    Ok(ClaudeProcessStart::Ready(process))
+}
+
+pub(super) async fn finish_process(
+    process: &mut ProcessSession,
+    prompt: &[u8],
+    mut transcript: ClaudeTranscript,
+    control: &DriverControl,
+) -> Result<ClaudeAttempt, NodeRunnerError> {
+    let stdout = process.detach_stdout();
+    let output = super::collect_transcript(stdout, &mut transcript, control);
+    match exchange_process_io(process, prompt, output).await {
+        ProcessExchange::Complete(Ok(())) => {
+            finish_process_completion(process, transcript, control).await
+        }
+        ProcessExchange::Complete(Err(error)) => {
+            finish_output_failure(process, transcript, control, error).await
+        }
+        ProcessExchange::InputFailure(failure) => {
+            finish_input_failure(transcript, failure, control).await
+        }
+    }
+}
+
+async fn finish_input_failure(
+    transcript: ClaudeTranscript,
+    failure: ProcessInputFailure<Result<(), NodeRunnerError>>,
+    control: &DriverControl,
+) -> Result<ClaudeAttempt, NodeRunnerError> {
+    let ProcessInputFailure {
+        output,
+        input_error,
+        completion,
+    } = failure;
+    let usage = control.record_token_usage(transcript.token_usage()).await;
+    if input_failure_cancelled(control, &output, &completion) {
+        return Err(NodeRunnerError::Cancelled);
+    }
+
+    let mut diagnostic = format!("provider process input failed: {input_error}");
+    if let Err(error) = output {
+        append_detail(
+            &mut diagnostic,
+            &format!("provider output delivery failed: {error}"),
+        );
+    }
+    append_completion_detail(&mut diagnostic, completion)?;
+    usage?;
+    transcript.finish(Some(&diagnostic))
+}
+
+fn input_failure_cancelled(
+    control: &DriverControl,
+    output: &Result<(), NodeRunnerError>,
+    completion: &Result<ProcessSessionOutput, ProcessRunnerError>,
+) -> bool {
+    control.is_cancelled()
+        || matches!(output, Err(NodeRunnerError::Cancelled))
+        || matches!(completion, Ok(output) if output.cancelled)
+}
+
+async fn finish_output_failure(
+    process: &mut ProcessSession,
+    transcript: ClaudeTranscript,
+    control: &DriverControl,
+    error: NodeRunnerError,
+) -> Result<ClaudeAttempt, NodeRunnerError> {
+    let token_usage = transcript.token_usage();
+    let attempt = release_failure(
+        process,
+        format!("provider output delivery failed: {error}"),
+        control,
+    )
+    .await;
+    let usage = control.record_token_usage(token_usage).await;
+    match attempt {
+        Err(NodeRunnerError::Cancelled) => Err(NodeRunnerError::Cancelled),
+        Err(error) => Err(error),
+        Ok(attempt) => {
+            usage?;
+            Ok(attempt)
+        }
+    }
+}
+
+async fn finish_process_completion(
+    process: &mut ProcessSession,
+    transcript: ClaudeTranscript,
+    control: &DriverControl,
+) -> Result<ClaudeAttempt, NodeRunnerError> {
+    let completion = process.wait().await;
+    let usage = control.record_token_usage(transcript.token_usage()).await;
+    let output = match completion {
+        Ok(output) => output,
+        Err(_) if control.is_cancelled() => return Err(NodeRunnerError::Cancelled),
+        Err(error) => {
+            usage?;
+            return transcript.finish(Some(&format!(
+                "provider process completion failed: {error}"
+            )));
+        }
+    };
+    let failure =
+        match process_failure_detail(&output, control.is_cancelled(), !transcript.is_success()) {
+            Err(NodeRunnerError::Cancelled) => return Err(NodeRunnerError::Cancelled),
+            result => result?,
+        };
+    usage?;
+    transcript.finish(failure.as_deref())
+}
+
+pub(super) async fn release_failure(
+    process: &mut ProcessSession,
+    mut diagnostic: String,
+    control: &DriverControl,
+) -> Result<ClaudeAttempt, NodeRunnerError> {
+    let completion = process.release().await;
+    if control.is_cancelled() {
+        return Err(NodeRunnerError::Cancelled);
+    }
+    append_completion_detail(&mut diagnostic, completion)?;
+    Ok(ClaudeAttempt::process_failure(diagnostic))
+}
+
+fn append_completion_detail(
+    diagnostic: &mut String,
+    completion: Result<ProcessSessionOutput, ProcessRunnerError>,
+) -> Result<(), NodeRunnerError> {
+    match completion {
+        Ok(output) => {
+            if let Some(detail) = process_failure_detail(&output, false, true)? {
+                append_detail(diagnostic, &detail);
+            }
+        }
+        Err(error) => append_detail(
+            diagnostic,
+            &format!("provider process cleanup failed: {error}"),
+        ),
+    }
+    Ok(())
+}
+
+fn append_detail(diagnostic: &mut String, detail: &str) {
+    let detail = detail.trim();
+    if !detail.is_empty() && detail != diagnostic.trim() {
+        diagnostic.push_str("; ");
+        diagnostic.push_str(detail);
+    }
+}

--- a/zeroshot-rust/src/native_v2_cli/tests/support.rs
+++ b/zeroshot-rust/src/native_v2_cli/tests/support.rs
@@ -399,6 +399,7 @@ impl NativeV2CliBackend for FakeBackend {
                     "subscriptionId":format!("logs-{attempt}"),
                     "runId":params.run_id,
                     "cursor":cursor,
+                    "timestamp":1_725_000_000_123_u64,
                     "record":{"level":"info","target":"agent","message":message}
                 }))
                 .assert_value(),

--- a/zeroshot-rust/src/native_v2_cloud/tests.rs
+++ b/zeroshot-rust/src/native_v2_cloud/tests.rs
@@ -112,7 +112,9 @@ impl NodeDriver for FakeDriver {
                 .collect(),
         );
         let _ = self.started.send(true);
-        control.emit(LiveOutput::new(LiveOutputStream::Output, "safe output")?)?;
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Output, "safe output")?)
+            .await?;
         match self.behavior {
             Behavior::Complete => Ok(fake_worker_outcome(&invocation)),
             Behavior::Hang => {

--- a/zeroshot-rust/src/native_v2_codex.rs
+++ b/zeroshot-rust/src/native_v2_codex.rs
@@ -6,6 +6,7 @@
 
 mod command;
 mod output;
+mod process;
 mod schema_file;
 #[path = "native_v2_codex/session.rs"]
 mod session;
@@ -19,14 +20,13 @@ use tokio::time::{Duration, Instant};
 
 use crate::execution::driver::WorkspaceCapability;
 use crate::execution::process::{
-    HostedProcessPool, LocalProcessRunner, ProcessFrame, ProcessSession, ProcessSessionCommand,
-    ProcessSessionOutput,
+    HostedProcessPool, LocalProcessRunner, ProcessRunnerError, ProcessSessionCommand,
 };
 use crate::native_v2_capsule::provider_process::{
     ClosedSessionFailure, ProviderFailure, ProviderFailureRetry, ProviderProcessRunners,
-    process_scope, redaction_values, validate_process_cleanup, validate_process_output,
+    process_scope, redaction_values, with_driver_detail,
 };
-use crate::native_v2_contract::{CodexProvider, NodeRuntimeBinding};
+use crate::native_v2_contract::CodexProvider;
 use crate::native_v2_runner::{
     AgentResponse, AgentResponseState, render_agent_prompt, resolve_agent_response_with_dialect,
     DriverControl, DriverInvocation, LiveOutput, LiveOutputStream, NodeRole, NodeRunnerError,
@@ -35,16 +35,16 @@ use crate::native_v2_runner::{
 
 use command::{
     add_local_execution_config, add_local_execution_policy, add_node_args, add_provider_args,
-    add_resume_command, add_session_target, configure_provider_auth, process_environment,
-    role_settings,
+    add_resume_command, add_session_target, agent_selection, configure_provider_auth,
+    process_environment, path_text, role_settings,
 };
-use output::{CodexOutput, CodexOutputDecoder};
+use output::CodexOutput;
+use process::{ProcessOpen, exchange_turn, open_process};
 use schema_file::CodexSchemaFile;
 use session::CodexSession;
-use turn::{CodexCommandInput, CodexTurnProcess};
+use turn::{CodexCommandInput, CodexTurnProcess, CodexTurnProcessOpen};
 
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(6 * 60 * 60);
-const MAX_CODEX_STDOUT_BYTES: usize = 8 * 1024 * 1024;
 
 /// Runtime capabilities required to launch Codex. None of these paths are durable run data.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -116,9 +116,11 @@ impl NativeV2CodexAdapter {
     fn turn_process(
         &self,
         invocation: &DriverInvocation,
-    ) -> Result<(LocalProcessRunner, PathBuf), NodeRunnerError> {
-        let scope = process_scope(invocation)?;
-        self.runners.turn_process(&self.config.runtime_home, scope)
+    ) -> Result<Result<(LocalProcessRunner, PathBuf), ProcessRunnerError>, NodeRunnerError> {
+        let scope = process_scope(invocation).map_err(|error| {
+            with_driver_detail(error, "Codex process scope requires an agent node role")
+        })?;
+        Ok(self.runners.turn_process(&self.config.runtime_home, scope))
     }
 
     fn command(
@@ -127,9 +129,15 @@ impl NativeV2CodexAdapter {
         input: CodexCommandInput<'_>,
     ) -> Result<ProcessSessionCommand, NodeRunnerError> {
         let invocation = turn.invocation;
-        let (model, effort) = agent_selection(&invocation.node.binding)?;
-        let (sandbox, access) = role_settings(invocation.role)?;
-        let executable = path_text(&self.config.executable)?;
+        let (model, effort) = agent_selection(&invocation.node.binding).map_err(|error| {
+            with_driver_detail(error, "Codex command requires an agent runtime binding")
+        })?;
+        let (sandbox, access) = role_settings(invocation.role).map_err(|error| {
+            with_driver_detail(error, "Codex workspace policy rejected the node role")
+        })?;
+        let executable = path_text(&self.config.executable).map_err(|error| {
+            with_driver_detail(error, "Codex executable path is not valid on this platform")
+        })?;
         let workspace = self.config.workspace.clone();
         let mut argv = vec!["exec".to_owned()];
         self.add_execution_policy(&mut argv, sandbox);
@@ -137,13 +145,25 @@ impl NativeV2CodexAdapter {
         add_provider_args(&mut argv, self.config.provider);
         self.add_execution_config(&mut argv, invocation.role);
         add_node_args(&mut argv, model.as_str(), effort.copied());
-        argv.extend(["--output-schema".to_owned(), path_text(input.schema_path)?]);
+        argv.extend([
+            "--output-schema".to_owned(),
+            path_text(input.schema_path).map_err(|error| {
+                with_driver_detail(
+                    error,
+                    "Codex response schema path is not valid on this platform",
+                )
+            })?,
+        ]);
         add_session_target(&mut argv, input.resume);
 
         Ok(ProcessSessionCommand {
             program: executable,
             argv,
-            environment: self.provider_environment(&invocation.environment, input.runtime_home)?,
+            environment: self
+                .provider_environment(&invocation.environment, input.runtime_home)
+                .map_err(|error| {
+                    with_driver_detail(error, "Codex provider environment is invalid")
+                })?,
             workspace: WorkspaceCapability {
                 current_dir: workspace,
                 mode: access,
@@ -158,9 +178,21 @@ impl NativeV2CodexAdapter {
         runtime_home: &Path,
     ) -> Result<BTreeMap<String, String>, NodeRunnerError> {
         let (home, codex_home) = match &self.config.local_user {
-            Some(local) => (path_text(&local.home)?, path_text(&local.codex_home)?),
+            Some(local) => (
+                path_text(&local.home).map_err(|error| {
+                    with_driver_detail(error, "Codex user home is not a valid platform path")
+                })?,
+                path_text(&local.codex_home).map_err(|error| {
+                    with_driver_detail(
+                        error,
+                        "Codex configuration home is not a valid platform path",
+                    )
+                })?,
+            ),
             None => {
-                let runtime_home = path_text(runtime_home)?;
+                let runtime_home = path_text(runtime_home).map_err(|error| {
+                    with_driver_detail(error, "Codex runtime home is not a valid platform path")
+                })?;
                 (runtime_home.clone(), runtime_home)
             }
         };
@@ -169,17 +201,31 @@ impl NativeV2CodexAdapter {
             home,
             codex_home,
             self.config.search_path.clone(),
-        )?;
+        )
+        .map_err(|error| {
+            with_driver_detail(
+                error,
+                "Codex declared environment conflicts with reserved runtime configuration",
+            )
+        })?;
         for provider_control in ["CODEX_BASE_URL", "OPENAI_BASE_URL", "OPENAI_API_BASE"] {
             if values.contains_key(provider_control) {
-                return Err(NodeRunnerError::Driver);
+                return Err(NodeRunnerError::DriverDetail(format!(
+                    "Codex declared environment contains provider-owned variable {provider_control}"
+                )));
             }
         }
         configure_provider_auth(
             &mut values,
             self.config.provider,
             self.config.local_user.is_some(),
-        )?;
+        )
+        .map_err(|error| {
+            with_driver_detail(
+                error,
+                "Codex provider credentials are missing or conflict with reserved credentials",
+            )
+        })?;
         Ok(values)
     }
 
@@ -200,7 +246,8 @@ impl NativeV2CodexAdapter {
             invocation.agent_instructions()?,
             &invocation.node.input,
             &invocation.response,
-        )?;
+        )
+        .map_err(|error| with_driver_detail(error, "Codex prompt could not be serialized"))?;
         let mut state = CodexRunState::new(invocation, prompt);
         loop {
             if let Some(outcome) = self.advance_run(&turn, &mut state).await? {
@@ -215,13 +262,17 @@ impl NativeV2CodexAdapter {
         state: &mut CodexRunState,
     ) -> Result<Option<WorkerOutcome>, NodeRunnerError> {
         match self.advance_turn(turn, state.response.prompt()).await {
-            Ok(CodexTurnAdvance::Response(response)) => state.accept_response(turn, response),
+            Ok(CodexTurnAdvance::Response(response)) => state.accept_response(turn, response).await,
             Ok(CodexTurnAdvance::ProviderFailure(detail)) => {
                 state.retry_provider_failure(turn, Some(&detail)).await?;
                 Ok(None)
             }
             Err(NodeRunnerError::Driver) => {
                 state.retry_provider_failure(turn, None).await?;
+                Ok(None)
+            }
+            Err(NodeRunnerError::DriverDetail(detail)) => {
+                state.retry_provider_failure(turn, Some(&detail)).await?;
                 Ok(None)
             }
             Err(error) => Err(error),
@@ -238,8 +289,14 @@ impl NativeV2CodexAdapter {
             .ensure_live(ClosedSessionFailure::Driver)?;
         let resume = turn.session.thread_id.lock().await.clone();
         let output = self.execute_turn(turn, resume.as_deref(), prompt).await?;
-        record_attempt_thread(turn.session, &output, resume.as_deref()).await?;
-        resolve_codex_output(turn, output)
+        if let Err(detail) = turn
+            .session
+            .record_attempt_thread(&output, resume.as_deref())
+            .await
+        {
+            return Ok(CodexTurnAdvance::ProviderFailure(detail.to_owned()));
+        }
+        resolve_codex_output(turn, output).await
     }
 
     async fn execute_turn(
@@ -248,36 +305,42 @@ impl NativeV2CodexAdapter {
         resume: Option<&str>,
         prompt: &str,
     ) -> Result<CodexOutput, NodeRunnerError> {
-        let mut turn_process = self.open_turn_process(turn, resume, prompt).await?;
+        let mut turn_process = match self.open_turn_process(turn, resume).await? {
+            CodexTurnProcessOpen::Ready(process) => process,
+            CodexTurnProcessOpen::ProviderFailure(detail) => {
+                return Ok(CodexOutput::provider_failure(detail));
+            }
+        };
         let redactions =
             redaction_values(turn.invocation.environment.iter().map(|(_, value)| value));
-        let output = collect_output(&mut turn_process.process, turn.control, &redactions).await;
-        let completion = finish_process(&mut turn_process.process, output.is_ok()).await;
-        turn.control
-            .record_token_usage(output.as_ref().ok().and_then(CodexOutput::token_usage))?;
-        let completion = completion?;
-        validate_process_cleanup(&completion, turn.control)?;
-        let output = output?;
-        if output.failure_message().is_none() {
-            validate_process_output(&completion, turn.control)?;
-        }
-        Ok(output)
+        exchange_turn(&mut turn_process.process, prompt, turn.control, &redactions).await
     }
 
     async fn open_turn_process(
         &self,
         turn: &CodexTurn<'_>,
         resume: Option<&str>,
-        prompt: &str,
-    ) -> Result<CodexTurnProcess, NodeRunnerError> {
-        let (runner, runtime_home) = self.turn_process(turn.invocation)?;
-        let schema = CodexSchemaFile::create(
+    ) -> Result<CodexTurnProcessOpen, NodeRunnerError> {
+        let (runner, runtime_home) = match self.turn_process(turn.invocation)? {
+            Ok(resources) => resources,
+            Err(error) => {
+                return Ok(CodexTurnProcessOpen::ProviderFailure(format!(
+                    "provider process setup failed: {error}"
+                )));
+            }
+        };
+        let schema = match CodexSchemaFile::create(
             &runtime_home,
             &turn
                 .invocation
                 .response
                 .provider_schema(ProviderSchemaDialect::OpenAiStrict),
-        )?;
+        ) {
+            Ok(schema) => schema,
+            Err(error) => {
+                return Ok(CodexTurnProcessOpen::ProviderFailure(error.to_string()));
+            }
+        };
         let command = self.command(
             turn,
             CodexCommandInput {
@@ -286,30 +349,16 @@ impl NativeV2CodexAdapter {
                 schema_path: schema.path(),
             },
         )?;
-        let prompt =
-            ProcessFrame::new(prompt.as_bytes().to_vec()).map_err(|_| NodeRunnerError::Driver)?;
-        let process = Self::open_process(runner, command, prompt, turn.control).await?;
-        Ok(CodexTurnProcess {
+        let process = match open_process(runner, command, turn.control).await? {
+            ProcessOpen::Ready(process) => process,
+            ProcessOpen::ProviderFailure(detail) => {
+                return Ok(CodexTurnProcessOpen::ProviderFailure(detail));
+            }
+        };
+        Ok(CodexTurnProcessOpen::Ready(CodexTurnProcess {
             process,
             _schema: schema,
-        })
-    }
-
-    async fn open_process(
-        runner: LocalProcessRunner,
-        command: ProcessSessionCommand,
-        prompt: ProcessFrame,
-        control: &DriverControl,
-    ) -> Result<ProcessSession, NodeRunnerError> {
-        let mut process = runner
-            .open(command, control.cancellation())
-            .await
-            .map_err(|_| NodeRunnerError::Driver)?;
-        if process.send(prompt).await.is_err() || process.close_stdin().await.is_err() {
-            let _ = process.release().await;
-            return Err(NodeRunnerError::Driver);
-        }
-        Ok(process)
+        }))
     }
 }
 
@@ -334,12 +383,12 @@ impl CodexRunState {
         }
     }
 
-    fn accept_response(
+    async fn accept_response(
         &mut self,
         turn: &CodexTurn<'_>,
         response: AgentResponse,
     ) -> Result<Option<WorkerOutcome>, NodeRunnerError> {
-        self.response.accept("Codex", turn.control, response)
+        self.response.accept("Codex", turn.control, response).await
     }
 
     async fn retry_provider_failure(
@@ -348,15 +397,18 @@ impl CodexRunState {
         detail: Option<&str>,
     ) -> Result<(), NodeRunnerError> {
         let has_session = turn.session.thread_id.lock().await.is_some();
-        let prompt = self.retry.after_failure(
-            turn.control,
-            ProviderFailure {
-                detail,
-                retryable: true,
-                has_session,
-                deadline: turn.deadline,
-            },
-        )?;
+        let prompt = self
+            .retry
+            .after_failure(
+                turn.control,
+                ProviderFailure {
+                    detail,
+                    retryable: true,
+                    has_session,
+                    deadline: turn.deadline,
+                },
+            )
+            .await?;
         self.response.replace_prompt(prompt);
         Ok(())
     }
@@ -367,20 +419,7 @@ enum CodexTurnAdvance {
     ProviderFailure(String),
 }
 
-async fn record_attempt_thread(
-    session: &CodexSession,
-    output: &CodexOutput,
-    resumed: Option<&str>,
-) -> Result<(), NodeRunnerError> {
-    if output.thread_id.is_none() && resumed.is_none() {
-        return Ok(());
-    }
-    session
-        .record_thread(output.thread_id.as_deref(), resumed)
-        .await
-}
-
-fn resolve_codex_output(
+async fn resolve_codex_output(
     turn: &CodexTurn<'_>,
     output: CodexOutput,
 ) -> Result<CodexTurnAdvance, NodeRunnerError> {
@@ -392,104 +431,22 @@ fn resolve_codex_output(
         output.final_message()?,
         ProviderSchemaDialect::OpenAiStrict,
     )?;
+    if let Some(diagnostic) = turn
+        .session
+        .missing_required_thread(turn.invocation, &response)
+        .await
+    {
+        return Ok(CodexTurnAdvance::ProviderFailure(diagnostic.to_owned()));
+    }
     if matches!(response, AgentResponse::Correction(_)) {
-        turn.control.emit(LiveOutput::new(
-            LiveOutputStream::System,
-            "Codex final output rejected; requesting correction",
-        )?)?;
+        turn.control
+            .emit(LiveOutput::new(
+                LiveOutputStream::System,
+                "Codex final output rejected; requesting correction",
+            )?)
+            .await?;
     }
     Ok(CodexTurnAdvance::Response(response))
-}
-
-async fn collect_output(
-    process: &mut ProcessSession,
-    control: &DriverControl,
-    redactions: &[String],
-) -> Result<CodexOutput, NodeRunnerError> {
-    let mut decoder = CodexOutputDecoder::new();
-    let mut total = 0usize;
-    while let Some(chunk) = process.recv_stdout().await {
-        total = total
-            .checked_add(chunk.as_slice().len())
-            .ok_or(NodeRunnerError::Driver)?;
-        if total > MAX_CODEX_STDOUT_BYTES {
-            return Err(NodeRunnerError::Driver);
-        }
-        for emission in decoder.push(chunk.as_slice())? {
-            let (stream, message) = emission.log();
-            emit_text(control, stream, message, redactions)?;
-        }
-    }
-    decoder.finish()
-}
-
-async fn finish_process(
-    process: &mut ProcessSession,
-    output_complete: bool,
-) -> Result<ProcessSessionOutput, NodeRunnerError> {
-    let completion = if output_complete {
-        process.wait().await
-    } else {
-        process.release().await
-    };
-    completion.map_err(|_| NodeRunnerError::Driver)
-}
-
-fn emit_text(
-    control: &DriverControl,
-    stream: LiveOutputStream,
-    text: &str,
-    redactions: &[String],
-) -> Result<(), NodeRunnerError> {
-    let safe = redact_text(text, redactions);
-    let mut rest = safe.as_str();
-    while !rest.is_empty() {
-        let split = if rest.len() <= 8 * 1024 {
-            rest.len()
-        } else {
-            rest.char_indices()
-                .map(|(index, _)| index)
-                .take_while(|index| *index <= 8 * 1024)
-                .last()
-                .filter(|index| *index > 0)
-                .ok_or(NodeRunnerError::UnsafeOutput)?
-        };
-        let (part, tail) = rest.split_at(split);
-        control.emit(LiveOutput::new(stream, part)?)?;
-        rest = tail;
-    }
-    if text.is_empty() {
-        control.emit(LiveOutput::new(stream, "")?)?;
-    }
-    Ok(())
-}
-
-fn agent_selection(
-    binding: &NodeRuntimeBinding,
-) -> Result<
-    (
-        &crate::worker_catalog::ModelId,
-        Option<&crate::worker_catalog::ReasoningEffort>,
-    ),
-    NodeRunnerError,
-> {
-    let NodeRuntimeBinding::Agent { model, effort, .. } = binding else {
-        return Err(NodeRunnerError::Driver);
-    };
-    Ok((model, effort.as_ref()))
-}
-
-fn redact_text(text: &str, redactions: &[String]) -> String {
-    redactions.iter().fold(text.to_owned(), |safe, value| {
-        safe.replace(value, "[REDACTED]")
-    })
-}
-
-fn path_text(path: &Path) -> Result<String, NodeRunnerError> {
-    path.to_str()
-        .filter(|value| !value.is_empty())
-        .map(str::to_owned)
-        .ok_or(NodeRunnerError::Driver)
 }
 
 #[cfg(test)]

--- a/zeroshot-rust/src/native_v2_codex/command.rs
+++ b/zeroshot-rust/src/native_v2_codex/command.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use crate::execution::WorkspaceAccessMode;
 use crate::native_v2_capsule::provider_process::effort_token;
-use crate::native_v2_contract::CodexProvider;
+use crate::native_v2_contract::{CodexProvider, NodeRuntimeBinding};
 use crate::native_v2_runner::{NodeRole, NodeRunnerError, ResolvedEnvironment};
-use crate::worker_catalog::ReasoningEffort;
+use crate::worker_catalog::{ModelId, ReasoningEffort};
 
 const CODEX_HOME: &str = "CODEX_HOME";
 const CODEX_API_KEY: &str = "CODEX_API_KEY";
@@ -138,4 +139,20 @@ pub(super) fn role_settings(
         NodeRole::Verifier => Ok(("read-only", WorkspaceAccessMode::ReadOnly)),
         NodeRole::GitDelivery => Err(NodeRunnerError::Driver),
     }
+}
+
+pub(super) fn path_text(path: &Path) -> Result<String, NodeRunnerError> {
+    path.to_str()
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .ok_or(NodeRunnerError::Driver)
+}
+
+pub(super) fn agent_selection(
+    binding: &NodeRuntimeBinding,
+) -> Result<(&ModelId, Option<&ReasoningEffort>), NodeRunnerError> {
+    let NodeRuntimeBinding::Agent { model, effort, .. } = binding else {
+        return Err(NodeRunnerError::Driver);
+    };
+    Ok((model, effort.as_ref()))
 }

--- a/zeroshot-rust/src/native_v2_codex/output.rs
+++ b/zeroshot-rust/src/native_v2_codex/output.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 
+use crate::native_v2_capsule::provider_json_lines::{ProviderJsonLine, ProviderJsonLines};
 use crate::native_v2_contract::{TokenUsageDelta, parse_token_usage_delta};
 use crate::native_v2_runner::{LiveOutputStream, NodeRunnerError};
 
@@ -19,76 +20,191 @@ impl CodexEmission {
 
 pub(super) struct CodexOutput {
     pub(super) thread_id: Option<String>,
-    pub(super) messages: Vec<String>,
-    completed: bool,
+    thread_failure: Option<String>,
+    final_message: Option<String>,
+    terminal: Option<CodexTerminal>,
     failure: Option<String>,
     token_usage: Option<TokenUsageDelta>,
+    malformed_records: usize,
+    oversized_records: usize,
 }
 
 pub(super) struct CodexOutputDecoder {
-    pending: Vec<u8>,
+    lines: ProviderJsonLines,
     output: CodexOutput,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CodexTerminal {
+    Completed,
+    Failed,
+}
+
+enum TerminalUsage {
+    Empty,
+    Valid(TokenUsageDelta),
+    Malformed,
+}
+
+enum AcceptedLine {
+    Emission(CodexEmission),
+    Ignored,
+    Malformed,
+    ThreadFailure(String),
 }
 
 impl CodexOutputDecoder {
     pub(super) fn new() -> Self {
         Self {
-            pending: Vec::new(),
+            lines: ProviderJsonLines::new(),
             output: CodexOutput::empty(),
         }
     }
 
-    pub(super) fn push(&mut self, bytes: &[u8]) -> Result<Vec<CodexEmission>, NodeRunnerError> {
-        self.pending.extend_from_slice(bytes);
+    pub(super) fn push(&mut self, bytes: &[u8]) -> Vec<CodexEmission> {
+        if self.output.is_settled() {
+            self.lines.discard();
+            return Vec::new();
+        }
         let mut emitted = Vec::new();
-        while let Some(line) = take_complete_line(&mut self.pending) {
-            if let Some(message) = self.output.accept_bytes(&line)? {
-                emitted.push(message);
+        for line in self.lines.push(bytes) {
+            if self.output.is_settled() {
+                break;
+            }
+            if let Some(emission) = self.accept_line(line) {
+                emitted.push(emission);
             }
         }
-        Ok(emitted)
-    }
-
-    pub(super) fn finish(mut self) -> Result<CodexOutput, NodeRunnerError> {
-        if !self.pending.is_empty() {
-            self.output.accept_bytes(&self.pending)?;
+        if self.output.is_settled() {
+            self.lines.discard();
         }
-        self.output.validate()?;
-        Ok(self.output)
+        emitted
     }
-}
 
-fn take_complete_line(pending: &mut Vec<u8>) -> Option<Vec<u8>> {
-    let newline = pending.iter().position(|byte| *byte == b'\n')?;
-    let remainder = pending.split_off(newline + 1);
-    let mut line = std::mem::replace(pending, remainder);
-    line.pop();
-    Some(line)
+    pub(super) fn finish(mut self) -> CodexOutput {
+        if self.output.is_settled() {
+            self.lines.discard();
+        } else if let Some(line) = self.lines.finish() {
+            self.accept_line(line);
+        }
+        self.output.finalize();
+        self.output
+    }
+
+    fn accept_line(&mut self, line: ProviderJsonLine) -> Option<CodexEmission> {
+        match line {
+            ProviderJsonLine::Oversized => {
+                self.output.oversized_records = self.output.oversized_records.saturating_add(1);
+                None
+            }
+            ProviderJsonLine::Record(line) => match self.output.accept_bytes(&line) {
+                AcceptedLine::Emission(emission) => Some(emission),
+                AcceptedLine::Ignored => None,
+                AcceptedLine::Malformed => {
+                    self.output.malformed_records = self.output.malformed_records.saturating_add(1);
+                    None
+                }
+                AcceptedLine::ThreadFailure(detail) => {
+                    if self.output.thread_failure.is_none() {
+                        self.output.thread_failure = Some(detail);
+                    }
+                    None
+                }
+            },
+        }
+    }
 }
 
 impl CodexOutput {
     #[cfg(test)]
-    pub(super) fn parse(bytes: &[u8]) -> Result<Self, NodeRunnerError> {
+    pub(super) fn parse(bytes: &[u8]) -> Self {
         let mut decoder = CodexOutputDecoder::new();
-        decoder.push(bytes)?;
+        decoder.push(bytes);
         decoder.finish()
     }
 
     fn empty() -> Self {
         Self {
             thread_id: None,
-            messages: Vec::new(),
-            completed: false,
+            thread_failure: None,
+            final_message: None,
+            terminal: None,
             failure: None,
             token_usage: None,
+            malformed_records: 0,
+            oversized_records: 0,
         }
     }
 
-    fn validate(&self) -> Result<(), NodeRunnerError> {
-        if self.completed == self.failure.is_some() || self.completed && self.messages.is_empty() {
-            return Err(NodeRunnerError::Driver);
+    pub(super) fn provider_failure(detail: String) -> Self {
+        let mut output = Self::empty();
+        output.merge_failure_detail(detail);
+        output
+    }
+
+    fn is_settled(&self) -> bool {
+        self.terminal.is_some()
+    }
+
+    fn finalize(&mut self) {
+        self.finalize_terminal();
+        self.prepend_thread_failure();
+    }
+
+    fn finalize_terminal(&mut self) {
+        match self.terminal {
+            Some(CodexTerminal::Completed) if self.final_message.is_none() => {
+                self.failure = Some(
+                    self.incomplete_detail("Codex turn completed without a final agent message"),
+                );
+            }
+            Some(CodexTerminal::Completed) => self.failure = None,
+            Some(CodexTerminal::Failed) => {
+                if self.failure.is_none() {
+                    self.failure =
+                        Some(self.incomplete_detail("Codex turn failed without provider detail"));
+                }
+            }
+            None => {
+                if self.failure.is_none() {
+                    self.failure = Some(
+                        self.incomplete_detail("Codex output ended without a terminal turn event"),
+                    );
+                }
+            }
         }
-        Ok(())
+    }
+
+    fn prepend_thread_failure(&mut self) {
+        if let Some(thread_failure) = self.thread_failure.take() {
+            self.failure = Some(match self.failure.take() {
+                Some(failure) if failure == thread_failure => thread_failure,
+                Some(failure) => format!("{thread_failure}; {failure}"),
+                None => thread_failure,
+            });
+        }
+    }
+
+    fn incomplete_detail(&self, message: &str) -> String {
+        match (self.malformed_records, self.oversized_records) {
+            (0, 0) => message.to_owned(),
+            (malformed, oversized) => format!(
+                "{message}; ignored {malformed} malformed and {oversized} oversized output records"
+            ),
+        }
+    }
+
+    pub(super) fn merge_failure_detail(&mut self, detail: String) {
+        let detail = detail.trim();
+        if detail.is_empty() {
+            return;
+        }
+        self.failure = Some(match self.failure.take() {
+            Some(existing) if existing == detail => existing,
+            Some(existing) => format!("{existing}; {detail}"),
+            None => detail.to_owned(),
+        });
+        self.terminal = Some(CodexTerminal::Failed);
     }
 
     pub(super) fn failure_message(&self) -> Option<&str> {
@@ -100,24 +216,24 @@ impl CodexOutput {
     }
 
     pub(super) fn final_message(&self) -> Result<&str, NodeRunnerError> {
-        self.messages
-            .last()
-            .map(String::as_str)
-            .ok_or(NodeRunnerError::Driver)
+        self.final_message.as_deref().ok_or(NodeRunnerError::Driver)
     }
 
-    fn accept_bytes(&mut self, line: &[u8]) -> Result<Option<CodexEmission>, NodeRunnerError> {
-        let line = std::str::from_utf8(line).map_err(|_| NodeRunnerError::Driver)?;
+    fn accept_bytes(&mut self, line: &[u8]) -> AcceptedLine {
+        let Ok(line) = std::str::from_utf8(line) else {
+            return AcceptedLine::Malformed;
+        };
         if line.trim().is_empty() {
-            return Ok(None);
+            return AcceptedLine::Ignored;
         }
-        let event: Value = serde_json::from_str(line).map_err(|_| NodeRunnerError::Driver)?;
-        let event_type = event
-            .get("type")
-            .and_then(Value::as_str)
-            .ok_or(NodeRunnerError::Driver)?;
+        let Ok(event) = serde_json::from_str::<Value>(line) else {
+            return AcceptedLine::Malformed;
+        };
+        let Some(event_type) = event.get("type").and_then(Value::as_str) else {
+            return AcceptedLine::Malformed;
+        };
         if event_type == "thread.started" {
-            return self.accept_thread(&event).map(|()| None);
+            return self.accept_thread(&event);
         }
         if matches!(
             event_type,
@@ -128,96 +244,128 @@ impl CodexOutput {
         self.accept_turn_event(&event, event_type)
     }
 
-    fn accept_turn_event(
-        &mut self,
-        event: &Value,
-        event_type: &str,
-    ) -> Result<Option<CodexEmission>, NodeRunnerError> {
+    fn accept_turn_event(&mut self, event: &Value, event_type: &str) -> AcceptedLine {
+        if self.is_settled() {
+            return AcceptedLine::Ignored;
+        }
         let message = match event_type {
             "turn.started" => "Codex turn started",
             "turn.completed" => {
-                self.completed = true;
-                self.token_usage =
-                    parse_token_usage_delta(event.get("usage"), Some("cached_input_tokens"), None);
+                self.terminal = Some(CodexTerminal::Completed);
+                self.failure = None;
+                self.record_terminal_usage(event);
                 "Codex turn completed"
             }
-            "turn.failed" | "error" => {
-                self.token_usage =
-                    parse_token_usage_delta(event.get("usage"), Some("cached_input_tokens"), None);
-                self.record_failure(event, event_type);
+            "turn.failed" => {
+                self.terminal = Some(CodexTerminal::Failed);
+                self.record_terminal_usage(event);
+                if let Some(detail) = failure_detail(event, event_type) {
+                    self.failure = Some(detail);
+                }
                 "Codex turn failed"
             }
-            _ => return Ok(None),
+            "error" => {
+                if event.get("usage").is_some() {
+                    self.token_usage = token_usage(event.get("usage"));
+                }
+                self.failure = failure_detail(event, event_type)
+                    .or_else(|| Some("Codex stream error without provider detail".to_owned()));
+                "Codex stream error"
+            }
+            _ => return AcceptedLine::Ignored,
         };
-        Ok(Some(CodexEmission::Progress(message.to_owned())))
+        AcceptedLine::Emission(CodexEmission::Progress(message.to_owned()))
     }
 
-    fn record_failure(&mut self, event: &Value, event_type: &str) {
-        if self.failure.is_some() {
-            return;
+    fn record_terminal_usage(&mut self, event: &Value) {
+        match terminal_usage(event) {
+            TerminalUsage::Empty => {}
+            TerminalUsage::Valid(usage) => self.token_usage = Some(usage),
+            TerminalUsage::Malformed => self.token_usage = None,
         }
-        let detail = if event_type == "turn.failed" {
+    }
+
+    fn accept_thread(&mut self, event: &Value) -> AcceptedLine {
+        let Some(thread_id) = event
+            .get("thread_id")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            return AcceptedLine::Malformed;
+        };
+        match self.thread_id.as_deref() {
+            Some(current) if current != thread_id => AcceptedLine::ThreadFailure(
+                "Codex output contained conflicting thread IDs".to_owned(),
+            ),
+            Some(_) => AcceptedLine::Ignored,
+            None => {
+                self.thread_id = Some(thread_id.to_owned());
+                AcceptedLine::Ignored
+            }
+        }
+    }
+
+    fn accept_item(&mut self, event: &Value, event_type: &str) -> AcceptedLine {
+        let Some(item) = event.get("item") else {
+            return AcceptedLine::Malformed;
+        };
+        let Some(item_type) = item.get("type").and_then(Value::as_str) else {
+            return AcceptedLine::Malformed;
+        };
+        let Some(phase) = event_type.strip_prefix("item.") else {
+            return AcceptedLine::Malformed;
+        };
+        match item_type {
+            "agent_message" if event_type == "item.completed" => {
+                let Some(message) = item.get("text").and_then(Value::as_str) else {
+                    return AcceptedLine::Malformed;
+                };
+                self.final_message = Some(message.to_owned());
+                AcceptedLine::Emission(CodexEmission::AgentMessage(message.to_owned()))
+            }
+            "agent_message" => AcceptedLine::Ignored,
+            _ => AcceptedLine::Emission(CodexEmission::Progress(semantic_item(
+                item, item_type, phase,
+            ))),
+        }
+    }
+}
+
+fn token_usage(value: Option<&Value>) -> Option<TokenUsageDelta> {
+    parse_token_usage_delta(
+        value,
+        Some("cached_input_tokens"),
+        Some("cache_write_input_tokens"),
+    )
+}
+
+fn terminal_usage(event: &Value) -> TerminalUsage {
+    match event.get("usage") {
+        None | Some(Value::Null) => TerminalUsage::Empty,
+        Some(Value::Object(usage)) if usage.is_empty() => TerminalUsage::Empty,
+        value => token_usage(value).map_or(TerminalUsage::Malformed, TerminalUsage::Valid),
+    }
+}
+
+fn failure_detail(event: &Value, event_type: &str) -> Option<String> {
+    let detail = if event_type == "turn.failed" {
+        event.get("error").and_then(|error| {
+            error
+                .get("message")
+                .and_then(Value::as_str)
+                .or_else(|| error.as_str())
+        })
+    } else {
+        event.get("message").and_then(Value::as_str).or_else(|| {
             event
                 .get("error")
                 .and_then(|error| error.get("message"))
                 .and_then(Value::as_str)
-        } else {
-            event.get("message").and_then(Value::as_str)
-        };
-        self.failure = Some(
-            detail
-                .filter(|message| !message.trim().is_empty())
-                .unwrap_or("Codex turn failed without provider detail")
-                .to_owned(),
-        );
-    }
-
-    fn accept_thread(&mut self, event: &Value) -> Result<(), NodeRunnerError> {
-        let thread_id = event
-            .get("thread_id")
-            .and_then(Value::as_str)
-            .filter(|value| !value.is_empty())
-            .ok_or(NodeRunnerError::Driver)?;
-        match self.thread_id.as_deref() {
-            Some(current) if current != thread_id => Err(NodeRunnerError::Driver),
-            Some(_) => Ok(()),
-            None => {
-                self.thread_id = Some(thread_id.to_owned());
-                Ok(())
-            }
-        }
-    }
-
-    fn accept_item(
-        &mut self,
-        event: &Value,
-        event_type: &str,
-    ) -> Result<Option<CodexEmission>, NodeRunnerError> {
-        let Some(item) = event.get("item") else {
-            return Err(NodeRunnerError::Driver);
-        };
-        let item_type = item
-            .get("type")
-            .and_then(Value::as_str)
-            .ok_or(NodeRunnerError::Driver)?;
-        let phase = event_type
-            .strip_prefix("item.")
-            .ok_or(NodeRunnerError::Driver)?;
-        match item_type {
-            "agent_message" if event_type == "item.completed" => {
-                let message = item
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .ok_or(NodeRunnerError::Driver)?;
-                self.messages.push(message.to_owned());
-                Ok(Some(CodexEmission::AgentMessage(message.to_owned())))
-            }
-            "agent_message" => Ok(None),
-            _ => Ok(Some(CodexEmission::Progress(semantic_item(
-                item, item_type, phase,
-            )))),
-        }
-    }
+        })
+    };
+    detail
+        .filter(|message| !message.trim().is_empty())
+        .map(str::to_owned)
 }
 
 fn semantic_item(item: &Value, item_type: &str, phase: &str) -> String {
@@ -348,116 +496,5 @@ fn semantic_todo_list(item: &Value, phase: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use openengine_cluster_testkit::assertions::AssertValue;
-    use serde_json::json;
-
-    use super::*;
-
-    #[test]
-    fn normalizes_worker_and_verifier_messages() {
-        let worker = CodexOutput::parse(
-            br#"{"type":"thread.started","thread_id":"thread-1"}
-{"type":"item.completed","item":{"type":"agent_message","text":"{\"answer\":42}"}}
-{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":1,"output_tokens":2}}
-"#,
-        )
-        .assert_value();
-        assert_eq!(worker.final_message().assert_value(), r#"{"answer":42}"#);
-        let usage = worker.token_usage().assert_value();
-        assert_eq!(usage.input_tokens.get(), 1);
-        assert_eq!(usage.output_tokens.get(), 2);
-        assert_eq!(usage.cache_read_input_tokens.assert_value().get(), 1);
-        assert!(usage.cache_creation_input_tokens.is_none());
-
-        let verifier_events = concat!(
-            "{\"type\":\"thread.started\",\"thread_id\":\"thread-2\"}\n",
-            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",",
-            "\"text\":\"{\\\"output\\\":{\\\"ok\\\":true},",
-            "\\\"signals\\\":{\\\"decision\\\":\\\"pass\\\"},",
-            "\\\"diagnostic\\\":null}\"}}\n",
-            "{\"type\":\"turn.completed\"}\n",
-        );
-        let verifier = CodexOutput::parse(verifier_events.as_bytes()).assert_value();
-        assert_eq!(
-            serde_json::from_str::<Value>(verifier.final_message().assert_value()).assert_value(),
-            json!({
-                "output": { "ok": true },
-                "signals": { "decision": "pass" },
-                "diagnostic": null
-            })
-        );
-    }
-
-    #[test]
-    fn malformed_terminal_usage_is_unavailable_without_rejecting_the_turn() {
-        let output = CodexOutput::parse(
-            br#"{"type":"item.completed","item":{"type":"agent_message","text":"done"}}
-{"type":"turn.completed","usage":{"input_tokens":"many","output_tokens":2}}
-"#,
-        )
-        .assert_value();
-        assert!(output.token_usage().is_none());
-    }
-
-    #[test]
-    fn rejects_missing_terminal_or_final_message() {
-        assert_eq!(
-            CodexOutput::parse(br#"{"type":"thread.started","thread_id":"thread-1"}"#).err(),
-            Some(NodeRunnerError::Driver)
-        );
-        assert_eq!(
-            CodexOutput::parse(br#"{"type":"turn.completed"}"#).err(),
-            Some(NodeRunnerError::Driver)
-        );
-    }
-
-    #[test]
-    fn retains_terminal_failure_detail_for_the_retry_policy() {
-        let failed = CodexOutput::parse(
-            br#"{"type":"thread.started","thread_id":"thread-1"}
-{"type":"turn.failed","error":{"message":"service unavailable"}}
-"#,
-        )
-        .assert_value();
-
-        assert_eq!(failed.thread_id.as_deref(), Some("thread-1"));
-        assert_eq!(failed.failure_message(), Some("service unavailable"));
-    }
-
-    #[test]
-    fn projects_provider_items_to_semantic_attach_messages() {
-        let mut decoder = CodexOutputDecoder::new();
-        let emissions = decoder
-            .push(
-                concat!(
-                    "{\"type\":\"item.updated\",\"item\":{\"type\":\"reasoning\",\"text\":\"checking tests\"}}\n",
-                    "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",",
-                    "\"command\":\"cargo test\",\"aggregated_output\":\"ok\",",
-                    "\"exit_code\":0,\"status\":\"completed\"}}\n",
-                    "{\"type\":\"item.completed\",\"item\":{\"type\":\"file_change\",",
-                    "\"changes\":[{\"path\":\"src/lib.rs\",\"kind\":\"update\"}],",
-                    "\"status\":\"completed\"}}\n",
-                    "{\"type\":\"item.completed\",\"item\":{\"type\":\"mcp_tool_call\",",
-                    "\"server\":\"github\",\"tool\":\"get_pr\",",
-                    "\"result\":{\"number\":7},\"status\":\"completed\"}}\n",
-                )
-                .as_bytes(),
-            )
-            .assert_value();
-        let messages = emissions
-            .iter()
-            .map(|emission| emission.log().1)
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            messages,
-            [
-                "Codex reasoning updated: checking tests",
-                "Codex command completed: cargo test [completed] exit=0\nok",
-                "Codex file change completed: update src/lib.rs",
-                "Codex tool completed: github.get_pr result={\"number\":7}",
-            ]
-        );
-    }
-}
+#[path = "output/tests.rs"]
+mod tests;

--- a/zeroshot-rust/src/native_v2_codex/output/tests.rs
+++ b/zeroshot-rust/src/native_v2_codex/output/tests.rs
@@ -1,0 +1,355 @@
+use openengine_cluster_testkit::assertions::AssertValue;
+use serde_json::json;
+
+use super::*;
+
+fn output_with_provisional_usage(event_type: &str, usage: Option<Value>) -> CodexOutput {
+    let mut terminal = json!({"type":event_type});
+    if event_type == "turn.failed" {
+        terminal
+            .as_object_mut()
+            .assert_value()
+            .insert("error".to_owned(), json!({"message":"terminal failure"}));
+    }
+    if let Some(usage) = usage {
+        terminal
+            .as_object_mut()
+            .assert_value()
+            .insert("usage".to_owned(), usage);
+    }
+    let mut bytes = Vec::new();
+    for event in [
+        json!({
+            "type":"error",
+            "message":"temporary",
+            "usage":{
+                "input_tokens":11,
+                "output_tokens":7,
+                "cached_input_tokens":5,
+                "cache_write_input_tokens":3
+            }
+        }),
+        json!({"type":"item.completed","item":{"type":"agent_message","text":"done"}}),
+        terminal,
+    ] {
+        serde_json::to_writer(&mut bytes, &event).assert_value();
+        bytes.push(b'\n');
+    }
+    CodexOutput::parse(&bytes)
+}
+
+fn assert_usage(output: &CodexOutput, expected: [u64; 4]) {
+    let usage = output.token_usage().assert_value();
+    assert_eq!(
+        [
+            usage.input_tokens.get(),
+            usage.output_tokens.get(),
+            usage.cache_read_input_tokens.assert_value().get(),
+            usage.cache_creation_input_tokens.assert_value().get(),
+        ],
+        expected
+    );
+}
+
+#[test]
+fn normalizes_worker_and_verifier_messages() {
+    let worker = CodexOutput::parse(
+        concat!(
+            "{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",",
+            "\"text\":\"{\\\"answer\\\":42}\"}}\n",
+            "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,",
+            "\"cached_input_tokens\":1,\"cache_write_input_tokens\":3,",
+            "\"output_tokens\":2}}\n",
+        )
+        .as_bytes(),
+    );
+    assert_eq!(worker.final_message().assert_value(), r#"{"answer":42}"#);
+    let usage = worker.token_usage().assert_value();
+    assert_eq!(usage.input_tokens.get(), 1);
+    assert_eq!(usage.output_tokens.get(), 2);
+    assert_eq!(usage.cache_read_input_tokens.assert_value().get(), 1);
+    assert_eq!(usage.cache_creation_input_tokens.assert_value().get(), 3);
+
+    let verifier_events = concat!(
+        "{\"type\":\"thread.started\",\"thread_id\":\"thread-2\"}\n",
+        "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",",
+        "\"text\":\"{\\\"output\\\":{\\\"ok\\\":true},",
+        "\\\"signals\\\":{\\\"decision\\\":\\\"pass\\\"},",
+        "\\\"diagnostic\\\":null}\"}}\n",
+        "{\"type\":\"turn.completed\"}\n",
+    );
+    let verifier = CodexOutput::parse(verifier_events.as_bytes());
+    assert_eq!(
+        serde_json::from_str::<Value>(verifier.final_message().assert_value()).assert_value(),
+        json!({
+            "output": { "ok": true },
+            "signals": { "decision": "pass" },
+            "diagnostic": null
+        })
+    );
+}
+
+#[test]
+fn malformed_terminal_usage_is_unavailable_without_rejecting_the_turn() {
+    let output = CodexOutput::parse(
+        br#"{"type":"error","message":"temporary","usage":{"input_tokens":11,"output_tokens":7}}
+{"type":"item.completed","item":{"type":"agent_message","text":"done"}}
+{"type":"turn.completed","usage":{"input_tokens":"many","output_tokens":2}}
+"#,
+    );
+    assert!(output.token_usage().is_none());
+}
+
+#[test]
+fn empty_terminal_usage_preserves_provisional_usage_for_every_terminal_outcome() {
+    for event_type in ["turn.completed", "turn.failed"] {
+        for usage in [None, Some(Value::Null), Some(json!({}))] {
+            assert_usage(
+                &output_with_provisional_usage(event_type, usage),
+                [11, 7, 5, 3],
+            );
+        }
+    }
+}
+
+#[test]
+fn valid_terminal_usage_replaces_provisional_usage_for_every_terminal_outcome() {
+    for event_type in ["turn.completed", "turn.failed"] {
+        let output = output_with_provisional_usage(
+            event_type,
+            Some(json!({
+                "input_tokens":19,
+                "output_tokens":13,
+                "cached_input_tokens":8,
+                "cache_write_input_tokens":2
+            })),
+        );
+        assert_usage(&output, [19, 13, 8, 2]);
+    }
+}
+
+#[test]
+fn malformed_terminal_usage_invalidates_provisional_usage_for_every_terminal_outcome() {
+    for event_type in ["turn.completed", "turn.failed"] {
+        for usage in [
+            json!("invalid"),
+            json!({"input_tokens":"many","output_tokens":2}),
+            json!({"input_tokens":1}),
+        ] {
+            assert!(
+                output_with_provisional_usage(event_type, Some(usage))
+                    .token_usage()
+                    .is_none()
+            );
+        }
+    }
+}
+
+#[test]
+fn reports_missing_terminal_or_final_message_with_actionable_detail() {
+    assert_eq!(
+        CodexOutput::parse(br#"{"type":"thread.started","thread_id":"thread-1"}"#)
+            .failure_message(),
+        Some("Codex output ended without a terminal turn event")
+    );
+    assert_eq!(
+        CodexOutput::parse(br#"{"type":"turn.completed"}"#).failure_message(),
+        Some("Codex turn completed without a final agent message")
+    );
+}
+
+#[test]
+fn retains_terminal_failure_detail_for_the_retry_policy() {
+    let failed = CodexOutput::parse(
+        concat!(
+            "{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}\n",
+            "{\"type\":\"error\",\"message\":\"temporary\",\"usage\":{",
+            "\"input_tokens\":21,\"output_tokens\":13}}\n",
+            "{\"type\":\"turn.failed\",\"usage\":{\"input_tokens\":8,",
+            "\"cached_input_tokens\":5,\"cache_write_input_tokens\":2,",
+            "\"output_tokens\":3},\"error\":{\"message\":\"service unavailable\"}}\n",
+        )
+        .as_bytes(),
+    );
+
+    assert_eq!(failed.thread_id.as_deref(), Some("thread-1"));
+    assert_eq!(failed.failure_message(), Some("service unavailable"));
+    let usage = failed.token_usage().assert_value();
+    assert_eq!(usage.cache_read_input_tokens.assert_value().get(), 5);
+    assert_eq!(usage.cache_creation_input_tokens.assert_value().get(), 2);
+}
+
+#[test]
+fn retains_error_usage_provisionally_at_eof() {
+    let output = CodexOutput::parse(
+        concat!(
+            "{\"type\":\"error\",\"message\":\"connection ended\",\"usage\":{",
+            "\"input_tokens\":19,\"cached_input_tokens\":7,",
+            "\"cache_write_input_tokens\":3,\"output_tokens\":5}}",
+        )
+        .as_bytes(),
+    );
+
+    assert_eq!(output.failure_message(), Some("connection ended"));
+    let usage = output.token_usage().assert_value();
+    assert_eq!(usage.input_tokens.get(), 19);
+    assert_eq!(usage.output_tokens.get(), 5);
+    assert_eq!(usage.cache_read_input_tokens.assert_value().get(), 7);
+    assert_eq!(usage.cache_creation_input_tokens.assert_value().get(), 3);
+}
+
+#[test]
+fn provisional_error_is_cleared_by_completion_and_latest_message_wins() {
+    let output = CodexOutput::parse(
+        br#"{"type":"error","message":"temporary transport retry","usage":{"input_tokens":31,"output_tokens":17}}
+{"type":"item.completed","item":{"type":"agent_message","text":"old"}}
+{"type":"item.completed","item":{"type":"agent_message","text":"final"}}
+{"type":"turn.completed","usage":{"input_tokens":3,"output_tokens":4}}
+{"type":"item.completed","item":{"type":"agent_message","text":"trailing"}}
+{"type":"turn.failed","error":{"message":"trailing failure"}}
+"#,
+    );
+
+    assert_eq!(output.final_message().assert_value(), "final");
+    assert_eq!(output.failure_message(), None);
+    let usage = output.token_usage().assert_value();
+    assert_eq!(usage.input_tokens.get(), 3);
+    assert_eq!(usage.output_tokens.get(), 4);
+}
+
+#[test]
+fn provisional_error_survives_eof_and_terminal_failure_prefers_its_detail() {
+    let ended = CodexOutput::parse(br#"{"type":"error","message":"temporary transport retry"}"#);
+    assert_eq!(ended.failure_message(), Some("temporary transport retry"));
+
+    let failed = CodexOutput::parse(
+        br#"{"type":"error","message":"temporary transport retry"}
+{"type":"turn.failed","error":"terminal service failure"}
+{"type":"turn.completed"}
+"#,
+    );
+    assert_eq!(failed.failure_message(), Some("terminal service failure"));
+}
+
+#[test]
+fn malformed_ancillary_records_do_not_discard_a_valid_result() {
+    let mut bytes = b"not json\n".to_vec();
+    bytes.extend_from_slice(&[0xff, b'\n']);
+    bytes.extend_from_slice(
+        br#"{}
+{"type":"thread.started"}
+{"type":"item.completed"}
+{"type":"future.event","payload":true}
+{"type":"item.completed","item":{"type":"agent_message","text":"done"}}
+{"type":"turn.completed"}"#,
+    );
+    let output = CodexOutput::parse(&bytes);
+
+    assert_eq!(output.final_message().assert_value(), "done");
+    assert_eq!(output.failure_message(), None);
+    assert_eq!(output.malformed_records, 5);
+    assert_eq!(output.oversized_records, 0);
+}
+
+#[test]
+fn malformed_records_are_reported_when_required_output_is_missing() {
+    let output = CodexOutput::parse(b"not json\n{\"type\":\"turn.completed\"}\n");
+    assert_eq!(
+        output.failure_message(),
+        Some(
+            "Codex turn completed without a final agent message; ignored 1 malformed and 0 oversized output records"
+        )
+    );
+}
+
+#[test]
+fn conflicting_thread_ids_wait_for_completion_and_preserve_terminal_evidence() {
+    let output = CodexOutput::parse(
+        br#"{"type":"thread.started","thread_id":"thread-1"}
+{"type":"thread.started","thread_id":"thread-2"}
+{"type":"item.completed","item":{"type":"agent_message","text":"done"}}
+{"type":"turn.completed","usage":{"input_tokens":8,"output_tokens":3}}
+{"type":"item.completed","item":{"type":"agent_message","text":"trailing"}}
+{"type":"turn.failed","usage":{"input_tokens":999,"output_tokens":999},"error":{"message":"trailing failure"}}
+"#,
+    );
+
+    assert_eq!(output.thread_id.as_deref(), Some("thread-1"));
+    assert_eq!(
+        output.failure_message(),
+        Some("Codex output contained conflicting thread IDs")
+    );
+    assert_eq!(output.final_message().assert_value(), "done");
+    let usage = output.token_usage().assert_value();
+    assert_eq!(usage.input_tokens.get(), 8);
+    assert_eq!(usage.output_tokens.get(), 3);
+}
+
+#[test]
+fn conflicting_thread_ids_preserve_failed_turn_usage_but_win_the_outcome() {
+    let output = CodexOutput::parse(
+        br#"{"type":"thread.started","thread_id":"thread-1"}
+{"type":"thread.started","thread_id":"thread-2"}
+{"type":"turn.failed","usage":{"input_tokens":13,"output_tokens":5},"error":{"message":"provider terminal detail"}}
+"#,
+    );
+
+    assert_eq!(output.thread_id.as_deref(), Some("thread-1"));
+    assert_eq!(
+        output.failure_message(),
+        Some("Codex output contained conflicting thread IDs; provider terminal detail")
+    );
+    let usage = output.token_usage().assert_value();
+    assert_eq!(usage.input_tokens.get(), 13);
+    assert_eq!(usage.output_tokens.get(), 5);
+}
+
+#[test]
+fn decoder_handles_split_crlf_and_an_unterminated_terminal_record() {
+    let mut decoder = CodexOutputDecoder::new();
+    assert!(
+        decoder
+            .push(b"{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_")
+            .is_empty()
+    );
+    let emissions = decoder.push(b"message\",\"text\":\"done\"}}\r\n{\"type\":\"turn.completed\"}");
+    assert_eq!(emissions.len(), 1);
+    let output = decoder.finish();
+    assert_eq!(output.final_message().assert_value(), "done");
+    assert_eq!(output.failure_message(), None);
+}
+
+#[test]
+fn projects_provider_items_to_semantic_attach_messages() {
+    let mut decoder = CodexOutputDecoder::new();
+    let emissions = decoder.push(
+        concat!(
+            "{\"type\":\"item.updated\",\"item\":{\"type\":\"reasoning\",\"text\":\"checking tests\"}}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",",
+            "\"command\":\"cargo test\",\"aggregated_output\":\"ok\",",
+            "\"exit_code\":0,\"status\":\"completed\"}}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"file_change\",",
+            "\"changes\":[{\"path\":\"src/lib.rs\",\"kind\":\"update\"}],",
+            "\"status\":\"completed\"}}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"mcp_tool_call\",",
+            "\"server\":\"github\",\"tool\":\"get_pr\",",
+            "\"result\":{\"number\":7},\"status\":\"completed\"}}\n",
+        )
+        .as_bytes(),
+    );
+    let messages = emissions
+        .iter()
+        .map(|emission| emission.log().1)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        messages,
+        [
+            "Codex reasoning updated: checking tests",
+            "Codex command completed: cargo test [completed] exit=0\nok",
+            "Codex file change completed: update src/lib.rs",
+            "Codex tool completed: github.get_pr result={\"number\":7}",
+        ]
+    );
+}

--- a/zeroshot-rust/src/native_v2_codex/process.rs
+++ b/zeroshot-rust/src/native_v2_codex/process.rs
@@ -1,0 +1,245 @@
+use crate::execution::process::{
+    LocalProcessRunner, ProcessRunnerError, ProcessSession, ProcessSessionCommand,
+    ProcessSessionOutput, ProcessStdout,
+};
+use crate::native_v2_capsule::provider_process::{
+    ProcessExchange, ProcessInputFailure, exchange_process_io, open_provider_process,
+    process_failure_detail, safe_provider_text,
+};
+use crate::native_v2_contract::TokenUsageDelta;
+use crate::native_v2_runner::{DriverControl, LiveOutput, LiveOutputStream, NodeRunnerError};
+
+use super::output::{CodexOutput, CodexOutputDecoder};
+
+pub(super) enum ProcessOpen {
+    Ready(ProcessSession),
+    ProviderFailure(String),
+}
+
+struct CollectedOutput {
+    output: CodexOutput,
+    delivery_error: Option<NodeRunnerError>,
+    usage: Option<TokenUsageDelta>,
+}
+
+pub(super) async fn open_process(
+    runner: LocalProcessRunner,
+    command: ProcessSessionCommand,
+    control: &DriverControl,
+) -> Result<ProcessOpen, NodeRunnerError> {
+    let process = match open_provider_process(runner, command, control).await? {
+        Ok(process) => process,
+        Err(error) => {
+            return Ok(ProcessOpen::ProviderFailure(format!(
+                "provider process could not start: {error}"
+            )));
+        }
+    };
+    Ok(ProcessOpen::Ready(process))
+}
+
+async fn collect_output(
+    mut stdout: ProcessStdout,
+    control: &DriverControl,
+    redactions: &[String],
+) -> CollectedOutput {
+    let mut decoder = CodexOutputDecoder::new();
+    let mut delivery_error = None;
+    while let Some(chunk) = stdout.recv().await {
+        for emission in decoder.push(chunk.as_slice()) {
+            if delivery_error.is_some() {
+                continue;
+            }
+            let (stream, message) = emission.log();
+            if let Err(error) = emit_text(control, stream, message, redactions).await {
+                delivery_error = Some(error);
+            }
+        }
+    }
+    finish_collection(decoder, delivery_error)
+}
+
+pub(super) async fn exchange_turn(
+    process: &mut ProcessSession,
+    prompt: &str,
+    control: &DriverControl,
+    redactions: &[String],
+) -> Result<CodexOutput, NodeRunnerError> {
+    let stdout = process.detach_stdout();
+    let collected = collect_output(stdout, control, redactions);
+    let exchange = exchange_process_io(process, prompt.as_bytes(), collected).await;
+    let (resolved, usage) = match exchange {
+        ProcessExchange::Complete(collected) => {
+            let output_complete = collected.delivery_error.is_none();
+            let output = retain_delivery_evidence(collected.output, collected.delivery_error);
+            let completion = finish_process(process, output_complete).await;
+            (
+                resolve_process_completion(output, completion, control.is_cancelled()),
+                collected.usage,
+            )
+        }
+        ProcessExchange::InputFailure(ProcessInputFailure {
+            output: collected,
+            input_error,
+            completion,
+        }) => {
+            let output = retain_delivery_evidence(collected.output, collected.delivery_error);
+            (
+                resolve_input_failure(output, input_error, completion, control.is_cancelled()),
+                collected.usage,
+            )
+        }
+    };
+    let recorded = control.record_token_usage(usage).await;
+    if matches!(&resolved, Err(NodeRunnerError::Cancelled)) {
+        return Err(NodeRunnerError::Cancelled);
+    }
+    recorded?;
+    resolved
+}
+
+fn finish_collection(
+    decoder: CodexOutputDecoder,
+    error: Option<NodeRunnerError>,
+) -> CollectedOutput {
+    let output = decoder.finish();
+    let usage = output.token_usage();
+    CollectedOutput {
+        output,
+        delivery_error: error,
+        usage,
+    }
+}
+
+fn retain_delivery_evidence(
+    mut output: CodexOutput,
+    error: Option<NodeRunnerError>,
+) -> Result<CodexOutput, NodeRunnerError> {
+    match error {
+        Some(NodeRunnerError::Cancelled) => Err(NodeRunnerError::Cancelled),
+        Some(error) => {
+            output.merge_failure_detail(format!("provider output delivery failed: {error}"));
+            Ok(output)
+        }
+        None => Ok(output),
+    }
+}
+
+pub(super) async fn finish_process(
+    process: &mut ProcessSession,
+    output_complete: bool,
+) -> Result<ProcessSessionOutput, ProcessRunnerError> {
+    if output_complete {
+        process.wait().await
+    } else {
+        process.release().await
+    }
+}
+
+pub(super) fn resolve_process_completion(
+    output: Result<CodexOutput, NodeRunnerError>,
+    completion: Result<ProcessSessionOutput, ProcessRunnerError>,
+    cancelled: bool,
+) -> Result<CodexOutput, NodeRunnerError> {
+    if process_was_cancelled(&output, &completion, cancelled) {
+        return Err(NodeRunnerError::Cancelled);
+    }
+    let provider_output_failed = output
+        .as_ref()
+        .map_or(true, |output| output.failure_message().is_some());
+    let process_detail = completion_detail(&completion, provider_output_failed)?;
+    merge_completion_detail(output, process_detail)
+}
+
+pub(super) fn resolve_input_failure(
+    output: Result<CodexOutput, NodeRunnerError>,
+    input_error: ProcessRunnerError,
+    completion: Result<ProcessSessionOutput, ProcessRunnerError>,
+    cancelled: bool,
+) -> Result<CodexOutput, NodeRunnerError> {
+    if process_was_cancelled(&output, &completion, cancelled) {
+        return Err(NodeRunnerError::Cancelled);
+    }
+    let mut output = output.unwrap_or_else(|error| {
+        CodexOutput::provider_failure(format!("provider output collection failed: {error}"))
+    });
+    output.merge_failure_detail(format!("provider process input failed: {input_error}"));
+    if let Some(detail) = completion_detail(&completion, true)? {
+        output.merge_failure_detail(detail);
+    }
+    Ok(output)
+}
+
+fn process_was_cancelled(
+    output: &Result<CodexOutput, NodeRunnerError>,
+    completion: &Result<ProcessSessionOutput, ProcessRunnerError>,
+    externally_cancelled: bool,
+) -> bool {
+    externally_cancelled
+        || matches!(output, Err(NodeRunnerError::Cancelled))
+        || matches!(completion, Ok(output) if output.cancelled)
+}
+
+fn completion_detail(
+    completion: &Result<ProcessSessionOutput, ProcessRunnerError>,
+    provider_output_failed: bool,
+) -> Result<Option<String>, NodeRunnerError> {
+    match completion {
+        Err(error) => Ok(Some(format!("provider process completion failed: {error}"))),
+        Ok(completion) => process_failure_detail(completion, false, provider_output_failed),
+    }
+}
+
+fn merge_completion_detail(
+    output: Result<CodexOutput, NodeRunnerError>,
+    process_detail: Option<String>,
+) -> Result<CodexOutput, NodeRunnerError> {
+    match (output, process_detail) {
+        (Ok(mut output), Some(detail)) => {
+            output.merge_failure_detail(detail);
+            Ok(output)
+        }
+        (Ok(output), None) => Ok(output),
+        (Err(error), Some(detail)) => {
+            let mut output = CodexOutput::provider_failure(format!(
+                "provider output collection failed: {error}"
+            ));
+            output.merge_failure_detail(detail);
+            Ok(output)
+        }
+        (Err(error), None) => Err(error),
+    }
+}
+
+async fn emit_text(
+    control: &DriverControl,
+    stream: LiveOutputStream,
+    text: &str,
+    redactions: &[String],
+) -> Result<(), NodeRunnerError> {
+    let safe = safe_provider_text(text, redactions);
+    let mut rest = safe.as_str();
+    while !rest.is_empty() {
+        let split = if rest.len() <= 8 * 1024 {
+            rest.len()
+        } else {
+            rest.char_indices()
+                .map(|(index, _)| index)
+                .take_while(|index| *index <= 8 * 1024)
+                .last()
+                .filter(|index| *index > 0)
+                .ok_or(NodeRunnerError::UnsafeOutput)?
+        };
+        let (part, tail) = rest.split_at(split);
+        control.emit(LiveOutput::new(stream, part)?).await?;
+        rest = tail;
+    }
+    if text.is_empty() {
+        control.emit(LiveOutput::new(stream, "")?).await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "process/tests.rs"]
+mod tests;

--- a/zeroshot-rust/src/native_v2_codex/process/tests.rs
+++ b/zeroshot-rust/src/native_v2_codex/process/tests.rs
@@ -1,0 +1,104 @@
+use crate::execution::process::{ProcessCleanupEvidence, ProcessLaunchEvidence, ProcessSessionOutput};
+use openengine_cluster_testkit::assertions::AssertValue;
+
+use super::*;
+
+fn completion(cleanup: ProcessCleanupEvidence, cancelled: bool) -> ProcessSessionOutput {
+    ProcessSessionOutput {
+        launch_evidence: ProcessLaunchEvidence::MayHaveStarted,
+        exit_code: Some(0),
+        termination_signal: None,
+        core_dumped: false,
+        stderr_tail: Vec::new(),
+        stderr_tail_truncated: false,
+        cancelled,
+        timed_out: false,
+        cleanup,
+        post_launch_error: None,
+    }
+}
+
+#[test]
+fn process_cancellation_wins_over_output_collection_failure() {
+    let resolved = resolve_process_completion(
+        Err(NodeRunnerError::DurableOutputClosed),
+        Ok(completion(ProcessCleanupEvidence::Reaped, true)),
+        false,
+    );
+
+    assert!(matches!(resolved, Err(NodeRunnerError::Cancelled)));
+}
+
+#[test]
+fn external_cancellation_wins_over_process_completion_failure() {
+    let resolved = resolve_process_completion(
+        Err(NodeRunnerError::DurableOutputClosed),
+        Err(ProcessRunnerError::Io("supervisor stopped".to_owned())),
+        true,
+    );
+
+    assert!(matches!(resolved, Err(NodeRunnerError::Cancelled)));
+}
+
+#[test]
+fn cleanup_evidence_is_retained_with_output_collection_failure() {
+    let output = resolve_process_completion(
+        Err(NodeRunnerError::DurableOutputClosed),
+        Ok(completion(ProcessCleanupEvidence::TimedOut, false)),
+        false,
+    )
+    .assert_value();
+    let detail = output.failure_message().assert_value();
+
+    assert!(detail.contains("provider output collection failed"));
+    assert!(detail.contains("cleanup did not prove the process tree empty"));
+}
+
+#[test]
+fn clean_completion_does_not_replace_output_collection_failure() {
+    let resolved = resolve_process_completion(
+        Err(NodeRunnerError::DurableOutputClosed),
+        Ok(completion(ProcessCleanupEvidence::Reaped, false)),
+        false,
+    );
+
+    assert!(matches!(
+        resolved,
+        Err(NodeRunnerError::DurableOutputClosed)
+    ));
+}
+
+#[test]
+fn parsing_after_an_emission_failure_retains_later_terminal_usage() {
+    let mut decoder = CodexOutputDecoder::new();
+    let emissions = decoder.push(
+        concat!(
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",",
+            "\"text\":\"done\"}}\n",
+        )
+        .as_bytes(),
+    );
+    assert_eq!(emissions.len(), 1);
+
+    let suppressed = decoder.push(
+        concat!(
+            "{\"type\":\"turn.completed\",\"usage\":{",
+            "\"input_tokens\":17,\"cached_input_tokens\":4,",
+            "\"cache_write_input_tokens\":3,\"output_tokens\":9}}\n",
+        )
+        .as_bytes(),
+    );
+    assert_eq!(suppressed.len(), 1);
+
+    let collected = finish_collection(decoder, Some(NodeRunnerError::DurableOutputClosed));
+    assert!(matches!(
+        collected.delivery_error,
+        Some(NodeRunnerError::DurableOutputClosed)
+    ));
+    assert_eq!(collected.output.final_message().assert_value(), "done");
+    let usage = collected.usage.assert_value();
+    assert_eq!(usage.input_tokens.get(), 17);
+    assert_eq!(usage.output_tokens.get(), 9);
+    assert_eq!(usage.cache_read_input_tokens.assert_value().get(), 4);
+    assert_eq!(usage.cache_creation_input_tokens.assert_value().get(), 3);
+}

--- a/zeroshot-rust/src/native_v2_codex/schema_file.rs
+++ b/zeroshot-rust/src/native_v2_codex/schema_file.rs
@@ -4,19 +4,29 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::execution::process::write_new_file;
-use crate::native_v2_runner::NodeRunnerError;
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum CodexSchemaFileError {
+    #[error("provider response schema could not be serialized: {0}")]
+    Serialize(#[source] serde_json::Error),
+    #[error("provider response schema file could not be created: {0}")]
+    Write(#[source] std::io::Error),
+}
 
 pub(super) struct CodexSchemaFile {
     path: PathBuf,
 }
 
 impl CodexSchemaFile {
-    pub(super) fn create(runtime_home: &Path, schema: &Value) -> Result<Self, NodeRunnerError> {
+    pub(super) fn create(
+        runtime_home: &Path,
+        schema: &Value,
+    ) -> Result<Self, CodexSchemaFileError> {
         let path = runtime_home.join(format!("response-schema-{}.json", Uuid::now_v7()));
-        let bytes = serde_json::to_vec(schema).map_err(|_| NodeRunnerError::Driver)?;
+        let bytes = serde_json::to_vec(schema).map_err(CodexSchemaFileError::Serialize)?;
         // Hosted children have a distinct uid. The containing runtime home is mode 0700,
         // so making this non-secret contract world-readable only exposes it to that child.
-        write_new_file(&path, &bytes, 0o444).map_err(|_| NodeRunnerError::Driver)?;
+        write_new_file(&path, &bytes, 0o444).map_err(CodexSchemaFileError::Write)?;
         Ok(Self { path })
     }
 
@@ -50,5 +60,22 @@ mod tests {
             path
         };
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn schema_file_creation_preserves_io_detail() {
+        let runtime = TestDirectory::new("codex-schema-file-error");
+        let missing_home = runtime.child("missing/home");
+        let error = CodexSchemaFile::create(&missing_home, &json!({"type":"null"}))
+            .err()
+            .assert_value();
+
+        assert!(error.to_string().contains("could not be created"));
+        let io_error = match error {
+            super::CodexSchemaFileError::Write(error) => Some(error),
+            super::CodexSchemaFileError::Serialize(_) => None,
+        }
+        .assert_value();
+        assert_eq!(io_error.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/zeroshot-rust/src/native_v2_codex/session.rs
+++ b/zeroshot-rust/src/native_v2_codex/session.rs
@@ -7,11 +7,12 @@ use tokio::sync::Mutex;
 use crate::native_v2_capsule::provider_process::{ProviderSessionCore, impl_provider_node_session};
 use crate::native_v2_contract::{NodeInvocation, NodeRuntimeBinding};
 use crate::native_v2_runner::{
-    DriverControl, DriverInvocation, NodeDriver, NodeRunnerError, NodeSession, ResolvedEnvironment,
-    SessionFactory,
+    AgentResponse, DriverControl, DriverInvocation, NodeDriver, NodeRunnerError, NodeSession,
+    ResolvedEnvironment, SessionFactory,
 };
 
 use super::NativeV2CodexAdapter;
+use super::output::CodexOutput;
 
 pub(super) struct CodexSession {
     pub(super) core: ProviderSessionCore,
@@ -30,23 +31,63 @@ impl CodexSession {
         &self,
         observed: Option<&str>,
         resumed: Option<&str>,
-    ) -> Result<(), NodeRunnerError> {
-        let expected = resumed.or(observed).ok_or(NodeRunnerError::Driver)?;
-        if expected.is_empty() || expected.len() > 256 || expected.contains(char::is_control) {
-            return Err(NodeRunnerError::Driver);
+    ) -> Result<(), &'static str> {
+        let expected = resumed
+            .or(observed)
+            .ok_or("Codex output did not provide a thread ID")?;
+        if expected.is_empty() {
+            return Err("Codex output provided an empty thread ID");
+        }
+        if expected.contains('\0') {
+            return Err("Codex output thread ID contained a NUL byte");
         }
         if observed.is_some_and(|value| value != expected) {
-            return Err(NodeRunnerError::Driver);
+            return Err("Codex output thread ID did not match the resumed session");
         }
         let mut thread_id = self.thread_id.lock().await;
         match thread_id.as_deref() {
-            Some(current) if current != expected => Err(NodeRunnerError::Driver),
+            Some(current) if current != expected => {
+                Err("Codex output thread ID changed across turns")
+            }
             Some(_) => Ok(()),
             None => {
                 *thread_id = Some(expected.to_owned());
                 Ok(())
             }
         }
+    }
+
+    pub(super) async fn record_attempt_thread(
+        &self,
+        output: &CodexOutput,
+        resumed: Option<&str>,
+    ) -> Result<(), &'static str> {
+        if output.thread_id.is_none() && resumed.is_none() {
+            return Ok(());
+        }
+        self.record_thread(output.thread_id.as_deref(), resumed)
+            .await
+    }
+
+    pub(super) async fn missing_required_thread(
+        &self,
+        invocation: &DriverInvocation,
+        response: &AgentResponse,
+    ) -> Option<&'static str> {
+        if self.thread_id.lock().await.is_some() {
+            return None;
+        }
+        if matches!(response, AgentResponse::Correction(_)) {
+            return Some("Codex output did not provide a thread ID required for correction");
+        }
+        matches!(
+            &invocation.node.binding,
+            NodeRuntimeBinding::Agent {
+                session_scope: crate::execution::SessionScope::NodeInstance,
+                ..
+            }
+        )
+        .then_some("Codex output did not provide a thread ID required for reusable session")
     }
 }
 
@@ -79,5 +120,56 @@ impl NodeDriver for NativeV2CodexAdapter {
             .downcast_ref::<CodexSession>()
             .ok_or(NodeRunnerError::Driver)?;
         self.run_turn(&invocation, session, control).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn thread_ids_are_opaque_beyond_process_argv_requirements() {
+        let session = CodexSession::new();
+        let thread_id = format!("thread-{}\nwith-tab\t", "x".repeat(512));
+
+        assert_eq!(session.record_thread(Some(&thread_id), None).await, Ok(()));
+        assert_eq!(
+            session
+                .record_thread(Some(&thread_id), Some(&thread_id))
+                .await,
+            Ok(())
+        );
+        assert_eq!(
+            session.thread_id.lock().await.as_deref(),
+            Some(thread_id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn thread_ids_reject_only_missing_empty_nul_or_conflicting_values() {
+        for (observed, expected) in [
+            (None, "Codex output did not provide a thread ID"),
+            (Some(""), "Codex output provided an empty thread ID"),
+            (
+                Some("thread\0id"),
+                "Codex output thread ID contained a NUL byte",
+            ),
+        ] {
+            assert_eq!(
+                CodexSession::new().record_thread(observed, None).await,
+                Err(expected)
+            );
+        }
+
+        let session = CodexSession::new();
+        assert_eq!(session.record_thread(Some("one"), None).await, Ok(()));
+        assert_eq!(
+            session.record_thread(Some("two"), Some("one")).await,
+            Err("Codex output thread ID did not match the resumed session")
+        );
+        assert_eq!(
+            session.record_thread(None, Some("two")).await,
+            Err("Codex output thread ID changed across turns")
+        );
     }
 }

--- a/zeroshot-rust/src/native_v2_codex/tests.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests.rs
@@ -6,10 +6,18 @@ mod cancellation;
 mod correction;
 #[path = "tests/environment.rs"]
 mod environment;
+#[path = "tests/large_output.rs"]
+mod large_output;
+#[path = "tests/large_prompt.rs"]
+mod large_prompt;
 #[path = "tests/local_identity.rs"]
 mod local_identity;
+#[path = "tests/process_start.rs"]
+mod process_start;
 #[path = "tests/retry.rs"]
 mod retry;
+#[path = "tests/session_id.rs"]
+mod session_id;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -62,13 +70,14 @@ test -n "$schema_path"
 /usr/bin/printf 'schema=%s\n' "$(/usr/bin/cat "$schema_path")" >> "$CAPTURE_PATH"
 
 resumed=false
+thread_id=${THREAD_ID-thread-123}
 for argument in "$@"; do
   if [ "$argument" = "resume" ]; then
     resumed=true
   fi
 done
 
-/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"thread-123"}'
+/usr/bin/printf '{"type":"thread.started","thread_id":"%s"}\n' "$thread_id"
 /usr/bin/printf '%s\n' '{"type":"turn.started"}'
 if [ "${OPENROUTER_API_KEY-unset}" != unset ]; then
   /usr/bin/printf '%s%s\n' \
@@ -97,8 +106,24 @@ if [ "${SLOW_RUN-false}" = true ]; then
   /usr/bin/printf '%s\n' "$$" > "$PID_PATH"
   /usr/bin/sleep 30
 fi
-/usr/bin/printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":1,"output_tokens":2}}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":1,' \
+  '"cache_write_input_tokens":3,"output_tokens":2}}'
 "#;
+
+const SUCCESS_OUTPUT_SCRIPT: &str = r#"
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":42}}"}}'
+/usr/bin/printf '%s\n' '{"type":"turn.completed"}'
+"#;
+
+fn script_with_success(prefix: &str) -> String {
+    let mut script = String::with_capacity(prefix.len() + SUCCESS_OUTPUT_SCRIPT.len());
+    script.push_str(prefix);
+    script.push_str(SUCCESS_OUTPUT_SCRIPT);
+    script
+}
 
 fn scripted_adapter(
     directory: &TestDirectory,
@@ -222,8 +247,35 @@ async fn openai_runtime(
     scope: SessionScope,
     environment: &[&str],
 ) -> (AdmittedRun, NativeNodeRunner) {
-    let adapter = scripted_adapter(directory, CodexProvider::OpenAi);
-    let admitted = admitted(binding(scope, environment), CodexProvider::OpenAi).await;
+    openai_scripted_runtime(
+        directory,
+        OpenAiScript {
+            scope,
+            environment,
+            name: "codex-script",
+            body: SCRIPT,
+        },
+    )
+    .await
+}
+
+struct OpenAiScript<'a> {
+    scope: SessionScope,
+    environment: &'a [&'a str],
+    name: &'a str,
+    body: &'a str,
+}
+
+async fn openai_scripted_runtime(
+    directory: &TestDirectory,
+    script: OpenAiScript<'_>,
+) -> (AdmittedRun, NativeNodeRunner) {
+    let adapter = scripted_adapter_with(directory, CodexProvider::OpenAi, script.name, script.body);
+    let admitted = admitted(
+        binding(script.scope, script.environment),
+        CodexProvider::OpenAi,
+    )
+    .await;
     let runtime = runner(&admitted, adapter);
     (admitted, runtime)
 }
@@ -238,6 +290,37 @@ async fn start(
         .start(request(admitted, execution, values))
         .await
         .assert_value()
+}
+
+async fn complete_with_logs(
+    mut handle: NodeHandle,
+) -> (String, Result<WorkerOutcome, NodeRunnerError>) {
+    let mut output = handle.take_initial_output().assert_value();
+    let (logs, completion) = tokio::join!(
+        async {
+            let mut logs = Vec::new();
+            while let Ok(entry) = output.recv_output().await {
+                logs.push(entry);
+            }
+            logs
+        },
+        handle.completion()
+    );
+    let logs = logs
+        .iter()
+        .map(|entry| entry.text.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (logs, completion.map(|completion| completion.outcome))
+}
+
+async fn complete_verified_with_logs(handle: NodeHandle) -> String {
+    let (logs, completion) = complete_with_logs(handle).await;
+    assert!(matches!(
+        completion.assert_value(),
+        WorkerOutcome::Verified { output, .. } if output == json!({"answer": 42})
+    ));
+    logs
 }
 
 fn assert_schema_capture(capture: &str) {
@@ -342,7 +425,7 @@ async fn openrouter_script_observes_exact_configuration_environment_output_and_a
             "inputTokens": 1,
             "outputTokens": 2,
             "cacheReadInputTokens": 1,
-            "cacheCreationInputTokens": null
+            "cacheCreationInputTokens": 3
         })
     );
     assert_eq!(attach.recv().await, Err(AttachReceiveError::Closed));
@@ -404,35 +487,4 @@ async fn openai_node_instance_session_resumes_the_exact_thread() {
             .iter()
             .all(|home| home.ends_with("writer-node-instance-1"))
     );
-}
-
-#[tokio::test]
-async fn malformed_output_stops_after_two_correction_turns() {
-    let directory = TestDirectory::new("codex-malformed-limit");
-    let capture = directory.child("capture");
-    let (admitted, runtime) = openai_runtime(
-        &directory,
-        SessionScope::Execution,
-        &["ALWAYS_MALFORMED", "CAPTURE_PATH", "OPENAI_API_KEY"],
-    )
-    .await;
-    let mut handle = start(
-        &runtime,
-        &admitted,
-        1,
-        &[
-            ("ALWAYS_MALFORMED", "true".to_owned()),
-            ("CAPTURE_PATH", capture.display().to_string()),
-            ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
-        ],
-    )
-    .await;
-
-    assert_eq!(
-        handle.completion().await.assert_value().outcome,
-        WorkerOutcome::malformed()
-    );
-    let capture = fs::read_to_string(capture).assert_value();
-    assert_eq!(capture.matches("prompt=").count(), 3);
-    assert_eq!(capture.matches("arg=resume").count(), 2);
 }

--- a/zeroshot-rust/src/native_v2_codex/tests/cancellation.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/cancellation.rs
@@ -2,6 +2,27 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use super::*;
+use crate::native_v2_runner::DurableNodeEvent;
+
+const TERMINAL_THEN_SLOW_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/cat > /dev/null
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"usage-before-cancel"}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":42}}"}}'
+/usr/bin/printf '%s\n' \
+  '{"type":"turn.completed","usage":{"input_tokens":17,"output_tokens":9}}'
+/usr/bin/printf '%s\n' "$$" > "$PID_PATH"
+/usr/bin/sleep 30
+"#;
+
+const INPUT_FAILURE_THEN_SLOW_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+exec 0<&-
+/usr/bin/printf '%s\n' "$$" > "$PID_PATH"
+/usr/bin/sleep 30
+"#;
 
 #[tokio::test]
 async fn cancellation_waits_for_contained_child_cleanup() {
@@ -42,6 +63,95 @@ async fn cancellation_waits_for_contained_child_cleanup() {
         !process_is_live(pid),
         "provider child remained alive after completion"
     );
+}
+
+#[tokio::test]
+async fn cancellation_after_terminal_output_preserves_parsed_usage_once() {
+    let directory = TestDirectory::new("codex-cancel-after-usage");
+    let pid_path = directory.child("pid");
+    let (admitted, runtime) = openai_scripted_runtime(
+        &directory,
+        OpenAiScript {
+            scope: SessionScope::Execution,
+            environment: &["OPENAI_API_KEY", "PID_PATH"],
+            name: "terminal-then-slow",
+            body: TERMINAL_THEN_SLOW_SCRIPT,
+        },
+    )
+    .await;
+    let mut handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[
+            ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+            ("PID_PATH", pid_path.display().to_string()),
+        ],
+    )
+    .await;
+    let mut output = handle.take_initial_output().assert_value();
+    assert_eq!(
+        output.recv_output().await.assert_value().text,
+        r#"{"response":{"answer":42}}"#
+    );
+    assert_eq!(
+        output.recv_output().await.assert_value().text,
+        "Codex turn completed"
+    );
+    let pid = wait_for_pid(&pid_path).await;
+
+    handle.cancel();
+    let (usage, completion) = tokio::join!(output.recv_usage(), handle.completion());
+    let usage = usage.assert_value().assert_value();
+    assert_eq!(usage.input_tokens.get(), 17);
+    assert_eq!(usage.output_tokens.get(), 9);
+    assert_eq!(completion, Err(NodeRunnerError::Cancelled));
+    assert!(!process_is_live(pid));
+    while let Ok(event) = output.recv().await {
+        assert!(!matches!(event, DurableNodeEvent::TokenUsage(_)));
+    }
+}
+
+#[tokio::test]
+async fn cancelled_input_failure_records_one_incomplete_usage_event() {
+    let directory = TestDirectory::new("codex-cancel-input-failure");
+    let pid_path = directory.child("pid");
+    let (admitted, runtime) = openai_scripted_runtime(
+        &directory,
+        OpenAiScript {
+            scope: SessionScope::Execution,
+            environment: &["OPENAI_API_KEY", "PID_PATH"],
+            name: "input-failure-then-slow",
+            body: INPUT_FAILURE_THEN_SLOW_SCRIPT,
+        },
+    )
+    .await;
+    let values = [
+        ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+        ("PID_PATH", pid_path.display().to_string()),
+    ];
+    let mut large_request = request(&admitted, 1, &values);
+    large_request.invocation.input = json!({"task":"x".repeat(8 * 1024 * 1024)});
+    let mut handle = runtime.start(large_request).await.assert_value();
+    let mut output = handle.take_initial_output().assert_value();
+    let pid = wait_for_pid(&pid_path).await;
+
+    handle.cancel();
+    let (usages, completion) = tokio::join!(
+        async {
+            let mut usages = Vec::new();
+            while let Ok(event) = output.recv().await {
+                if let DurableNodeEvent::TokenUsage(usage) = event {
+                    usages.push(usage);
+                }
+            }
+            usages
+        },
+        handle.completion()
+    );
+    assert_eq!(completion, Err(NodeRunnerError::Cancelled));
+    assert_eq!(usages, [None]);
+    assert!(!process_is_live(pid));
 }
 
 async fn wait_for_pid(path: &Path) -> u32 {

--- a/zeroshot-rust/src/native_v2_codex/tests/correction.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/correction.rs
@@ -87,3 +87,34 @@ async fn openrouter_correction_scopes_configuration_to_the_resume_command() {
     assert!(resumed.contains("arg=--model\narg=openai/gpt-5.6-sol\n"));
     assert!(resumed.contains("arg=thread-123\narg=-\n"));
 }
+
+#[tokio::test]
+async fn malformed_output_stops_after_two_correction_turns() {
+    let directory = TestDirectory::new("codex-malformed-limit");
+    let capture = directory.child("capture");
+    let (admitted, runtime) = openai_runtime(
+        &directory,
+        SessionScope::Execution,
+        &["ALWAYS_MALFORMED", "CAPTURE_PATH", "OPENAI_API_KEY"],
+    )
+    .await;
+    let mut handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[
+            ("ALWAYS_MALFORMED", "true".to_owned()),
+            ("CAPTURE_PATH", capture.display().to_string()),
+            ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+        ],
+    )
+    .await;
+
+    assert_eq!(
+        handle.completion().await.assert_value().outcome,
+        WorkerOutcome::malformed()
+    );
+    let capture = fs::read_to_string(capture).assert_value();
+    assert_eq!(capture.matches("prompt=").count(), 3);
+    assert_eq!(capture.matches("arg=resume").count(), 2);
+}

--- a/zeroshot-rust/src/native_v2_codex/tests/environment.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/environment.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::native_v2_capsule::provider_process::safe_provider_text;
 
 #[test]
 fn command_is_exact_and_rejects_adapter_owned_collisions() {
@@ -68,7 +69,7 @@ fn log_redactions_are_longest_first_and_do_not_leave_overlapping_suffixes() {
     let redactions = redaction_values(environment.iter().map(|(_, value)| value));
     assert_eq!(redactions, vec!["secret-tail", "secret"]);
     assert_eq!(
-        redact_text("value=secret-tail", &redactions),
-        "value=[REDACTED]"
+        safe_provider_text("value=secret-tail\0after", &redactions),
+        "value=[REDACTED]\u{fffd}after"
     );
 }

--- a/zeroshot-rust/src/native_v2_codex/tests/large_output.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/large_output.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+const LARGE_OUTPUT_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/cat > /dev/null
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"large-output-thread"}'
+index=0
+while [ "$index" -lt 9 ]; do
+  /usr/bin/printf '%s' '{"type":"item.completed","item":{"type":"padding","payload":"'
+  /usr/bin/head -c 1048576 /dev/zero | /usr/bin/tr '\000' x
+  /usr/bin/printf '%s\n' '"}}'
+  index=$((index + 1))
+done
+/usr/bin/printf '%s\n' '{"type":"error","message":"temporary transport retry"}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"command_execution","command":"scan",' \
+  '"aggregated_output":"before\u0000after","exit_code":0,"status":"completed"}}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":42}}"}}'
+/usr/bin/printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":7}}'
+/usr/bin/printf '%s\n' 'trailing output is not JSON'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":999}}"}}'
+/usr/bin/printf '%s\n' '{"type":"turn.failed","error":{"message":"trailing failure"}}'
+"#;
+
+#[tokio::test]
+async fn large_output_provisional_error_and_nul_log_complete_successfully() {
+    let directory = TestDirectory::new("codex-large-output");
+    let adapter = scripted_adapter_with(
+        &directory,
+        CodexProvider::OpenAi,
+        "codex-large-output-script",
+        LARGE_OUTPUT_SCRIPT,
+    );
+    let admitted = admitted(
+        binding(SessionScope::Execution, &["OPENAI_API_KEY"]),
+        CodexProvider::OpenAi,
+    )
+    .await;
+    let runtime = runner(&admitted, adapter);
+    let handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[("OPENAI_API_KEY", "fake-openai-key".to_owned())],
+    )
+    .await;
+    let rendered = complete_verified_with_logs(handle).await;
+    assert_eq!(
+        rendered
+            .matches("Codex activity completed: padding")
+            .count(),
+        9
+    );
+    assert!(rendered.contains("Codex stream error"));
+    assert!(rendered.contains("Codex command completed: scan [completed] exit=0\nbefore�after"));
+    assert!(!rendered.contains('\0'));
+    assert!(!rendered.contains("999"));
+    assert!(!rendered.contains("trailing failure"));
+}

--- a/zeroshot-rust/src/native_v2_codex/tests/large_prompt.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/large_prompt.rs
@@ -1,0 +1,43 @@
+use super::*;
+
+const LARGE_PROMPT_SCRIPT_PREFIX: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/head -c 5242880 /dev/zero | /usr/bin/tr '\000' x
+/usr/bin/printf '\n'
+/usr/bin/wc -c <&0 > "$CAPTURE_PATH"
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"large-prompt-thread"}'
+"#;
+
+#[tokio::test]
+async fn stdout_is_drained_while_a_multiframe_prompt_is_delivered_in_full() {
+    let directory = TestDirectory::new("codex-large-prompt");
+    let capture = directory.child("prompt-size");
+    let script = script_with_success(LARGE_PROMPT_SCRIPT_PREFIX);
+    let adapter = scripted_adapter_with(
+        &directory,
+        CodexProvider::OpenAi,
+        "codex-large-prompt-script",
+        &script,
+    );
+    let admitted = admitted(
+        binding(SessionScope::Execution, &["CAPTURE_PATH", "OPENAI_API_KEY"]),
+        CodexProvider::OpenAi,
+    )
+    .await;
+    let runtime = runner(&admitted, adapter);
+    let values = [
+        ("CAPTURE_PATH", capture.display().to_string()),
+        ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+    ];
+    let mut large_request = request(&admitted, 1, &values);
+    large_request.invocation.input = json!({"task": "x".repeat(8 * 1024 * 1024)});
+    let handle = runtime.start(large_request).await.assert_value();
+
+    complete_verified_with_logs(handle).await;
+    let delivered = fs::read_to_string(capture)
+        .assert_value()
+        .trim()
+        .parse::<usize>()
+        .assert_value();
+    assert!(delivered > 8 * 1024 * 1024);
+}

--- a/zeroshot-rust/src/native_v2_codex/tests/local_identity.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/local_identity.rs
@@ -34,6 +34,9 @@ fn local_codex_user_reuses_native_homes_without_an_openai_api_key() {
     let isolated = NativeV2CodexAdapter::new(adapter.config.clone());
     assert_eq!(
         isolated.provider_environment(&environment, &runtime_home),
-        Err(NodeRunnerError::Driver)
+        Err(NodeRunnerError::DriverDetail(
+            "Codex provider credentials are missing or conflict with reserved credentials"
+                .to_owned()
+        ))
     );
 }

--- a/zeroshot-rust/src/native_v2_codex/tests/process_start.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/process_start.rs
@@ -1,0 +1,197 @@
+use super::*;
+use crate::native_v2_contract::TokenUsageDelta;
+use crate::native_v2_runner::DurableNodeEvent;
+
+#[path = "process_start/duplex.rs"]
+mod duplex;
+
+const EARLY_EXIT_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+exec 0<&-
+/usr/bin/printf '%s\n' 'early provider exit contains sentinel-secret' >&2
+exit 23
+"#;
+
+type CompletionResult = Result<crate::native_v2_contract::NodeCompletion, NodeRunnerError>;
+
+fn adapter_with_paths(
+    directory: &TestDirectory,
+    executable: PathBuf,
+    runtime_home: PathBuf,
+) -> Arc<NativeV2CodexAdapter> {
+    let workspace = directory.child("workspace");
+    fs::create_dir_all(&workspace).assert_value();
+    Arc::new(NativeV2CodexAdapter::new_for_test(NativeV2CodexConfig {
+        provider: CodexProvider::OpenAi,
+        executable,
+        workspace,
+        runtime_home,
+        local_user: None,
+        search_path: "/usr/bin:/bin".to_owned(),
+        process_pool: HostedProcessPool::new(10_002, 10_002, 20_000, 20_000).assert_value(),
+    }))
+}
+
+async fn failed_with_logs(
+    adapter: Arc<NativeV2CodexAdapter>,
+    environment: &[&str],
+    values: &[(&str, String)],
+) -> (NodeRunnerError, String) {
+    let (error, logs, _) = failed_with_events(adapter, environment, values).await;
+    (error, logs)
+}
+
+async fn failed_with_events(
+    adapter: Arc<NativeV2CodexAdapter>,
+    environment: &[&str],
+    values: &[(&str, String)],
+) -> (NodeRunnerError, String, Vec<Option<TokenUsageDelta>>) {
+    let (admitted, runtime) = failure_runtime(adapter, environment).await;
+    let handle = start(&runtime, &admitted, 1, values).await;
+    let (completion, logs, usages) = complete_with_events(handle).await;
+    (completion.err().assert_value(), logs, usages)
+}
+
+async fn complete_with_events(
+    mut handle: NodeHandle,
+) -> (CompletionResult, String, Vec<Option<TokenUsageDelta>>) {
+    let mut durable = handle.take_initial_output().assert_value();
+    let (events, completion) = tokio::join!(
+        async {
+            let mut events = Vec::new();
+            while let Ok(event) = durable.recv().await {
+                events.push(event);
+            }
+            events
+        },
+        handle.completion()
+    );
+    let mut logs = Vec::new();
+    let mut usages = Vec::new();
+    for event in events {
+        match event {
+            DurableNodeEvent::Output { output, .. } => logs.push(output.text),
+            DurableNodeEvent::TokenUsage(usage) => usages.push(usage),
+        }
+    }
+    (completion, logs.join("\n"), usages)
+}
+
+async fn failure_runtime(
+    adapter: Arc<NativeV2CodexAdapter>,
+    environment: &[&str],
+) -> (AdmittedRun, NativeNodeRunner) {
+    let admitted = admitted(
+        binding(SessionScope::Execution, environment),
+        CodexProvider::OpenAi,
+    )
+    .await;
+    let runtime = runner(&admitted, adapter);
+    (admitted, runtime)
+}
+
+async fn failed_with_openai_key(adapter: Arc<NativeV2CodexAdapter>) -> (NodeRunnerError, String) {
+    failed_with_logs(
+        adapter,
+        &["OPENAI_API_KEY"],
+        &[("OPENAI_API_KEY", "fake-openai-key".to_owned())],
+    )
+    .await
+}
+
+fn assert_actionable_retry(error: &NodeRunnerError, logs: &str) {
+    assert_eq!(*error, NodeRunnerError::Driver);
+    assert_eq!(
+        logs.matches("Codex provider failed; continuing once")
+            .count(),
+        1
+    );
+    assert!(!logs.contains("execution failed without provider detail"));
+}
+
+#[tokio::test]
+async fn nonexistent_executable_reports_launch_detail_and_retries_once() {
+    let directory = TestDirectory::new("codex-missing-executable");
+    let runtime_home = directory.child("runtime-home");
+    fs::create_dir_all(&runtime_home).assert_value();
+    let adapter = adapter_with_paths(&directory, directory.child("missing-codex"), runtime_home);
+    let (error, logs) = failed_with_openai_key(adapter).await;
+
+    assert_actionable_retry(&error, &logs);
+    assert!(logs.contains("provider process could not start: process launch failed before start"));
+}
+
+#[tokio::test]
+async fn early_exit_preserves_stdin_or_exit_detail_and_redacted_stderr() {
+    let directory = TestDirectory::new("codex-early-exit");
+    let executable = directory.write_executable("early-exit", EARLY_EXIT_SCRIPT);
+    let runtime_home = directory.child("runtime-home");
+    fs::create_dir_all(&runtime_home).assert_value();
+    let adapter = adapter_with_paths(&directory, executable, runtime_home);
+    let (error, logs, usages) = failed_with_events(
+        adapter,
+        &["OPENAI_API_KEY", "TEST_SECRET"],
+        &[
+            ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+            ("TEST_SECRET", "sentinel-secret".to_owned()),
+        ],
+    )
+    .await;
+
+    assert_actionable_retry(&error, &logs);
+    assert!(logs.contains("provider process exited with status 23"));
+    assert!(logs.contains("stderr: early provider exit contains [REDACTED]"));
+    assert!(!logs.contains("sentinel-secret"));
+    assert_eq!(usages, [None, None]);
+}
+
+#[tokio::test]
+async fn preterminal_thread_conflict_records_authoritative_turn_usage() {
+    let directory = TestDirectory::new("codex-preterminal-thread-conflict-usage");
+    let adapter = scripted_adapter_with(
+        &directory,
+        CodexProvider::OpenAi,
+        "thread-conflict",
+        r#"#!/bin/sh
+set -eu
+cat >/dev/null
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-one"}'
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-two"}'
+printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":42}}"}}'
+printf '%s%s\n' \
+  '{"type":"turn.completed","usage":{"input_tokens":43,"output_tokens":19,' \
+  '"cached_input_tokens":13,"cache_write_input_tokens":5}}'
+"#,
+    );
+    let (error, logs, usages) = failed_with_events(
+        adapter,
+        &["OPENAI_API_KEY"],
+        &[("OPENAI_API_KEY", "fake-openai-key".to_owned())],
+    )
+    .await;
+
+    assert_actionable_retry(&error, &logs);
+    assert!(logs.contains("Codex output contained conflicting thread IDs"));
+    assert_eq!(usages.len(), 2);
+    for usage in usages {
+        let usage = usage.assert_value();
+        assert_eq!(usage.input_tokens.get(), 43);
+        assert_eq!(usage.output_tokens.get(), 19);
+        assert_eq!(usage.cache_read_input_tokens.assert_value().get(), 13);
+        assert_eq!(usage.cache_creation_input_tokens.assert_value().get(), 5);
+    }
+}
+
+#[tokio::test]
+async fn private_home_setup_failure_is_actionable_and_retried_once() {
+    let directory = TestDirectory::new("codex-private-home-failure");
+    let runtime_home = directory.write("runtime-home", "not a directory");
+    let adapter = adapter_with_paths(&directory, PathBuf::from("/bin/true"), runtime_home);
+    let (error, logs) = failed_with_openai_key(adapter).await;
+
+    assert_actionable_retry(&error, &logs);
+    assert!(logs.contains("provider process setup failed: process launch failed before start"));
+    assert!(logs.contains("provider private home create failed"));
+}

--- a/zeroshot-rust/src/native_v2_codex/tests/process_start/duplex.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/process_start/duplex.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+const LARGE_INPUT_BYTES: usize = 9 * 1024 * 1024;
+
+const INPUT_FAILURE_FIRST: &str = r#"#!/bin/sh
+set -eu
+if [ -e "$STATE_PATH" ]; then
+  /usr/bin/cat > "$STATE_PATH.prompt.2"
+  for argument in "$@"; do /usr/bin/printf '%s\n' "$argument" >> "$STATE_PATH.args.2"; done
+  /usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"duplex-thread"}'
+  /usr/bin/printf '%s%s\n' \
+    '{"type":"item.completed","item":{"type":"agent_message",' \
+    '"text":"{\"response\":{\"answer\":42}}"}}'
+  /usr/bin/printf '%s\n' '{"type":"turn.completed"}'
+  exit 0
+fi
+: > "$STATE_PATH"
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"duplex-thread"}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":41}}"}}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"turn.completed","usage":{"input_tokens":23,"output_tokens":9,' \
+  '"cached_input_tokens":17,"cache_write_input_tokens":5}}'
+exec 0<&-
+/usr/bin/sleep 30
+"#;
+
+const OUTPUT_FAILURE_FIRST: &str = r#"#!/bin/sh
+set -eu
+if [ -e "$STATE_PATH" ]; then
+  /usr/bin/cat > "$STATE_PATH.prompt.2"
+  for argument in "$@"; do /usr/bin/printf '%s\n' "$argument" >> "$STATE_PATH.args.2"; done
+  /usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"duplex-thread"}'
+  /usr/bin/printf '%s%s\n' \
+    '{"type":"item.completed","item":{"type":"agent_message",' \
+    '"text":"{\"response\":{\"answer\":42}}"}}'
+  /usr/bin/printf '%s\n' '{"type":"turn.completed"}'
+  exit 0
+fi
+: > "$STATE_PATH"
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"duplex-thread"}'
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":41}}"}}'
+/usr/bin/printf '%s\n' '{"type":"turn.completed"}'
+exec 1>&-
+/usr/bin/sleep 1
+exec 0<&-
+/usr/bin/sleep 30
+"#;
+
+struct DuplexRun {
+    directory: TestDirectory,
+    logs: String,
+    usages: Vec<Option<TokenUsageDelta>>,
+    completion: Result<WorkerOutcome, NodeRunnerError>,
+}
+
+async fn run_duplex(label: &str, script: &str) -> DuplexRun {
+    let directory = TestDirectory::new(label);
+    let state = directory.child("duplex-state");
+    let adapter = scripted_adapter_with(&directory, CodexProvider::OpenAi, label, script);
+    let admitted = admitted(
+        binding(SessionScope::Execution, &["OPENAI_API_KEY", "STATE_PATH"]),
+        CodexProvider::OpenAi,
+    )
+    .await;
+    let runtime = runner(&admitted, adapter);
+    let values = [
+        ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+        ("STATE_PATH", state.display().to_string()),
+    ];
+    let mut invocation = request(&admitted, 1, &values);
+    invocation.invocation.input = json!({"task":"x".repeat(LARGE_INPUT_BYTES)});
+    let handle = runtime.start(invocation).await.assert_value();
+    let (completion, logs, usages) = complete_with_events(handle).await;
+    DuplexRun {
+        directory,
+        logs,
+        usages,
+        completion: completion.map(|completion| completion.outcome),
+    }
+}
+
+fn assert_resumed(run: &DuplexRun) {
+    assert!(matches!(
+        run.completion.as_ref().assert_value(),
+        WorkerOutcome::Verified { output, .. } if output == &json!({"answer":42})
+    ));
+    assert!(run.logs.contains("provider process input failed"));
+    assert!(run.logs.contains("Codex provider failed; continuing once"));
+    assert_eq!(run.directory.read("duplex-state.prompt.2"), "Continue");
+    let arguments = run.directory.read("duplex-state.args.2");
+    assert!(arguments.lines().any(|argument| argument == "resume"));
+    assert!(
+        arguments
+            .lines()
+            .any(|argument| argument == "duplex-thread")
+    );
+}
+
+#[tokio::test]
+async fn input_failure_wins_while_the_unfinished_output_is_drained() {
+    let run = run_duplex("codex-duplex-input-first", INPUT_FAILURE_FIRST).await;
+
+    assert_resumed(&run);
+    assert_eq!(run.usages.len(), 2);
+    let usage = run.usages.first().copied().flatten().assert_value();
+    assert_eq!(usage.input_tokens.get(), 23);
+    assert_eq!(usage.output_tokens.get(), 9);
+    assert_eq!(usage.cache_read_input_tokens.assert_value().get(), 17);
+    assert_eq!(usage.cache_creation_input_tokens.assert_value().get(), 5);
+    assert_eq!(run.usages.get(1).copied().flatten(), None);
+}
+
+#[tokio::test]
+async fn completed_output_cannot_mask_input_failure_or_session_evidence() {
+    let run = run_duplex("codex-duplex-output-first", OUTPUT_FAILURE_FIRST).await;
+
+    assert_resumed(&run);
+    assert_eq!(run.usages, [None, None]);
+}

--- a/zeroshot-rust/src/native_v2_codex/tests/retry.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/retry.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-const RETRY_SCRIPT: &str = r#"#!/bin/sh
+const RETRY_SCRIPT_PREFIX: &str = r#"#!/bin/sh
 set -eu
 prompt=$(/usr/bin/cat)
 if [ -e "$STATE_PATH" ]; then attempt=2; else attempt=1; : > "$STATE_PATH"; fi
@@ -17,7 +17,9 @@ if [ "$attempt" = 1 ]; then
     '{"type":"item.completed","item":{"type":"command_execution",' \
     '"command":"cargo test","aggregated_output":"hidden sentinel-secret",' \
     '"exit_code":1,"status":"failed"}}'
-  /usr/bin/printf '%s\n' '{"type":"turn.failed","error":{"message":"provider lost sentinel-secret"}}'
+  /usr/bin/printf '%s%s\n' \
+    '{"type":"turn.failed","usage":{"input_tokens":13,"output_tokens":5},' \
+    '"error":{"message":"provider lost sentinel-secret"}}'
   exit 1
 fi
 /usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"retry-thread"}'
@@ -29,25 +31,48 @@ fi
 /usr/bin/printf '%s%s\n' \
   '{"type":"item.completed","item":{"type":"file_change",' \
   '"changes":[{"path":"src/lib.rs","kind":"update"}],"status":"completed"}}'
-/usr/bin/printf '%s%s\n' \
-  '{"type":"item.completed","item":{"type":"agent_message",' \
-  '"text":"{\"response\":{\"answer\":42}}"}}'
-/usr/bin/printf '%s\n' '{"type":"turn.completed"}'
+"#;
+
+const PROCESS_FAILURE_SCRIPT_PREFIX: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/cat > /dev/null
+if [ ! -e "$STATE_PATH" ]; then
+  : > "$STATE_PATH"
+  /usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"process-retry-thread"}'
+  /usr/bin/printf '%s\n' 'provider stderr contains sentinel-secret' >&2
+  exit 17
+fi
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"process-retry-thread"}'
+"#;
+
+const CLEAN_EXIT_INCOMPLETE_SCRIPT_PREFIX: &str = r#"#!/bin/sh
+set -eu
+prompt=$(/usr/bin/cat)
+if [ ! -e "$STATE_PATH" ]; then
+  : > "$STATE_PATH"
+  /usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"clean-exit-retry-thread"}'
+  /usr/bin/printf '%s\n' 'clean-exit stderr contains sentinel-secret' >&2
+  exit 0
+fi
+/usr/bin/printf '%s' "$prompt" > "$STATE_PATH.prompt.2"
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"clean-exit-retry-thread"}'
 "#;
 
 async fn codex_retry_runtime(
     directory: &TestDirectory,
+    scope: SessionScope,
 ) -> (AdmittedRun, NativeNodeRunner, PathBuf) {
     let state = directory.child("retry-state");
+    let script = script_with_success(RETRY_SCRIPT_PREFIX);
     let adapter = scripted_adapter_with(
         directory,
         CodexProvider::OpenAi,
         "codex-retry-script",
-        RETRY_SCRIPT,
+        &script,
     );
     let admitted = admitted(
         binding(
-            SessionScope::Execution,
+            scope,
             &[
                 "FAIL_TWICE",
                 "NO_FIRST_SESSION",
@@ -73,36 +98,44 @@ fn retry_values(state: &Path, fail_twice: bool, no_first_session: bool) -> Vec<(
     ]
 }
 
+async fn process_retry_logs(label: &str, script_prefix: &str) -> String {
+    let directory = TestDirectory::new(label);
+    let state = directory.child("retry-state");
+    let script = script_with_success(script_prefix);
+    let adapter = scripted_adapter_with(&directory, CodexProvider::OpenAi, label, &script);
+    let admitted = admitted(
+        binding(
+            SessionScope::Execution,
+            &["OPENAI_API_KEY", "STATE_PATH", "TEST_SECRET"],
+        ),
+        CodexProvider::OpenAi,
+    )
+    .await;
+    let runtime = runner(&admitted, adapter);
+    let handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[
+            ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+            ("STATE_PATH", state.display().to_string()),
+            ("TEST_SECRET", "sentinel-secret".to_owned()),
+        ],
+    )
+    .await;
+    complete_verified_with_logs(handle).await
+}
+
 #[tokio::test]
 async fn terminal_error_continues_once_in_the_same_session() {
     let directory = TestDirectory::new("codex-provider-retry");
-    let (admitted, runtime, state) = codex_retry_runtime(&directory).await;
-    let mut handle = start(&runtime, &admitted, 1, &retry_values(&state, false, false)).await;
-    let mut output = handle.take_initial_output().assert_value();
-    let (logs, completion) = tokio::join!(
-        async {
-            let mut logs = Vec::new();
-            while let Ok(entry) = output.recv_output().await {
-                logs.push(entry);
-            }
-            logs
-        },
-        handle.completion()
-    );
-
-    assert!(matches!(
-        completion.assert_value().outcome,
-        WorkerOutcome::Verified { output, .. } if output == json!({"answer": 42})
-    ));
+    let (admitted, runtime, state) = codex_retry_runtime(&directory, SessionScope::Execution).await;
+    let handle = start(&runtime, &admitted, 1, &retry_values(&state, false, false)).await;
+    let rendered = complete_verified_with_logs(handle).await;
     assert_eq!(
         fs::read_to_string(state.with_extension("prompt.2")).assert_value(),
         "Continue"
     );
-    let rendered = logs
-        .iter()
-        .map(|entry| entry.text.as_str())
-        .collect::<Vec<_>>()
-        .join("\n");
     assert!(rendered.contains("Codex command completed: cargo test [failed] exit=1"));
     assert!(rendered.contains("hidden [REDACTED]"));
     assert!(rendered.contains("Codex provider failure: provider lost [REDACTED]"));
@@ -112,9 +145,27 @@ async fn terminal_error_continues_once_in_the_same_session() {
 }
 
 #[tokio::test]
+async fn terminal_failure_usage_is_recorded_before_the_retry() {
+    let directory = TestDirectory::new("codex-provider-retry-usage");
+    let (admitted, runtime, state) = codex_retry_runtime(&directory, SessionScope::Execution).await;
+    let mut handle = start(&runtime, &admitted, 1, &retry_values(&state, false, false)).await;
+    let mut output = handle.take_initial_output().assert_value();
+
+    let failed_usage = output.recv_usage().await.assert_value().assert_value();
+    assert_eq!(failed_usage.input_tokens.get(), 13);
+    assert_eq!(failed_usage.output_tokens.get(), 5);
+    assert_eq!(output.recv_usage().await.assert_value(), None);
+    assert!(matches!(
+        handle.completion().await.assert_value().outcome,
+        WorkerOutcome::Verified { .. }
+    ));
+}
+
+#[tokio::test]
 async fn no_session_retries_the_original_prompt_once() {
     let directory = TestDirectory::new("codex-provider-retry-no-session");
-    let (admitted, runtime, state) = codex_retry_runtime(&directory).await;
+    let (admitted, runtime, state) =
+        codex_retry_runtime(&directory, SessionScope::NodeInstance).await;
     let mut handle = start(&runtime, &admitted, 1, &retry_values(&state, false, true)).await;
 
     assert!(matches!(
@@ -135,10 +186,37 @@ async fn no_session_retries_the_original_prompt_once() {
 #[tokio::test]
 async fn terminal_error_is_retried_only_once() {
     let directory = TestDirectory::new("codex-provider-retry-limit");
-    let (admitted, runtime, state) = codex_retry_runtime(&directory).await;
+    let (admitted, runtime, state) = codex_retry_runtime(&directory, SessionScope::Execution).await;
     let mut handle = start(&runtime, &admitted, 1, &retry_values(&state, true, false)).await;
 
     assert_eq!(handle.completion().await, Err(NodeRunnerError::Driver));
     assert!(state.with_extension("prompt.2").exists());
     assert!(!state.with_extension("prompt.3").exists());
+}
+
+#[tokio::test]
+async fn process_failure_detail_and_stderr_are_preserved_before_retry() {
+    let rendered = process_retry_logs(
+        "codex-process-failure-script",
+        PROCESS_FAILURE_SCRIPT_PREFIX,
+    )
+    .await;
+    assert!(rendered.contains("provider process exited with status 17"));
+    assert!(rendered.contains("stderr: provider stderr contains [REDACTED]"));
+    assert!(!rendered.contains("execution failed without provider detail"));
+    assert!(!rendered.contains("sentinel-secret"));
+}
+
+#[tokio::test]
+async fn clean_exit_incomplete_stream_preserves_stderr_and_retries() {
+    let rendered = process_retry_logs(
+        "codex-clean-exit-incomplete-script",
+        CLEAN_EXIT_INCOMPLETE_SCRIPT_PREFIX,
+    )
+    .await;
+    assert!(rendered.contains("Codex output ended without a terminal turn event"));
+    assert!(rendered.contains("stderr: clean-exit stderr contains [REDACTED]"));
+    assert!(rendered.contains("Codex provider failed; continuing once"));
+    assert!(!rendered.contains("execution failed without provider detail"));
+    assert!(!rendered.contains("sentinel-secret"));
 }

--- a/zeroshot-rust/src/native_v2_codex/tests/session_id.rs
+++ b/zeroshot-rust/src/native_v2_codex/tests/session_id.rs
@@ -1,0 +1,233 @@
+use super::*;
+
+const CHANGED_THREAD_SCRIPT_PREFIX: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/cat > /dev/null
+if [ ! -e "$STATE_PATH" ]; then
+  : > "$STATE_PATH"
+  /usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"thread-one"}'
+  /usr/bin/printf '%s\n' '{"type":"turn.failed","error":{"message":"retry me"}}'
+  exit 1
+fi
+/usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"thread-two"}'
+"#;
+
+const NO_THREAD_SCRIPT_PREFIX: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/cat > /dev/null
+"#;
+
+const NO_THREAD_CORRECTION_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/cat > /dev/null
+/usr/bin/printf '%s%s\n' \
+  '{"type":"item.completed","item":{"type":"agent_message",' \
+  '"text":"{\"response\":{\"answer\":\"wrong\"}}"}}'
+/usr/bin/printf '%s\n' '{"type":"turn.completed"}'
+"#;
+
+const RETAINED_THREAD_SCRIPT: &str = r#"#!/bin/sh
+set -eu
+/usr/bin/cat > /dev/null
+{
+  for argument in "$@"; do /usr/bin/printf 'arg=%s\n' "$argument"; done
+  /usr/bin/printf '%s\n' '---'
+} >> "$CAPTURE_PATH"
+if [ ! -e "$STATE_PATH" ]; then
+  : > "$STATE_PATH"
+  /usr/bin/printf '%s\n' '{"type":"thread.started","thread_id":"retained-thread"}'
+  /usr/bin/printf '%s%s\n' \
+    '{"type":"item.completed","item":{"type":"agent_message",' \
+    '"text":"{\"response\":{\"answer\":42}}"}}'
+else
+  /usr/bin/printf '%s%s\n' \
+    '{"type":"item.completed","item":{"type":"agent_message",' \
+    '"text":"{\"response\":{\"answer\":43}}"}}'
+fi
+/usr/bin/printf '%s\n' '{"type":"turn.completed"}'
+"#;
+
+async fn assert_two_turn_outputs(
+    runtime: &NativeNodeRunner,
+    admitted: &AdmittedRun,
+    values: &[(&str, String)],
+) {
+    for (execution, expected) in [(1, 42), (2, 43)] {
+        let mut handle = start(runtime, admitted, execution, values).await;
+        assert!(matches!(
+            handle.completion().await.assert_value().outcome,
+            WorkerOutcome::Verified { output, .. } if output == json!({"answer":expected})
+        ));
+    }
+}
+
+async fn missing_thread_failure(
+    directory: &TestDirectory,
+    scope: SessionScope,
+    name: &str,
+    body: &str,
+) -> String {
+    let (admitted, runtime) = openai_scripted_runtime(
+        directory,
+        OpenAiScript {
+            scope,
+            environment: &["OPENAI_API_KEY"],
+            name,
+            body,
+        },
+    )
+    .await;
+    let handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[("OPENAI_API_KEY", "fake-openai-key".to_owned())],
+    )
+    .await;
+    let (logs, completion) = complete_with_logs(handle).await;
+    assert_eq!(completion, Err(NodeRunnerError::Driver));
+    logs
+}
+
+#[tokio::test]
+async fn long_provider_thread_id_survives_and_resumes_exactly() {
+    let directory = TestDirectory::new("codex-long-thread-id");
+    let capture = directory.child("capture");
+    let thread_id = format!("thread-{}", "x".repeat(1024));
+    let (admitted, runtime) = openai_runtime(
+        &directory,
+        SessionScope::NodeInstance,
+        &["CAPTURE_PATH", "OPENAI_API_KEY", "THREAD_ID"],
+    )
+    .await;
+    let values = [
+        ("CAPTURE_PATH", capture.display().to_string()),
+        ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+        ("THREAD_ID", thread_id.clone()),
+    ];
+
+    assert_two_turn_outputs(&runtime, &admitted, &values).await;
+
+    let capture = fs::read_to_string(capture).assert_value();
+    assert_eq!(capture.matches("arg=resume").count(), 1);
+    assert_eq!(capture.matches(&format!("arg={thread_id}\n")).count(), 1);
+}
+
+#[tokio::test]
+async fn changed_thread_id_reports_actionable_failure_after_retry() {
+    let directory = TestDirectory::new("codex-changed-thread-id");
+    let state = directory.child("state");
+    let script = script_with_success(CHANGED_THREAD_SCRIPT_PREFIX);
+    let (admitted, runtime) = openai_scripted_runtime(
+        &directory,
+        OpenAiScript {
+            scope: SessionScope::Execution,
+            environment: &["OPENAI_API_KEY", "STATE_PATH"],
+            name: "changed-thread",
+            body: &script,
+        },
+    )
+    .await;
+    let handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[
+            ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+            ("STATE_PATH", state.display().to_string()),
+        ],
+    )
+    .await;
+    let (logs, completion) = complete_with_logs(handle).await;
+
+    assert_eq!(completion, Err(NodeRunnerError::Driver));
+    assert!(logs.contains("Codex output thread ID did not match the resumed session"));
+    assert!(!logs.contains("execution failed without provider detail"));
+}
+
+#[tokio::test]
+async fn execution_scoped_success_does_not_require_a_thread_id() {
+    let directory = TestDirectory::new("codex-execution-no-thread");
+    let script = script_with_success(NO_THREAD_SCRIPT_PREFIX);
+    let (admitted, runtime) = openai_scripted_runtime(
+        &directory,
+        OpenAiScript {
+            scope: SessionScope::Execution,
+            environment: &["OPENAI_API_KEY"],
+            name: "execution-no-thread",
+            body: &script,
+        },
+    )
+    .await;
+    let mut handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[("OPENAI_API_KEY", "fake-openai-key".to_owned())],
+    )
+    .await;
+
+    assert!(matches!(
+        handle.completion().await.assert_value().outcome,
+        WorkerOutcome::Verified { output, .. } if output == json!({"answer":42})
+    ));
+}
+
+#[tokio::test]
+async fn node_instance_success_requires_a_thread_id() {
+    let directory = TestDirectory::new("codex-node-instance-no-thread");
+    let script = script_with_success(NO_THREAD_SCRIPT_PREFIX);
+    let logs = missing_thread_failure(
+        &directory,
+        SessionScope::NodeInstance,
+        "node-instance-no-thread",
+        &script,
+    )
+    .await;
+
+    assert!(
+        logs.contains("Codex output did not provide a thread ID required for reusable session")
+    );
+}
+
+#[tokio::test]
+async fn correction_requires_a_thread_id() {
+    let directory = TestDirectory::new("codex-correction-no-thread");
+    let logs = missing_thread_failure(
+        &directory,
+        SessionScope::Execution,
+        "correction-no-thread",
+        NO_THREAD_CORRECTION_SCRIPT,
+    )
+    .await;
+
+    assert!(logs.contains("Codex output did not provide a thread ID required for correction"));
+    assert!(!logs.contains("requesting correction"));
+}
+
+#[tokio::test]
+async fn retained_resume_allows_a_turn_without_an_observed_thread_id() {
+    let directory = TestDirectory::new("codex-retained-thread");
+    let capture = directory.child("capture");
+    let state = directory.child("state");
+    let (admitted, runtime) = openai_scripted_runtime(
+        &directory,
+        OpenAiScript {
+            scope: SessionScope::NodeInstance,
+            environment: &["CAPTURE_PATH", "OPENAI_API_KEY", "STATE_PATH"],
+            name: "retained-thread",
+            body: RETAINED_THREAD_SCRIPT,
+        },
+    )
+    .await;
+    let values = [
+        ("CAPTURE_PATH", capture.display().to_string()),
+        ("OPENAI_API_KEY", "fake-openai-key".to_owned()),
+        ("STATE_PATH", state.display().to_string()),
+    ];
+    assert_two_turn_outputs(&runtime, &admitted, &values).await;
+
+    let capture = fs::read_to_string(capture).assert_value();
+    assert_eq!(capture.matches("arg=resume\n").count(), 1);
+    assert_eq!(capture.matches("arg=retained-thread\n").count(), 1);
+}

--- a/zeroshot-rust/src/native_v2_codex/turn.rs
+++ b/zeroshot-rust/src/native_v2_codex/turn.rs
@@ -14,3 +14,8 @@ pub(super) struct CodexTurnProcess {
     pub(super) process: ProcessSession,
     pub(super) _schema: CodexSchemaFile,
 }
+
+pub(super) enum CodexTurnProcessOpen {
+    Ready(CodexTurnProcess),
+    ProviderFailure(String),
+}

--- a/zeroshot-rust/src/native_v2_delivery.rs
+++ b/zeroshot-rust/src/native_v2_delivery.rs
@@ -443,8 +443,10 @@ fn ensure_active(control: &DriverControl) -> Result<(), NodeRunnerError> {
         .ok_or(NodeRunnerError::Cancelled)
 }
 
-fn emit(control: &DriverControl, message: &str) -> Result<(), NodeRunnerError> {
-    control.emit(LiveOutput::new(LiveOutputStream::System, message)?)
+async fn emit(control: &DriverControl, message: &str) -> Result<(), NodeRunnerError> {
+    control
+        .emit(LiveOutput::new(LiveOutputStream::System, message)?)
+        .await
 }
 
 fn valid_repository(value: &str) -> bool {

--- a/zeroshot-rust/src/native_v2_delivery/adapter.rs
+++ b/zeroshot-rust/src/native_v2_delivery/adapter.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 mod input;
+mod review;
 use input::source_issue;
+use review::{crash_outcome, rejected_merge_step, review_completion, ReviewProgress, ReviewStep};
 
 #[derive(Clone)]
 pub struct NativeV2DeliveryAdapter {
@@ -202,7 +204,8 @@ impl NativeV2DeliveryAdapter {
         emit(
             preparation.control,
             "delivery: review created or rediscovered",
-        )?;
+        )
+        .await?;
         Ok(review)
     }
 
@@ -220,7 +223,7 @@ impl NativeV2DeliveryAdapter {
             {
                 Ok(review) => return Ok(review),
                 Err(_) if attempt + 1 < REVIEW_SYNC_ATTEMPTS => {
-                    emit(control, "delivery: waiting for pushed review head")?;
+                    emit(control, "delivery: waiting for pushed review head").await?;
                     tokio::time::sleep(REVIEW_SYNC_INTERVAL).await;
                 }
                 Err(_) => return Err(crash_outcome()),
@@ -234,7 +237,7 @@ impl NativeV2DeliveryAdapter {
         session: &DeliverySession,
         control: &DriverControl,
     ) -> Result<String, DeliveryStop> {
-        emit(control, "delivery: preparing workspace revision")?;
+        emit(control, "delivery: preparing workspace revision").await?;
         match self
             .git
             .prepare_revision(&session.workspace, &self.config.target.base_revision)
@@ -242,13 +245,13 @@ impl NativeV2DeliveryAdapter {
         {
             Ok(revision) => Ok(revision),
             Err(GitError::NoMutation) => {
-                emit(control, "delivery: workspace has no deliverable mutation")?;
+                emit(control, "delivery: workspace has no deliverable mutation").await?;
                 Err(DeliveryStop::Outcome(WorkerOutcome::declared_failure(
                     WorkerErrorCode::Malformed,
                 )))
             }
             Err(GitError::Command) => {
-                emit(control, "delivery: local Git preparation failed")?;
+                emit(control, "delivery: local Git preparation failed").await?;
                 Err(crash_outcome())
             }
         }
@@ -265,7 +268,7 @@ impl NativeV2DeliveryAdapter {
             head_branch: review.head_branch.clone(),
             head_revision: review.head_revision.clone(),
         };
-        emit(preparation.control, "delivery: pushing run branch")?;
+        emit(preparation.control, "delivery: pushing run branch").await?;
         self.authority
             .push_branch(&push, preparation.credential)
             .await
@@ -298,7 +301,8 @@ impl NativeV2DeliveryAdapter {
         emit(
             drive.control,
             "delivery: authoritative confirmation timed out",
-        )?;
+        )
+        .await?;
         Ok(WorkerOutcome::declared_failure(WorkerErrorCode::Timeout))
     }
 
@@ -308,12 +312,12 @@ impl NativeV2DeliveryAdapter {
         progress: ReviewProgress,
     ) -> Result<ReviewStep, DeliveryStop> {
         match drive.mode {
-            DeliveryMode::PullRequest => self.advance_pull_request(drive, progress),
+            DeliveryMode::PullRequest => self.advance_pull_request(drive, progress).await,
             DeliveryMode::Merge => self.advance_merge(drive, progress).await,
         }
     }
 
-    fn advance_pull_request(
+    async fn advance_pull_request(
         &self,
         drive: &ReviewDrive<'_>,
         progress: ReviewProgress,
@@ -322,11 +326,14 @@ impl NativeV2DeliveryAdapter {
             ReviewProgress::CiFailed(_)
             | ReviewProgress::Mergeable
             | ReviewProgress::Pending
-            | ReviewProgress::Conflict => review_completion(
-                drive,
-                DELIVERY_OPENED_LABEL,
-                "GitHub authoritatively confirmed the pull request is open",
-            ),
+            | ReviewProgress::Conflict => {
+                review_completion(
+                    drive,
+                    DELIVERY_OPENED_LABEL,
+                    "GitHub authoritatively confirmed the pull request is open",
+                )
+                .await
+            }
             ReviewProgress::Merged | ReviewProgress::Closed => Err(crash_outcome()),
         }
     }
@@ -337,22 +344,28 @@ impl NativeV2DeliveryAdapter {
         progress: ReviewProgress,
     ) -> Result<ReviewStep, DeliveryStop> {
         match progress {
-            ReviewProgress::Merged => review_completion(
-                drive,
-                DELIVERY_MERGED_LABEL,
-                "GitHub authoritatively confirmed merge",
-            ),
-            ReviewProgress::Conflict => review_completion(
-                drive,
-                DELIVERY_CONFLICT_LABEL,
-                "GitHub authoritatively reported a merge conflict",
-            ),
+            ReviewProgress::Merged => {
+                review_completion(
+                    drive,
+                    DELIVERY_MERGED_LABEL,
+                    "GitHub authoritatively confirmed merge",
+                )
+                .await
+            }
+            ReviewProgress::Conflict => {
+                review_completion(
+                    drive,
+                    DELIVERY_CONFLICT_LABEL,
+                    "GitHub authoritatively reported a merge conflict",
+                )
+                .await
+            }
             ReviewProgress::CiFailed(diagnostic) => {
-                review_completion(drive, DELIVERY_CI_FAILED_LABEL, &diagnostic)
+                review_completion(drive, DELIVERY_CI_FAILED_LABEL, &diagnostic).await
             }
             ReviewProgress::Mergeable => self.advance_mergeable(drive).await,
             ReviewProgress::Pending => {
-                emit(drive.control, "delivery: waiting for required CI checks")?;
+                emit(drive.control, "delivery: waiting for required CI checks").await?;
                 Ok(ReviewStep::Continue)
             }
             ReviewProgress::Closed => Err(crash_outcome()),
@@ -367,7 +380,8 @@ impl NativeV2DeliveryAdapter {
             emit(
                 drive.control,
                 "delivery: waiting for authoritative merge confirmation",
-            )?;
+            )
+            .await?;
         } else {
             match self
                 .request_merge(drive.review, drive.credential, drive.control)
@@ -375,7 +389,7 @@ impl NativeV2DeliveryAdapter {
             {
                 GitHubMergeRequestOutcome::Accepted => drive.merge_requested = true,
                 GitHubMergeRequestOutcome::Pending => {
-                    if let Some(completion) = rejected_merge_step(drive)? {
+                    if let Some(completion) = rejected_merge_step(drive).await? {
                         return Ok(completion);
                     }
                 }
@@ -384,7 +398,8 @@ impl NativeV2DeliveryAdapter {
                         drive,
                         DELIVERY_CONFLICT_LABEL,
                         "GitHub authoritatively rejected merge due to conflict",
-                    );
+                    )
+                    .await;
                 }
             }
         }
@@ -413,77 +428,10 @@ impl NativeV2DeliveryAdapter {
         credential: GitHubCredential<'_>,
         control: &DriverControl,
     ) -> Result<GitHubMergeRequestOutcome, DeliveryStop> {
-        emit(control, "delivery: requesting merge")?;
+        emit(control, "delivery: requesting merge").await?;
         self.authority
             .request_merge(review, credential)
             .await
             .map_err(|_| crash_outcome())
     }
-}
-
-fn rejected_merge_step(drive: &mut ReviewDrive<'_>) -> Result<Option<ReviewStep>, DeliveryStop> {
-    if !drive.merge_rejection_reobserved {
-        drive.merge_rejection_reobserved = true;
-        emit(drive.control, "delivery: merge request is not yet accepted")?;
-        return Ok(None);
-    }
-    emit(
-        drive.control,
-        "delivery: target policy rejected direct merge",
-    )?;
-    Ok(Some(ReviewStep::Complete(WorkerOutcome::policy_refusal())))
-}
-
-enum ReviewProgress {
-    Merged,
-    CiFailed(String),
-    Mergeable,
-    Pending,
-    Conflict,
-    Closed,
-}
-
-enum ReviewStep {
-    Continue,
-    Complete(WorkerOutcome),
-}
-
-impl ReviewProgress {
-    fn from_state(state: GitHubReviewState) -> Result<Self, DeliveryStop> {
-        match state {
-            GitHubReviewState::Merged { merge_revision } if valid_revision(&merge_revision) => {
-                Ok(Self::Merged)
-            }
-            GitHubReviewState::Merged { .. } => {
-                Err(DeliveryStop::Outcome(WorkerOutcome::malformed()))
-            }
-            GitHubReviewState::Open {
-                checks: GitHubChecks::Failed { diagnostic },
-            } => Ok(Self::CiFailed(diagnostic)),
-            GitHubReviewState::Open {
-                checks: GitHubChecks::Pending,
-            } => Ok(Self::Pending),
-            GitHubReviewState::Open {
-                checks: GitHubChecks::NotRequired | GitHubChecks::Passed,
-            } => Ok(Self::Mergeable),
-            GitHubReviewState::Conflict => Ok(Self::Conflict),
-            GitHubReviewState::Closed => Ok(Self::Closed),
-        }
-    }
-}
-
-fn crash_outcome() -> DeliveryStop {
-    DeliveryStop::Outcome(WorkerOutcome::declared_failure(WorkerErrorCode::Crash))
-}
-
-fn review_completion(
-    drive: &ReviewDrive<'_>,
-    label: &'static str,
-    diagnostic: &str,
-) -> Result<ReviewStep, DeliveryStop> {
-    emit(drive.control, diagnostic)?;
-    validate_delivery_contract(drive.mode, drive.response).map_err(DeliveryStop::Runner)?;
-    delivery_outcome(drive.mode, label, drive.review, diagnostic)
-        .map(ReviewStep::Complete)
-        .map_err(DeliveryStop::Runner)
 }

--- a/zeroshot-rust/src/native_v2_delivery/adapter/review.rs
+++ b/zeroshot-rust/src/native_v2_delivery/adapter/review.rs
@@ -1,0 +1,71 @@
+use super::*;
+
+pub(super) async fn rejected_merge_step(
+    drive: &mut ReviewDrive<'_>,
+) -> Result<Option<ReviewStep>, DeliveryStop> {
+    if !drive.merge_rejection_reobserved {
+        drive.merge_rejection_reobserved = true;
+        emit(drive.control, "delivery: merge request is not yet accepted").await?;
+        return Ok(None);
+    }
+    emit(
+        drive.control,
+        "delivery: target policy rejected direct merge",
+    )
+    .await?;
+    Ok(Some(ReviewStep::Complete(WorkerOutcome::policy_refusal())))
+}
+
+pub(super) enum ReviewProgress {
+    Merged,
+    CiFailed(String),
+    Mergeable,
+    Pending,
+    Conflict,
+    Closed,
+}
+
+pub(super) enum ReviewStep {
+    Continue,
+    Complete(WorkerOutcome),
+}
+
+impl ReviewProgress {
+    pub(super) fn from_state(state: GitHubReviewState) -> Result<Self, DeliveryStop> {
+        match state {
+            GitHubReviewState::Merged { merge_revision } if valid_revision(&merge_revision) => {
+                Ok(Self::Merged)
+            }
+            GitHubReviewState::Merged { .. } => {
+                Err(DeliveryStop::Outcome(WorkerOutcome::malformed()))
+            }
+            GitHubReviewState::Open {
+                checks: GitHubChecks::Failed { diagnostic },
+            } => Ok(Self::CiFailed(diagnostic)),
+            GitHubReviewState::Open {
+                checks: GitHubChecks::Pending,
+            } => Ok(Self::Pending),
+            GitHubReviewState::Open {
+                checks: GitHubChecks::NotRequired | GitHubChecks::Passed,
+            } => Ok(Self::Mergeable),
+            GitHubReviewState::Conflict => Ok(Self::Conflict),
+            GitHubReviewState::Closed => Ok(Self::Closed),
+        }
+    }
+}
+
+pub(super) fn crash_outcome() -> DeliveryStop {
+    DeliveryStop::Outcome(WorkerOutcome::declared_failure(WorkerErrorCode::Crash))
+}
+
+pub(super) async fn review_completion(
+    drive: &ReviewDrive<'_>,
+    label: &'static str,
+    diagnostic: &str,
+) -> Result<ReviewStep, DeliveryStop> {
+    emit(drive.control, diagnostic).await?;
+    validate_delivery_contract(drive.mode, drive.response).map_err(DeliveryStop::Runner)?;
+    delivery_outcome(drive.mode, label, drive.review, diagnostic)
+        .map(ReviewStep::Complete)
+        .map_err(DeliveryStop::Runner)
+}

--- a/zeroshot-rust/src/native_v2_observability/projection.rs
+++ b/zeroshot-rust/src/native_v2_observability/projection.rs
@@ -74,6 +74,7 @@ pub(super) fn log_notification(
 ) -> Result<Option<RunLogEventNotification>, NativeV2ObservationError> {
     let RunEvent::SafeLog {
         execution,
+        timestamp,
         stream,
         line,
     } = &stored.event
@@ -96,6 +97,7 @@ pub(super) fn log_notification(
         subscription_id: subscription_id.clone(),
         run_id: snapshot.run_id.clone(),
         cursor: stored.cursor.clone(),
+        timestamp: *timestamp,
         execution: public_execution,
         record: log_record(*stream, line.as_str())?,
     }))

--- a/zeroshot-rust/src/native_v2_observability/tests/attach.rs
+++ b/zeroshot-rust/src/native_v2_observability/tests/attach.rs
@@ -21,6 +21,8 @@ async fn durable_logs_resume_exclusively_without_gaps_or_duplicates() {
         ["v2:4", "v2:6"]
     );
     assert_eq!(records.assert_at(0).record.message.as_str(), "first");
+    assert_eq!(records.assert_at(0).timestamp.get(), 1_725_000_000_123);
+    assert_eq!(records.assert_at(1).timestamp.get(), 1_725_000_000_456);
     let saved_log_cursor = records.assert_at(0).cursor.clone();
     drop(logs);
     let (_, mut resumed_logs) = service
@@ -34,6 +36,7 @@ async fn durable_logs_resume_exclusively_without_gaps_or_duplicates() {
     let resumed = resumed_logs.read_available().await.assert_value();
     assert_eq!(resumed.len(), 1);
     assert_eq!(resumed.assert_at(0).cursor.as_str(), "v2:6");
+    assert_eq!(resumed.assert_at(0).timestamp.get(), 1_725_000_000_456);
 }
 
 #[derive(Default)]
@@ -83,10 +86,12 @@ impl NodeDriver for ParallelVerifierDriver {
         control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
         self.release.wait().await;
-        control.emit(LiveOutput::new(
-            LiveOutputStream::Output,
-            invocation.node.reference.node.as_str(),
-        )?)?;
+        control
+            .emit(LiveOutput::new(
+                LiveOutputStream::Output,
+                invocation.node.reference.node.as_str(),
+            )?)
+            .await?;
         Ok(WorkerOutcome::Verifier {
             output: Value::Null,
             signals: BTreeMap::new(),
@@ -105,10 +110,14 @@ impl NodeDriver for ControlledDriver {
         _invocation: DriverInvocation,
         control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
-        control.emit(LiveOutput::new(LiveOutputStream::Output, "before attach")?)?;
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Output, "before attach")?)
+            .await?;
         self.first_emitted.notify_one();
         self.release.notified().await;
-        control.emit(LiveOutput::new(LiveOutputStream::Output, "after attach")?)?;
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Output, "after attach")?)
+            .await?;
         Ok(WorkerOutcome::Verified {
             output: Value::Null,
             artifacts: Vec::new(),

--- a/zeroshot-rust/src/native_v2_observability/tests/errors.rs
+++ b/zeroshot-rust/src/native_v2_observability/tests/errors.rs
@@ -93,6 +93,8 @@ pub(super) async fn persist_output(
             run_id,
             vec![RunEvent::SafeLog {
                 execution: Some(execution),
+                timestamp: openengine_cluster_protocol::UnixTimestampMillis::new(1_725_000_000_123)
+                    .assert_value(),
                 stream,
                 line: SafeLogLine::new(output.text).assert_value(),
             }],

--- a/zeroshot-rust/src/native_v2_observability/tests/status.rs
+++ b/zeroshot-rust/src/native_v2_observability/tests/status.rs
@@ -61,12 +61,20 @@ pub(super) async fn cursor_fixture() -> (
                 started(&right),
                 RunEvent::SafeLog {
                     execution: Some(left.execution),
+                    timestamp: openengine_cluster_protocol::UnixTimestampMillis::new(
+                        1_725_000_000_123,
+                    )
+                    .assert_value(),
                     stream: SafeLogStream::Output,
                     line: SafeLogLine::new("first").assert_value(),
                 },
                 completed(&left, Value::Null),
                 RunEvent::SafeLog {
                     execution: Some(left.execution),
+                    timestamp: openengine_cluster_protocol::UnixTimestampMillis::new(
+                        1_725_000_000_456,
+                    )
+                    .assert_value(),
                     stream: SafeLogStream::Output,
                     line: SafeLogLine::new("second").assert_value(),
                 },

--- a/zeroshot-rust/src/native_v2_runner.rs
+++ b/zeroshot-rust/src/native_v2_runner.rs
@@ -1,8 +1,7 @@
 //! Native-v2 node execution boundary.
 //!
-//! The runner owns only three cross-cutting runtime rules: one shared-workspace gate, exact
-//! session lifetime, and a read-only live output stream. Provider processes remain behind
-//! [`NodeDriver`], while durable observation remains in the run ledger.
+//! The runner owns workspace gates, session lifetimes, live output, and durable handoff while
+//! provider processes remain behind [`NodeDriver`].
 
 use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
@@ -12,10 +11,10 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use openengine_cluster_protocol::{
-    GraphNode, NodeInstructions, NodeName, RunId, WorkerOutcome, WorkerRef,
+    GraphNode, NodeInstructions, NodeName, RunId, UnixTimestampMillis, WorkerOutcome, WorkerRef,
 };
 use tokio::sync::{
-    broadcast, mpsc, oneshot, watch, Mutex, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock,
+    broadcast, oneshot, watch, Mutex, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock,
 };
 
 use crate::execution::driver::DriverCancellation;
@@ -28,13 +27,16 @@ use crate::native_v2_contract::{
 
 const LIVE_OUTPUT_CAPACITY: usize = 256;
 const MAX_LIVE_OUTPUT_BYTES: usize = 16 * 1024;
+pub(crate) const DURABLE_OUTPUT_CAPACITY: usize = 1024;
 
+mod handle;
 mod output;
 mod remote;
 mod response;
 
+pub use handle::NodeHandle;
 pub use output::{AttachReceiveError, DurableOutput, LiveOutputSource, ReadOnlyAttach};
-use output::closed_live_attach;
+use output::{DurableEventSender, durable_event_channel, durable_output_event};
 pub use response::{render_agent_prompt, NodeResponseContract};
 pub(crate) use response::ProviderSchemaDialect;
 pub(crate) use response::{
@@ -78,7 +80,10 @@ impl LiveOutput {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DurableNodeEvent {
-    Output(LiveOutput),
+    Output {
+        output: LiveOutput,
+        timestamp: UnixTimestampMillis,
+    },
     TokenUsage(Option<TokenUsageDelta>),
 }
 
@@ -92,6 +97,8 @@ pub enum NodeRunnerError {
     SessionLost,
     #[error("node execution failed")]
     Driver,
+    #[error("node execution failed: {0}")]
+    DriverDetail(String),
     #[error("the remote node runtime connection was lost")]
     ConnectionLost,
     #[error("node execution was cancelled")]
@@ -149,7 +156,7 @@ impl DriverInvocation {
 pub struct DriverControl {
     cancellation: watch::Receiver<bool>,
     live_output: broadcast::Sender<LiveOutput>,
-    durable_output: mpsc::UnboundedSender<DurableNodeEvent>,
+    durable_output: DurableEventSender,
 }
 
 impl DriverControl {
@@ -171,21 +178,29 @@ impl DriverControl {
         DriverCancellation::new(self.cancellation.clone())
     }
 
-    pub fn emit(&self, output: LiveOutput) -> Result<(), NodeRunnerError> {
-        self.durable_output
-            .send(DurableNodeEvent::Output(output.clone()))
-            .map_err(|_| NodeRunnerError::DurableOutputClosed)?;
+    pub async fn emit(&self, output: LiveOutput) -> Result<(), NodeRunnerError> {
+        self.send_durable(durable_output_event(output.clone()))
+            .await?;
         let _ = self.live_output.send(output);
         Ok(())
     }
 
-    pub fn record_token_usage(
+    pub async fn record_token_usage(
         &self,
         usage: Option<TokenUsageDelta>,
     ) -> Result<(), NodeRunnerError> {
         self.durable_output
-            .send(DurableNodeEvent::TokenUsage(usage))
-            .map_err(|_| NodeRunnerError::DurableOutputClosed)
+            .send_terminal(
+                DurableNodeEvent::TokenUsage(usage),
+                self.cancellation.clone(),
+            )
+            .await
+    }
+
+    async fn send_durable(&self, event: DurableNodeEvent) -> Result<(), NodeRunnerError> {
+        self.durable_output
+            .send(event, self.cancellation.clone())
+            .await
     }
 }
 
@@ -237,7 +252,7 @@ impl NodeRunner for NativeNodeRunner {
         let reference = request.invocation.reference.clone();
         let (cancel_sender, cancel_receiver) = watch::channel(false);
         let (output_sender, _) = broadcast::channel(LIVE_OUTPUT_CAPACITY);
-        let (durable_output_sender, durable_output_receiver) = mpsc::unbounded_channel();
+        let (durable_output_sender, durable_output) = durable_event_channel();
         let (completion_sender, completion_receiver) = oneshot::channel();
         let activity = self
             .activity
@@ -269,9 +284,7 @@ impl NodeRunner for NativeNodeRunner {
             reference,
             cancel: cancel_sender,
             output: Some(output_sender),
-            initial_output: Some(DurableOutput {
-                receiver: durable_output_receiver,
-            }),
+            initial_output: Some(durable_output),
             completion: Some(completion_receiver),
             cancel_on_drop: true,
         })
@@ -302,7 +315,7 @@ struct RunnerTask<'a> {
     response: NodeResponseContract,
     cancellation: watch::Receiver<bool>,
     output: broadcast::Sender<LiveOutput>,
-    durable_output: mpsc::UnboundedSender<DurableNodeEvent>,
+    durable_output: DurableEventSender,
     activity: &'a ActivityToken,
 }
 
@@ -383,70 +396,6 @@ fn session_scope(binding: &NodeRuntimeBinding) -> Result<SessionScope, NodeRunne
     match binding {
         NodeRuntimeBinding::Agent { session_scope, .. } => Ok(*session_scope),
         NodeRuntimeBinding::GitDelivery { .. } => Ok(SessionScope::Execution),
-    }
-}
-
-pub struct NodeHandle {
-    reference: ExecutionRef,
-    cancel: watch::Sender<bool>,
-    output: Option<broadcast::Sender<LiveOutput>>,
-    initial_output: Option<DurableOutput>,
-    completion: Option<oneshot::Receiver<Result<NodeCompletion, NodeRunnerError>>>,
-    cancel_on_drop: bool,
-}
-
-impl NodeHandle {
-    #[must_use]
-    pub fn reference(&self) -> &ExecutionRef {
-        &self.reference
-    }
-
-    pub fn cancel(&self) {
-        let _ = self.cancel.send(true);
-    }
-
-    #[must_use]
-    pub fn attach(&self) -> ReadOnlyAttach {
-        self.live_output_source()
-            .map_or_else(closed_live_attach, |source| source.subscribe())
-    }
-
-    /// Returns read-only subscription authority for an active execution.
-    #[must_use]
-    pub fn live_output_source(&self) -> Option<LiveOutputSource> {
-        self.output.as_ref().map(|output| LiveOutputSource {
-            output: output.clone(),
-        })
-    }
-
-    /// Takes the receiver established before execution starts for durable log bridging.
-    pub fn take_initial_output(&mut self) -> Option<DurableOutput> {
-        self.initial_output.take()
-    }
-
-    /// Waits for completion without consuming the handle.
-    ///
-    /// Cancelling this wait leaves the receiver intact so a supervisor can signal cancellation
-    /// and then wait again for the driver's cleanup acknowledgement.
-    pub async fn completion(&mut self) -> Result<NodeCompletion, NodeRunnerError> {
-        let result = self
-            .completion
-            .as_mut()
-            .ok_or(NodeRunnerError::CompletionClosed)?
-            .await
-            .map_err(|_| NodeRunnerError::CompletionClosed)?;
-        self.completion.take();
-        self.output.take();
-        self.cancel_on_drop = false;
-        result
-    }
-}
-
-impl Drop for NodeHandle {
-    fn drop(&mut self) {
-        if self.cancel_on_drop {
-            let _ = self.cancel.send(true);
-        }
     }
 }
 

--- a/zeroshot-rust/src/native_v2_runner/handle.rs
+++ b/zeroshot-rust/src/native_v2_runner/handle.rs
@@ -1,0 +1,97 @@
+use tokio::sync::{broadcast, oneshot, watch};
+
+use super::output::closed_live_attach;
+use super::{DurableOutput, LiveOutput, LiveOutputSource, NodeRunnerError, ReadOnlyAttach};
+use crate::native_v2_contract::{ExecutionRef, NodeCompletion};
+
+pub struct NodeHandle {
+    pub(super) reference: ExecutionRef,
+    pub(super) cancel: watch::Sender<bool>,
+    pub(super) output: Option<broadcast::Sender<LiveOutput>>,
+    pub(super) initial_output: Option<DurableOutput>,
+    pub(super) completion: Option<oneshot::Receiver<Result<NodeCompletion, NodeRunnerError>>>,
+    pub(super) cancel_on_drop: bool,
+}
+
+impl NodeHandle {
+    #[must_use]
+    pub fn reference(&self) -> &ExecutionRef {
+        &self.reference
+    }
+
+    pub fn cancel(&self) {
+        let _ = self.cancel.send(true);
+    }
+
+    #[must_use]
+    pub fn attach(&self) -> ReadOnlyAttach {
+        self.live_output_source()
+            .map_or_else(closed_live_attach, |source| source.subscribe())
+    }
+
+    /// Returns read-only subscription authority for an active execution.
+    #[must_use]
+    pub fn live_output_source(&self) -> Option<LiveOutputSource> {
+        self.output.as_ref().map(|output| LiveOutputSource {
+            output: output.clone(),
+        })
+    }
+
+    /// Takes the receiver established before execution starts for durable log bridging.
+    pub fn take_initial_output(&mut self) -> Option<DurableOutput> {
+        self.initial_output.take()
+    }
+
+    /// Waits for completion without consuming the handle.
+    ///
+    /// Cancelling this wait leaves the receiver intact so a supervisor can signal cancellation
+    /// and then wait again for the driver's cleanup acknowledgement. If the initial durable
+    /// receiver was not taken, this wait drains it as needed so bounded producer backpressure
+    /// cannot deadlock completion. Callers that need durable events must take the receiver first.
+    pub async fn completion(&mut self) -> Result<NodeCompletion, NodeRunnerError> {
+        let completed_while_draining = {
+            let completion = self
+                .completion
+                .as_mut()
+                .ok_or(NodeRunnerError::CompletionClosed)?;
+            if let Some(output) = self.initial_output.as_mut() {
+                loop {
+                    tokio::select! {
+                        biased;
+                        result = &mut *completion => break Some(result),
+                        () = output.wait_until_saturated() => {
+                            let event = output.recv().await;
+                            if event.is_err() {
+                                break None;
+                            }
+                        }
+                    }
+                }
+            } else {
+                None
+            }
+        };
+        let result = match completed_while_draining {
+            Some(result) => result,
+            None => {
+                self.completion
+                    .as_mut()
+                    .ok_or(NodeRunnerError::CompletionClosed)?
+                    .await
+            }
+        }
+        .map_err(|_| NodeRunnerError::CompletionClosed)?;
+        self.completion.take();
+        self.output.take();
+        self.cancel_on_drop = false;
+        result
+    }
+}
+
+impl Drop for NodeHandle {
+    fn drop(&mut self) {
+        if self.cancel_on_drop {
+            let _ = self.cancel.send(true);
+        }
+    }
+}

--- a/zeroshot-rust/src/native_v2_runner/output.rs
+++ b/zeroshot-rust/src/native_v2_runner/output.rs
@@ -1,6 +1,20 @@
-use tokio::sync::{broadcast, mpsc};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::{DurableNodeEvent, LiveOutput};
+use openengine_cluster_protocol::{MAX_SAFE_GENERATION, UnixTimestampMillis};
+use tokio::sync::{broadcast, mpsc, watch, Notify};
+
+use super::{
+    DURABLE_OUTPUT_CAPACITY, DurableNodeEvent, LiveOutput, NodeRunnerError, wait_for_cancellation,
+};
+
+/// Built-in providers emit at most four terminal-usage records per execution: the initial turn,
+/// one provider continuation, and two correction turns. Mirroring the primary durable capacity
+/// leaves generous headroom for custom drivers while keeping cancellation cleanup memory bounded.
+pub(super) const CANCELLED_TERMINAL_CAPACITY: usize = DURABLE_OUTPUT_CAPACITY;
+pub(super) const CANCELLED_TERMINAL_OVERFLOW_DETAIL: &str =
+    "terminal usage exceeded the cancellation-safe durable queue capacity";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum AttachReceiveError {
@@ -36,16 +50,269 @@ pub(super) fn closed_live_attach() -> ReadOnlyAttach {
 
 /// Lossless run-local bridge into the durable log writer.
 ///
-/// Harnesses bound the total provider output accepted for one execution, so this queue remains
-/// bounded by that harness cap without blocking provider process cleanup.
+/// Provider adapters emit bounded chunks while continuously draining the child process. The
+/// bounded output queue applies backpressure until the durable consumer has persisted earlier
+/// events. Once cancellation begins, terminal usage metadata takes a bounded, nonblocking side
+/// channel so process cleanup cannot deadlock behind a saturated output queue. Side-channel
+/// overflow is reported immediately and becomes one trailing incomplete-usage marker after both
+/// queues close and drain.
 pub struct DurableOutput {
-    pub(super) receiver: mpsc::UnboundedReceiver<DurableNodeEvent>,
+    pub(super) receiver: mpsc::Receiver<DurableNodeEvent>,
+    pub(super) cancelled_terminal: mpsc::Receiver<DurableNodeEvent>,
+    cancelled_terminal_overflowed: Arc<AtomicBool>,
+    usage_incomplete_emitted: bool,
+    saturated: Arc<Notify>,
 }
 
 impl DurableOutput {
-    pub async fn recv(&mut self) -> Result<DurableNodeEvent, AttachReceiveError> {
-        self.receiver.recv().await.ok_or(AttachReceiveError::Closed)
+    pub(super) fn new(
+        receiver: mpsc::Receiver<DurableNodeEvent>,
+        cancelled_terminal: mpsc::Receiver<DurableNodeEvent>,
+        cancelled_terminal_overflowed: Arc<AtomicBool>,
+        saturated: Arc<Notify>,
+    ) -> Self {
+        Self {
+            receiver,
+            cancelled_terminal,
+            cancelled_terminal_overflowed,
+            usage_incomplete_emitted: false,
+            saturated,
+        }
     }
+
+    pub(super) async fn wait_until_saturated(&self) {
+        if self.receiver.capacity() > 0 {
+            self.saturated.notified().await;
+        }
+    }
+
+    pub async fn recv(&mut self) -> Result<DurableNodeEvent, AttachReceiveError> {
+        loop {
+            if let Some(event) = self.try_recv() {
+                return Ok(event);
+            }
+            match self.recv_pending().await {
+                Some(event) => return Ok(event),
+                None => {
+                    if let Some(result) = self.closed_result() {
+                        return result;
+                    }
+                }
+            }
+        }
+    }
+
+    fn closed_result(&mut self) -> Option<Result<DurableNodeEvent, AttachReceiveError>> {
+        if !self.receiver.is_closed() || !self.cancelled_terminal.is_closed() {
+            return None;
+        }
+        Some(
+            self.try_recv()
+                .or_else(|| self.take_overflow_marker())
+                .ok_or(AttachReceiveError::Closed),
+        )
+    }
+
+    fn try_recv(&mut self) -> Option<DurableNodeEvent> {
+        let event = self
+            .receiver
+            .try_recv()
+            .ok()
+            .or_else(|| self.cancelled_terminal.try_recv().ok());
+        event.map(|event| self.observe(event))
+    }
+
+    fn observe(&mut self, event: DurableNodeEvent) -> DurableNodeEvent {
+        if matches!(event, DurableNodeEvent::TokenUsage(None)) {
+            self.usage_incomplete_emitted = true;
+        }
+        event
+    }
+
+    fn take_overflow_marker(&mut self) -> Option<DurableNodeEvent> {
+        if !self
+            .cancelled_terminal_overflowed
+            .swap(false, Ordering::AcqRel)
+            || self.usage_incomplete_emitted
+        {
+            return None;
+        }
+        self.usage_incomplete_emitted = true;
+        Some(DurableNodeEvent::TokenUsage(None))
+    }
+
+    async fn recv_pending(&mut self) -> Option<DurableNodeEvent> {
+        let event = match (
+            self.receiver.is_closed(),
+            self.cancelled_terminal.is_closed(),
+        ) {
+            (false, false) => tokio::select! {
+                biased;
+                event = self.receiver.recv() => event,
+                event = self.cancelled_terminal.recv() => event,
+            },
+            (false, true) => self.receiver.recv().await,
+            (true, false) => self.cancelled_terminal.recv().await,
+            // Closure is monotonic. Recheck both queues only after observing that no sender can
+            // race another enqueue; otherwise a terminal event sent between `try_recv` above and
+            // these closure observations could be mistaken for an empty stream.
+            (true, true) => return self.try_recv(),
+        };
+        event.map(|event| self.observe(event))
+    }
+
+    pub(crate) async fn recv_many(
+        &mut self,
+        events: &mut Vec<DurableNodeEvent>,
+        limit: usize,
+    ) -> usize {
+        if limit == 0 {
+            return 0;
+        }
+        let initial_len = events.len();
+        let Ok(first) = self.recv().await else {
+            return 0;
+        };
+        events.push(first);
+        while events.len() - initial_len < limit {
+            let Some(event) = self.try_recv() else {
+                break;
+            };
+            events.push(event);
+        }
+        events.len() - initial_len
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct DurableEventSender {
+    events: mpsc::Sender<DurableNodeEvent>,
+    cancelled_terminal: mpsc::Sender<DurableNodeEvent>,
+    cancelled_terminal_active: Arc<AtomicBool>,
+    cancelled_terminal_overflowed: Arc<AtomicBool>,
+    saturated: Arc<Notify>,
+}
+
+impl DurableEventSender {
+    pub(super) async fn send(
+        &self,
+        event: DurableNodeEvent,
+        mut cancellation: watch::Receiver<bool>,
+    ) -> Result<(), NodeRunnerError> {
+        tokio::select! {
+            biased;
+            _ = wait_for_cancellation(&mut cancellation) => Err(NodeRunnerError::Cancelled),
+            result = self.events.send(event) => {
+                result.map_err(|_| NodeRunnerError::DurableOutputClosed)?;
+                self.notify_if_saturated();
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) async fn send_terminal(
+        &self,
+        event: DurableNodeEvent,
+        mut cancellation: watch::Receiver<bool>,
+    ) -> Result<(), NodeRunnerError> {
+        if self.cancelled_terminal_active.load(Ordering::Acquire) {
+            return self.try_send_cancelled_terminal(event);
+        }
+        match self.events.try_send(event) {
+            Ok(()) => {
+                self.notify_if_saturated();
+                Ok(())
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(NodeRunnerError::DurableOutputClosed),
+            Err(mpsc::error::TrySendError::Full(event)) => {
+                let permit = self.events.reserve();
+                tokio::pin!(permit);
+                tokio::select! {
+                    biased;
+                    _ = wait_for_cancellation(&mut cancellation) => {
+                        self.cancelled_terminal_active.store(true, Ordering::Release);
+                        self.try_send_cancelled_terminal(event)
+                    },
+                    result = &mut permit => {
+                        let permit = result.map_err(|_| NodeRunnerError::DurableOutputClosed)?;
+                        permit.send(event);
+                        self.notify_if_saturated();
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+
+    fn try_send_cancelled_terminal(&self, event: DurableNodeEvent) -> Result<(), NodeRunnerError> {
+        match self.cancelled_terminal.try_send(event) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(NodeRunnerError::DurableOutputClosed),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.cancelled_terminal_overflowed
+                    .store(true, Ordering::Release);
+                Err(NodeRunnerError::DriverDetail(
+                    CANCELLED_TERMINAL_OVERFLOW_DETAIL.to_owned(),
+                ))
+            }
+        }
+    }
+
+    fn notify_if_saturated(&self) {
+        if self.events.capacity() == 0 {
+            self.saturated.notify_one();
+        }
+    }
+}
+
+pub(super) fn durable_event_channel() -> (DurableEventSender, DurableOutput) {
+    durable_event_channel_with_capacity(DURABLE_OUTPUT_CAPACITY)
+}
+
+pub(super) fn durable_event_channel_with_capacity(
+    capacity: usize,
+) -> (DurableEventSender, DurableOutput) {
+    let (events, receiver) = mpsc::channel(capacity);
+    let (cancelled_terminal, cancelled_terminal_receiver) =
+        mpsc::channel(CANCELLED_TERMINAL_CAPACITY);
+    let cancelled_terminal_active = Arc::new(AtomicBool::new(false));
+    let cancelled_terminal_overflowed = Arc::new(AtomicBool::new(false));
+    let saturated = Arc::new(Notify::new());
+    (
+        DurableEventSender {
+            events,
+            cancelled_terminal,
+            cancelled_terminal_active,
+            cancelled_terminal_overflowed: cancelled_terminal_overflowed.clone(),
+            saturated: saturated.clone(),
+        },
+        DurableOutput::new(
+            receiver,
+            cancelled_terminal_receiver,
+            cancelled_terminal_overflowed,
+            saturated,
+        ),
+    )
+}
+
+pub(super) fn durable_output_event(output: LiveOutput) -> DurableNodeEvent {
+    DurableNodeEvent::Output {
+        output,
+        timestamp: current_timestamp(),
+    }
+}
+
+pub(super) fn current_timestamp() -> UnixTimestampMillis {
+    let milliseconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map_or(1, |duration| {
+            u64::try_from(duration.as_millis())
+                .unwrap_or(MAX_SAFE_GENERATION)
+                .min(MAX_SAFE_GENERATION)
+        })
+        .max(1);
+    UnixTimestampMillis::new(milliseconds).unwrap_or(UnixTimestampMillis::MIN)
 }
 
 impl ReadOnlyAttach {
@@ -54,5 +321,66 @@ impl ReadOnlyAttach {
             broadcast::error::RecvError::Closed => AttachReceiveError::Closed,
             broadcast::error::RecvError::Lagged(_) => AttachReceiveError::Lagged,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn closed_output_with_terminal_event() -> DurableOutput {
+        let (sender, mut output) = durable_event_channel_with_capacity(1);
+        assert!(output.try_recv().is_none());
+        assert!(
+            sender
+                .cancelled_terminal
+                .try_send(DurableNodeEvent::TokenUsage(None))
+                .is_ok()
+        );
+        drop(sender);
+        output
+    }
+
+    #[tokio::test]
+    async fn closure_recheck_drains_terminal_event_enqueued_after_initial_probe() {
+        let mut output = closed_output_with_terminal_event();
+
+        assert_eq!(
+            output.recv_pending().await,
+            Some(DurableNodeEvent::TokenUsage(None))
+        );
+        assert_eq!(output.recv().await, Err(AttachReceiveError::Closed));
+    }
+
+    #[tokio::test]
+    async fn closed_result_rechecks_the_other_lane_after_a_closed_lane_wakes_receive() {
+        let mut output = closed_output_with_terminal_event();
+
+        assert_eq!(
+            output.closed_result(),
+            Some(Ok(DurableNodeEvent::TokenUsage(None)))
+        );
+        assert_eq!(
+            output.closed_result(),
+            Some(Err(AttachReceiveError::Closed))
+        );
+    }
+
+    #[tokio::test]
+    async fn overflow_does_not_duplicate_an_existing_incomplete_marker() {
+        let (sender, mut output) = durable_event_channel_with_capacity(1);
+        sender
+            .cancelled_terminal_overflowed
+            .store(true, Ordering::Release);
+        assert!(
+            sender
+                .cancelled_terminal
+                .try_send(DurableNodeEvent::TokenUsage(None))
+                .is_ok()
+        );
+        drop(sender);
+
+        assert_eq!(output.recv().await, Ok(DurableNodeEvent::TokenUsage(None)));
+        assert_eq!(output.recv().await, Err(AttachReceiveError::Closed));
     }
 }

--- a/zeroshot-rust/src/native_v2_runner/remote.rs
+++ b/zeroshot-rust/src/native_v2_runner/remote.rs
@@ -1,34 +1,38 @@
-use tokio::sync::{broadcast, mpsc, oneshot, watch};
+use tokio::sync::{broadcast, oneshot, watch};
 
 use super::{
-    DurableNodeEvent, DurableOutput, LIVE_OUTPUT_CAPACITY, LiveOutput, NodeHandle, NodeRunnerError,
+    DurableEventSender, DurableNodeEvent, LIVE_OUTPUT_CAPACITY, LiveOutput, NodeHandle,
+    NodeRunnerError, durable_event_channel,
 };
+#[cfg(test)]
+use super::output::current_timestamp;
 use crate::native_v2_contract::{ExecutionRef, NodeCompletion, TokenUsageDelta};
+use openengine_cluster_protocol::UnixTimestampMillis;
 
 /// Producer half used only by the private capsule transport.
 pub(crate) struct RemoteNodeHandleBridge {
+    cancellation_signal: watch::Sender<bool>,
     cancellation: watch::Receiver<bool>,
     output: Option<broadcast::Sender<LiveOutput>>,
-    durable_output: Option<mpsc::UnboundedSender<DurableNodeEvent>>,
+    durable_output: Option<DurableEventSender>,
     completion: Option<oneshot::Sender<Result<NodeCompletion, NodeRunnerError>>>,
 }
 
 pub(crate) fn remote_node_handle(reference: ExecutionRef) -> (NodeHandle, RemoteNodeHandleBridge) {
     let (cancel, cancellation) = watch::channel(false);
     let (output, _) = broadcast::channel(LIVE_OUTPUT_CAPACITY);
-    let (durable_output, durable_receiver) = mpsc::unbounded_channel();
+    let (durable_output, durable) = durable_event_channel();
     let (completion, completion_receiver) = oneshot::channel();
     let handle = NodeHandle {
         reference,
-        cancel,
+        cancel: cancel.clone(),
         output: Some(output.clone()),
-        initial_output: Some(DurableOutput {
-            receiver: durable_receiver,
-        }),
+        initial_output: Some(durable),
         completion: Some(completion_receiver),
         cancel_on_drop: true,
     };
     let bridge = RemoteNodeHandleBridge {
+        cancellation_signal: cancel,
         cancellation,
         output: Some(output),
         durable_output: Some(durable_output),
@@ -38,6 +42,10 @@ pub(crate) fn remote_node_handle(reference: ExecutionRef) -> (NodeHandle, Remote
 }
 
 impl RemoteNodeHandleBridge {
+    pub(crate) fn cancellation_signal(&self) -> watch::Sender<bool> {
+        self.cancellation_signal.clone()
+    }
+
     pub(crate) async fn cancelled(&mut self) {
         while !*self.cancellation.borrow_and_update() {
             if self.cancellation.changed().await.is_err() {
@@ -46,27 +54,47 @@ impl RemoteNodeHandleBridge {
         }
     }
 
-    pub(crate) fn emit(&self, output: LiveOutput) -> Result<(), NodeRunnerError> {
-        self.durable_output
-            .as_ref()
-            .ok_or(NodeRunnerError::DurableOutputClosed)?
-            .send(DurableNodeEvent::Output(output.clone()))
-            .map_err(|_| NodeRunnerError::DurableOutputClosed)?;
+    #[cfg(test)]
+    pub(crate) async fn emit(&self, output: LiveOutput) -> Result<(), NodeRunnerError> {
+        self.emit_at(output, current_timestamp()).await
+    }
+
+    pub(crate) async fn emit_at(
+        &self,
+        output: LiveOutput,
+        timestamp: UnixTimestampMillis,
+    ) -> Result<(), NodeRunnerError> {
+        self.send_durable(DurableNodeEvent::Output {
+            output: output.clone(),
+            timestamp,
+        })
+        .await?;
         if let Some(live) = &self.output {
             let _ = live.send(output);
         }
         Ok(())
     }
 
-    pub(crate) fn record_token_usage(
+    pub(crate) async fn record_token_usage(
         &self,
         usage: Option<TokenUsageDelta>,
     ) -> Result<(), NodeRunnerError> {
         self.durable_output
             .as_ref()
             .ok_or(NodeRunnerError::DurableOutputClosed)?
-            .send(DurableNodeEvent::TokenUsage(usage))
-            .map_err(|_| NodeRunnerError::DurableOutputClosed)
+            .send_terminal(
+                DurableNodeEvent::TokenUsage(usage),
+                self.cancellation.clone(),
+            )
+            .await
+    }
+
+    async fn send_durable(&self, event: DurableNodeEvent) -> Result<(), NodeRunnerError> {
+        let durable = self
+            .durable_output
+            .as_ref()
+            .ok_or(NodeRunnerError::DurableOutputClosed)?;
+        durable.send(event, self.cancellation.clone()).await
     }
 
     pub(crate) fn finish(mut self, result: Result<NodeCompletion, NodeRunnerError>) {

--- a/zeroshot-rust/src/native_v2_runner/response.rs
+++ b/zeroshot-rust/src/native_v2_runner/response.rs
@@ -222,7 +222,7 @@ impl AgentResponseState {
         self.prompt = prompt;
     }
 
-    pub(crate) fn accept(
+    pub(crate) async fn accept(
         &mut self,
         provider: &str,
         control: &DriverControl,
@@ -231,10 +231,12 @@ impl AgentResponseState {
         match response {
             AgentResponse::Complete(outcome) => Ok(Some(outcome)),
             AgentResponse::Correction(_) if self.corrections == MAX_OUTPUT_CORRECTIONS => {
-                control.emit(LiveOutput::new(
-                    LiveOutputStream::System,
-                    format!("{provider} final output remained malformed after two corrections"),
-                )?)?;
+                control
+                    .emit(LiveOutput::new(
+                        LiveOutputStream::System,
+                        format!("{provider} final output remained malformed after two corrections"),
+                    )?)
+                    .await?;
                 Ok(Some(WorkerOutcome::malformed()))
             }
             AgentResponse::Correction(correction) => {

--- a/zeroshot-rust/src/native_v2_runner/test_support.rs
+++ b/zeroshot-rust/src/native_v2_runner/test_support.rs
@@ -20,7 +20,7 @@ impl DurableOutput {
     pub(crate) async fn recv_output(&mut self) -> Result<LiveOutput, AttachReceiveError> {
         loop {
             match self.recv().await? {
-                DurableNodeEvent::Output(output) => return Ok(output),
+                DurableNodeEvent::Output { output, .. } => return Ok(output),
                 DurableNodeEvent::TokenUsage(_) => {}
             }
         }
@@ -31,7 +31,7 @@ impl DurableOutput {
     ) -> Result<Option<TokenUsageDelta>, AttachReceiveError> {
         loop {
             match self.recv().await? {
-                DurableNodeEvent::Output(_) => {}
+                DurableNodeEvent::Output { .. } => {}
                 DurableNodeEvent::TokenUsage(usage) => return Ok(usage),
             }
         }
@@ -292,10 +292,12 @@ impl NodeDriver for BurstDriver {
         control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
         for index in 0..(LIVE_OUTPUT_CAPACITY + 44) {
-            control.emit(LiveOutput::new(
-                LiveOutputStream::Output,
-                index.to_string(),
-            )?)?;
+            control
+                .emit(LiveOutput::new(
+                    LiveOutputStream::Output,
+                    index.to_string(),
+                )?)
+                .await?;
         }
         Ok(WorkerOutcome::Verified {
             output: Value::Null,
@@ -334,7 +336,9 @@ impl NodeDriver for FakeDriver {
             concurrency: &self.concurrency,
             reader,
         };
-        control.emit(LiveOutput::new(LiveOutputStream::Output, "working").assert_value())?;
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Output, "working").assert_value())
+            .await?;
         let mut cancellation = control.cancellation();
         tokio::select! {
             _ = cancellation.cancelled() => Err(NodeRunnerError::Cancelled),

--- a/zeroshot-rust/src/native_v2_runner/tests.rs
+++ b/zeroshot-rust/src/native_v2_runner/tests.rs
@@ -9,6 +9,9 @@ use openengine_cluster_protocol::{
 use serde_json::Value;
 use tokio::sync::watch;
 
+#[path = "tests/backpressure.rs"]
+mod backpressure;
+
 use super::*;
 use super::test_support::{
     admitted, binding, request, runner, BurstDriver, FakeDriver, FakeFactory,

--- a/zeroshot-rust/src/native_v2_runner/tests/backpressure.rs
+++ b/zeroshot-rust/src/native_v2_runner/tests/backpressure.rs
@@ -1,0 +1,244 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use openengine_cluster_protocol::{TokenCount, WorkerOutcome};
+use tokio::sync::{broadcast, watch};
+
+use super::super::{
+    AttachReceiveError, DriverControl, DurableNodeEvent, DurableOutput, LiveOutput,
+    LiveOutputStream, NodeRunner, NodeRunnerError, DURABLE_OUTPUT_CAPACITY,
+};
+use super::super::output::{
+    CANCELLED_TERMINAL_CAPACITY, CANCELLED_TERMINAL_OVERFLOW_DETAIL,
+    durable_event_channel_with_capacity,
+};
+use crate::native_v2_contract::TokenUsageDelta;
+use crate::native_v2_runner::test_support::{FakeFactory, admitted, request};
+
+use openengine_cluster_testkit::assertions::AssertValue;
+
+fn control_with_capacity(capacity: usize) -> (watch::Sender<bool>, DriverControl, DurableOutput) {
+    let (cancel, cancellation) = watch::channel(false);
+    let (live_output, _) = broadcast::channel(1);
+    let (durable_output, durable) = durable_event_channel_with_capacity(capacity);
+    (
+        cancel,
+        DriverControl {
+            cancellation,
+            live_output,
+            durable_output,
+        },
+        durable,
+    )
+}
+
+async fn saturated_cancelled_control() -> (DriverControl, DurableOutput) {
+    let (cancel, control, durable) = control_with_capacity(1);
+    control
+        .emit(LiveOutput::new(LiveOutputStream::Output, "queued").assert_value())
+        .await
+        .assert_value();
+    cancel.send_replace(true);
+    (control, durable)
+}
+
+fn token_usage(input_tokens: u64, output_tokens: u64) -> TokenUsageDelta {
+    TokenUsageDelta {
+        input_tokens: TokenCount::new(input_tokens).assert_value(),
+        output_tokens: TokenCount::new(output_tokens).assert_value(),
+        cache_read_input_tokens: None,
+        cache_creation_input_tokens: None,
+    }
+}
+
+#[tokio::test]
+async fn durable_output_backpressure_is_lossless_and_ordered() {
+    let (_cancel, control, mut durable) = control_with_capacity(1);
+    control
+        .emit(LiveOutput::new(LiveOutputStream::Output, "first").assert_value())
+        .await
+        .assert_value();
+    let second = control.emit(LiveOutput::new(LiveOutputStream::Output, "second").assert_value());
+    tokio::pin!(second);
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut second)
+            .await
+            .is_err()
+    );
+    assert!(matches!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::Output { output, .. }) if output.text == "first"
+    ));
+    second.await.assert_value();
+    assert!(matches!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::Output { output, .. }) if output.text == "second"
+    ));
+}
+
+#[tokio::test]
+async fn cancellation_does_not_discard_reported_token_usage() {
+    let (cancel, control, mut durable) = control_with_capacity(1);
+    control
+        .emit(LiveOutput::new(LiveOutputStream::Output, "queued").assert_value())
+        .await
+        .assert_value();
+    cancel.send_replace(true);
+    let usage = token_usage(13, 5);
+
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        control.record_token_usage(Some(usage)),
+    )
+    .await
+    .assert_value()
+    .assert_value();
+    assert!(matches!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::Output { output, .. }) if output.text == "queued"
+    ));
+    assert_eq!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::TokenUsage(Some(usage)))
+    );
+}
+
+#[tokio::test]
+async fn cancelled_terminal_queue_accepts_its_wide_capacity_without_blocking() {
+    let (control, mut durable) = saturated_cancelled_control().await;
+
+    for _ in 0..CANCELLED_TERMINAL_CAPACITY {
+        tokio::time::timeout(Duration::from_millis(100), control.record_token_usage(None))
+            .await
+            .assert_value()
+            .assert_value();
+    }
+
+    let mut events = Vec::with_capacity(CANCELLED_TERMINAL_CAPACITY + 1);
+    assert_eq!(
+        durable
+            .recv_many(&mut events, CANCELLED_TERMINAL_CAPACITY + 1)
+            .await,
+        CANCELLED_TERMINAL_CAPACITY + 1
+    );
+    let (first, terminal) = events.split_first().assert_value();
+    assert!(matches!(
+        first,
+        DurableNodeEvent::Output { output, .. } if output.text == "queued"
+    ));
+    assert!(
+        terminal
+            .iter()
+            .all(|event| matches!(event, DurableNodeEvent::TokenUsage(None)))
+    );
+}
+
+#[tokio::test]
+async fn cancelled_terminal_queue_reports_immediate_safe_overflow() {
+    let (control, mut durable) = saturated_cancelled_control().await;
+    let usage = token_usage(1, 1);
+
+    for _ in 0..CANCELLED_TERMINAL_CAPACITY {
+        control.record_token_usage(Some(usage)).await.assert_value();
+    }
+    let result = tokio::time::timeout(
+        Duration::from_millis(100),
+        control.record_token_usage(Some(usage)),
+    )
+    .await
+    .assert_value();
+    assert_eq!(
+        result,
+        Err(NodeRunnerError::DriverDetail(
+            CANCELLED_TERMINAL_OVERFLOW_DETAIL.to_owned()
+        ))
+    );
+
+    drop(control);
+    assert!(matches!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::Output { output, .. }) if output.text == "queued"
+    ));
+    for _ in 0..CANCELLED_TERMINAL_CAPACITY {
+        assert_eq!(
+            durable.recv().await,
+            Ok(DurableNodeEvent::TokenUsage(Some(usage)))
+        );
+    }
+    assert_eq!(durable.recv().await, Ok(DurableNodeEvent::TokenUsage(None)));
+    assert_eq!(durable.recv().await, Err(AttachReceiveError::Closed));
+}
+
+#[tokio::test]
+async fn primary_events_remain_ordered_before_cancelled_terminal_events() {
+    let (control, mut durable) = saturated_cancelled_control().await;
+    let first = token_usage(1, 2);
+    let second = token_usage(3, 4);
+    control.record_token_usage(Some(first)).await.assert_value();
+
+    assert!(matches!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::Output { output, .. }) if output.text == "queued"
+    ));
+
+    // Once cancellation diverts a terminal event, later terminal events stay in that lane even
+    // after the primary queue regains capacity. This keeps their send order observable.
+    control
+        .record_token_usage(Some(second))
+        .await
+        .assert_value();
+
+    assert_eq!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::TokenUsage(Some(first)))
+    );
+    assert_eq!(
+        durable.recv().await,
+        Ok(DurableNodeEvent::TokenUsage(Some(second)))
+    );
+}
+
+struct CompletionBurstDriver;
+
+#[async_trait]
+impl super::super::NodeDriver for CompletionBurstDriver {
+    async fn run(
+        &self,
+        _invocation: super::super::DriverInvocation,
+        control: DriverControl,
+    ) -> Result<WorkerOutcome, super::super::NodeRunnerError> {
+        for index in 0..DURABLE_OUTPUT_CAPACITY + 1 {
+            control
+                .emit(LiveOutput::new(
+                    LiveOutputStream::Output,
+                    index.to_string(),
+                )?)
+                .await?;
+        }
+        Ok(WorkerOutcome::Verified {
+            output: serde_json::Value::Null,
+            artifacts: Vec::new(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn completion_without_a_durable_consumer_does_not_deadlock() {
+    let runner = super::super::NativeNodeRunner::new(
+        &admitted(),
+        Arc::new(CompletionBurstDriver),
+        Arc::new(FakeFactory::default()),
+    )
+    .assert_value();
+    let mut handle = runner
+        .start(request("completion-drain", "worker", (1, 1)))
+        .await
+        .assert_value();
+
+    tokio::time::timeout(Duration::from_secs(1), handle.completion())
+        .await
+        .assert_value()
+        .assert_value();
+}

--- a/zeroshot-rust/src/native_v2_supervisor/runtime.rs
+++ b/zeroshot-rust/src/native_v2_supervisor/runtime.rs
@@ -166,18 +166,29 @@ pub(super) async fn bridge_durable_events(
     execution: ExecutionId,
     mut output: crate::native_v2_runner::DurableOutput,
 ) -> Result<(), RunLedgerError> {
-    while let Ok(event) = output.recv().await {
-        let event = match event {
-            DurableNodeEvent::Output(output) => RunEvent::SafeLog {
-                execution: Some(execution),
-                stream: safe_log_stream(output.stream),
-                line: SafeLogLine::new(output.text)?,
-            },
-            DurableNodeEvent::TokenUsage(usage) => {
-                RunEvent::TokenUsageObserved { execution, usage }
-            }
-        };
-        ledger.append(&run_id, vec![event]).await?;
+    const BATCH_SIZE: usize = 64;
+
+    let mut queued = Vec::with_capacity(BATCH_SIZE);
+    loop {
+        queued.clear();
+        if output.recv_many(&mut queued, BATCH_SIZE).await == 0 {
+            break;
+        }
+        let mut events = Vec::with_capacity(queued.len());
+        for event in queued.drain(..) {
+            events.push(match event {
+                DurableNodeEvent::Output { output, timestamp } => RunEvent::SafeLog {
+                    execution: Some(execution),
+                    timestamp,
+                    stream: safe_log_stream(output.stream),
+                    line: SafeLogLine::new(output.text)?,
+                },
+                DurableNodeEvent::TokenUsage(usage) => {
+                    RunEvent::TokenUsageObserved { execution, usage }
+                }
+            });
+        }
+        ledger.append(&run_id, events).await?;
     }
     Ok(())
 }
@@ -349,6 +360,7 @@ pub(super) fn runner_failure(error: NodeRunnerError) -> WorkerOutcome {
         | NodeRunnerError::SessionOpen
         | NodeRunnerError::SessionLost
         | NodeRunnerError::Driver
+        | NodeRunnerError::DriverDetail(_)
         | NodeRunnerError::ConnectionLost
         | NodeRunnerError::UnsafeOutput
         | NodeRunnerError::DurableOutputClosed

--- a/zeroshot-rust/src/native_v2_supervisor/tests.rs
+++ b/zeroshot-rust/src/native_v2_supervisor/tests.rs
@@ -144,7 +144,9 @@ impl NodeDriver for FakeDriver {
                     outcome: success_for(invocation.role),
                 })
         };
-        control.emit(LiveOutput::new(LiveOutputStream::Output, node.clone())?)?;
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Output, node.clone())?)
+            .await?;
         self.state().emissions.push(node.clone());
         let result = match behavior {
             Behavior::Complete { delay, outcome } => {

--- a/zeroshot-rust/src/native_v2_target/tests/hosted_authority.rs
+++ b/zeroshot-rust/src/native_v2_target/tests/hosted_authority.rs
@@ -206,6 +206,7 @@ fn hosted_run_response(request: &CapturedHttpRequest) -> Option<String> {
                         "subscriptionId": "logs-1",
                         "runId": "run-hosted",
                         "cursor": "v2:4",
+                        "timestamp": 1_725_000_000_123_u64,
                         "execution": "worker/1",
                         "record": {
                             "level": "info",

--- a/zeroshot-rust/src/v2_run_ledger.rs
+++ b/zeroshot-rust/src/v2_run_ledger.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use async_trait::async_trait;
 use openengine_cluster_protocol::{
     Cursor, IdempotencyKey, Phase, PositiveInteger, RunId, RunSize, RunTitle, Sha256Digest,
-    ResolvedSource, TerminalResult, TokenUsage, WorkerOutcome,
+    ResolvedSource, TerminalResult, TokenUsage, UnixTimestampMillis, WorkerOutcome,
 };
 use serde::de;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -198,6 +198,7 @@ pub enum RunEvent {
     },
     SafeLog {
         execution: Option<ExecutionId>,
+        timestamp: UnixTimestampMillis,
         stream: SafeLogStream,
         line: SafeLogLine,
     },

--- a/zeroshot-rust/src/v2_run_ledger/tests.rs
+++ b/zeroshot-rust/src/v2_run_ledger/tests.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use openengine_cluster_protocol::{
     ArtifactRef, CompiledGraphIr, IdempotencyKey, NodeName, PositiveInteger, RunId, Sha256Digest,
     RunSize, RunTitle, SourceBranchId, SourceRepositoryId, SourceRevisionId, ResolvedSource,
-    TerminalResult, TokenCount, TokenUsage, WorkerOutcome,
+    TerminalResult, TokenCount, TokenUsage, UnixTimestampMillis, WorkerOutcome,
 };
 use serde_json::{Value, json};
 
@@ -207,6 +207,7 @@ async fn fake_projects_outputs_voids_safe_logs_and_terminal_in_order() {
                 started(second.clone()),
                 RunEvent::SafeLog {
                     execution: Some(first.execution),
+                    timestamp: UnixTimestampMillis::new(1_725_000_000_123).assert_value(),
                     stream: SafeLogStream::Output,
                     line: SafeLogLine::new("working").assert_value(),
                 },
@@ -257,10 +258,10 @@ async fn fake_projects_outputs_voids_safe_logs_and_terminal_in_order() {
     assert_eq!(observation.snapshot.cursor, cursor_for(7));
     assert_eq!(observation.events.len(), 4);
     assert_eq!(observation.events.assert_at(0).cursor, cursor_for(4));
-    assert!(matches!(
-        observation.events.assert_at(0).event,
-        RunEvent::SafeLog { .. }
-    ));
+    assert_eq!(
+        safe_log_timestamp(&observation.events.assert_at(0).event),
+        Some(1_725_000_000_123)
+    );
 
     assert_eq!(
         ledger
@@ -269,6 +270,13 @@ async fn fake_projects_outputs_voids_safe_logs_and_terminal_in_order() {
             .assert_error(),
         RunLedgerError::InvalidEvent("run is already terminal")
     );
+}
+
+fn safe_log_timestamp(event: &RunEvent) -> Option<u64> {
+    match event {
+        RunEvent::SafeLog { timestamp, .. } => Some(timestamp.get()),
+        _ => None,
+    }
 }
 
 #[tokio::test]
@@ -421,6 +429,12 @@ async fn sqlite_survives_reopen_and_preserves_cursor_tail_and_identity() {
                 vec![
                     RunEvent::RunStarted,
                     started(reference(&run_id, 1)),
+                    RunEvent::SafeLog {
+                        execution: Some(ExecutionId::new(1).assert_value()),
+                        timestamp: UnixTimestampMillis::new(1_725_000_000_123).assert_value(),
+                        stream: SafeLogStream::System,
+                        line: SafeLogLine::new("persisted timestamp").assert_value(),
+                    },
                     RunEvent::TokenUsageObserved {
                         execution: ExecutionId::new(1).assert_value(),
                         usage: Some(usage(5, 1, None, None)),
@@ -434,7 +448,7 @@ async fn sqlite_survives_reopen_and_preserves_cursor_tail_and_identity() {
 
     let reopened = SqliteRunLedger::open(&path).assert_value();
     let stored = reopened.get(&run_id).await.assert_value().assert_value();
-    assert_eq!(stored.snapshot.cursor, cursor_for(4));
+    assert_eq!(stored.snapshot.cursor, cursor_for(5));
     let persisted_usage = stored.snapshot.token_usage.assert_value();
     assert_eq!(persisted_usage.input_tokens.get(), 5);
     assert_eq!(persisted_usage.output_tokens.get(), 1);
@@ -447,8 +461,20 @@ async fn sqlite_survives_reopen_and_preserves_cursor_tail_and_identity() {
         .snapshot_and_tail(&run_id, Some(&cursor_for(1)))
         .await
         .assert_value();
-    assert_eq!(observation.events.len(), 3);
+    assert_eq!(observation.events.len(), 4);
     assert_eq!(observation.events.assert_at(0).cursor, cursor_for(2));
+    let persisted_log = observation
+        .events
+        .iter()
+        .find_map(|event| match &event.event {
+            RunEvent::SafeLog {
+                timestamp, line, ..
+            } => Some((*timestamp, line)),
+            _ => None,
+        })
+        .assert_value();
+    assert_eq!(persisted_log.0.get(), 1_725_000_000_123);
+    assert_eq!(persisted_log.1.as_str(), "persisted timestamp");
 
     drop(reopened);
     std::fs::remove_file(&path).assert_value();

--- a/zeroshot-rust/tests/native_v2_cli_loopback/base.rs
+++ b/zeroshot-rust/tests/native_v2_cli_loopback/base.rs
@@ -152,10 +152,12 @@ impl NodeDriver for BlockingDriver {
         _invocation: DriverInvocation,
         mut control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
-        control.emit(LiveOutput::new(
-            LiveOutputStream::Output,
-            "acceptance-live-output",
-        )?)?;
+        control
+            .emit(LiveOutput::new(
+                LiveOutputStream::Output,
+                "acceptance-live-output",
+            )?)
+            .await?;
         control.cancelled().await;
         Err(NodeRunnerError::Cancelled)
     }

--- a/zeroshot-rust/tests/native_v2_cli_loopback/retry.rs
+++ b/zeroshot-rust/tests/native_v2_cli_loopback/retry.rs
@@ -302,8 +302,7 @@ set -eu
 attempt=1
 if [ -e attempt.state ]; then attempt=$(( $(/usr/bin/cat attempt.state) + 1 )); fi
 /usr/bin/printf '%s' "$attempt" > attempt.state
-prompt=
-for argument in "$@"; do prompt=$argument; done
+prompt=$(/usr/bin/cat)
 /usr/bin/printf '%s' "$prompt" > "attempt-$attempt.prompt"
 if [ "$attempt" = 1 ]; then
   /usr/bin/printf '%s\n' '{"type":"system","subtype":"init","session_id":"retry-session"}'

--- a/zeroshot-rust/tests/streaming_process_runner.rs
+++ b/zeroshot-rust/tests/streaming_process_runner.rs
@@ -94,12 +94,7 @@ async fn stdout_queue_applies_capacity_sixty_four_backpressure() {
         .assert_value_with("release must not depend on stdout capacity")
         .assert_value();
     assert_eq!(released.cleanup, ProcessCleanupEvidence::Reaped);
-    assert!(
-        released
-            .post_launch_error
-            .as_deref()
-            .is_some_and(|error| error.contains("drain timed out"))
-    );
+    assert_eq!(released.post_launch_error, None);
     let _ = fs::remove_file(marker);
 }
 
@@ -152,7 +147,7 @@ async fn cancellation_and_child_exit_races_settle_once() {
             .assert_value_with("child-exit race must settle")
             .assert_value();
         if completion.cancelled {
-            assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
+            assert!(completion.cleanup.proves_tree_empty());
         } else {
             assert_eq!(completion.exit_code, Some(0));
         }
@@ -331,6 +326,7 @@ async fn stderr_keeps_only_the_bounded_diagnostic_tail() {
         .assert_value();
     assert_eq!(completion.stderr_tail.len(), MAX_PROCESS_DIAGNOSTIC_BYTES);
     assert!(completion.stderr_tail.ends_with(b"TAIL"));
+    assert!(completion.stderr_tail_truncated);
     assert_eq!(completion.post_launch_error, None);
 }
 


### PR DESCRIPTION
Summary:
- remove cumulative Claude/Codex JSONL byte and event caps while retaining a 64 MiB unfinished-record guard
- preserve stderr, OS, cleanup, session, and token-usage evidence across provider failures and cancellation
- make durable event delivery bounded, ordered, timestamped, loss-aware, and race-safe through endpoint/proxy close
- project required safe-log timestamps through generated protocol types and the Python SDK

Validation:
- cargo test --workspace --all-features --all-targets
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- npm test, lint, typecheck, and protocol check
- Python Ruff, mypy, pydoclint, pytest, MkDocs, wheel, and Twine checks
- strict Opcore and staged Opcore Zero gates
- two fresh three-agent review rounds; final round reported no findings

Breaking change: native-v2 safe-log observation events now require a positive JavaScript-safe Unix millisecond timestamp.