### PR TITLE
chore: record standing rules in-tree and surface claims from agents zeroshot did not spawn

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,12 @@
             "command": "node \"$(git rev-parse --show-toplevel)/scripts/opcore-agent-gate.js\" --harness claude --repo \"$(git rev-parse --show-toplevel)\"",
             "timeout": 120,
             "statusMessage": "Running Opcore introduced-change gate"
+          },
+          {
+            "type": "command",
+            "command": "knos status 2>/dev/null || true",
+            "timeout": 10,
+            "statusMessage": "Checking shared claims"
           }
         ]
       }

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question — it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,25 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question — it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **never spawn without permission** — Do not run `zeroshot run <id>` unless the user explicitly asks to run it.  _(AGENTS.md, CRITICAL RULES)_
+- **no git in validator prompts** — Validators check files directly rather than shelling out to git.  _(AGENTS.md, CRITICAL RULES)_
+- **agents never ask questions** — Runs are non-interactive; an agent makes the autonomous decision rather than blocking on input.  _(AGENTS.md, CRITICAL RULES)_
+- **main is the only trunk** — Target normal PRs at `main`. Never recreate a long-lived `dev -> main` release-promotion flow.  _(AGENTS.md, CRITICAL RULES)_
+- **PR titles are conventional commits** — Squash merge makes the title the released commit, so `fix:`/`perf:` publish patches, `feat:` minors, and `docs:`/`chore:` intentionally publish nothing.  _(AGENTS.md, CRITICAL RULES)_
+- **manifests are non-authoritative** — Checked-in publication manifests are development versions; release tags, npm metadata and GitHub Releases are authoritative, and automation never commits versions to `main`.  _(AGENTS.md, CRITICAL RULES)_
+- **isolation copies reuse the pinned root** — Traversal, directory creation and copies go through the shared pinned-root boundary in `src/copy-containment.ts`, revalidated immediately before every filesystem effect.  _(AGENTS.md, CRITICAL RULES)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>


### PR DESCRIPTION
Opening this narrowly, because zeroshot already coordinates agents and I don't want to look like I'm proposing a second engine.

**The gap this covers is the agents zeroshot did not spawn.** A cluster knows what its own workers hold. It has no view of the Claude Code session someone left open in another terminal, or the Cursor window on the same checkout. Those are the ones that collide silently, and `scripts/opcore-agent-gate.js` catches the change after it is introduced rather than before it starts.

**What's in the PR**

- `.knos/decisions.md` — the CRITICAL RULES from `AGENTS.md` in a file a fresh clone reads with nothing installed, each line citing its source. It is markdown, so it diffs in review.
- One `PreToolUse` hook in `.claude/settings.json`, appended after the Opcore gate, printing who holds what. 10s timeout, `2>/dev/null || true`, so a machine without knos installed is unaffected and the gate's behaviour is untouched.

**Titled `chore:` deliberately** — per the release rules in `AGENTS.md`, `chore:` publishes nothing, which is the right outcome for a config addition that ships no code.

**Disclosure:** I wrote Knos. It is a local MCP server, three tools, no ports and no network. I have kept the record seeded from your rules rather than mine so it is checkable. If a third-party hook is not something you want in `.claude/settings.json`, drop that file and the decisions record still works — it needs no hook and no install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)