### PR TITLE
fix(rust): wait for all GitHub checks before merge

### DIFF
--- a/zeroshot-rust/src/native_v2_delivery/github.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github.rs
@@ -157,6 +157,8 @@ impl GhCliDeliveryAuthority {
                     "GET".to_owned(),
                     "-H".to_owned(),
                     "Accept: application/vnd.github+json".to_owned(),
+                    "--paginate".to_owned(),
+                    "--slurp".to_owned(),
                     "-f".to_owned(),
                     "per_page=100".to_owned(),
                 ],

--- a/zeroshot-rust/src/native_v2_delivery/github/tests.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/tests.rs
@@ -176,6 +176,34 @@ fn every_github_terminal_check_conclusion_is_classified() {
 }
 
 #[test]
+fn paginated_check_runs_are_classified_as_one_complete_set() {
+    let pages = json!([
+        {
+            "total_count": 2,
+            "check_runs": [check_run("scope", "completed", Some("success"))]
+        },
+        {
+            "total_count": 2,
+            "check_runs": [check_run("matrix shard", "in_progress", None)]
+        }
+    ]);
+    assert_eq!(
+        classify_checks(pages, no_statuses()).assert_value(),
+        GitHubChecks::Pending
+    );
+    assert!(
+        classify_checks(
+            json!([{
+                "total_count": 2,
+                "check_runs": [check_run("only page", "completed", Some("success"))]
+            }]),
+            no_statuses()
+        )
+        .is_err()
+    );
+}
+
+#[test]
 fn receipt_rejects_changed_authority() {
     let request = GitHubReviewRequest {
         target: DeliveryTarget::new(

--- a/zeroshot-rust/src/native_v2_delivery/github/tests.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/tests.rs
@@ -4,6 +4,24 @@ use serde_json::json;
 use super::*;
 use crate::native_v2_delivery::DeliveryTarget;
 
+fn check_run(name: &str, status: &str, conclusion: Option<&str>) -> Value {
+    json!({
+        "id": 91,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "details_url": "https://github.com/acme/project/actions/runs/17"
+    })
+}
+
+fn check_runs(runs: Vec<Value>) -> Value {
+    json!({"total_count":runs.len(),"check_runs":runs})
+}
+
+fn no_statuses() -> Value {
+    json!({"state":"pending","statuses":[]})
+}
+
 #[test]
 fn basic_credential_encoding_is_canonical() {
     assert_eq!(
@@ -72,6 +90,89 @@ fn check_evidence_is_closed_and_complete() {
         )
         .is_err()
     );
+}
+
+#[test]
+fn pending_check_runs_override_completed_successes_in_any_order() {
+    let passed = check_run("scope", "completed", Some("success"));
+    for pending_status in ["queued", "in_progress", "requested", "waiting", "pending"] {
+        let pending = check_run("frontend", pending_status, None);
+        for runs in [
+            vec![passed.clone(), pending.clone()],
+            vec![pending.clone(), passed.clone()],
+        ] {
+            assert_eq!(
+                classify_checks(check_runs(runs), no_statuses()).assert_value(),
+                GitHubChecks::Pending
+            );
+        }
+    }
+}
+
+#[test]
+fn checks_and_commit_statuses_use_failure_pending_success_precedence() {
+    let passed_checks = check_runs(vec![check_run("checks", "completed", Some("success"))]);
+    let pending_checks = check_runs(vec![check_run("checks", "in_progress", None)]);
+    let failed_checks = check_runs(vec![check_run("checks", "completed", Some("failure"))]);
+    let passed_statuses = json!({"state":"success","statuses":[{
+        "state":"success","context":"legacy-ci","description":null,"target_url":null
+    }]});
+    let pending_statuses = json!({"state":"pending","statuses":[{
+        "state":"pending","context":"legacy-ci","description":null,"target_url":null
+    }]});
+    let failed_statuses = json!({"state":"failure","statuses":[{
+        "state":"failure","context":"legacy-ci","description":null,"target_url":null
+    }]});
+
+    assert_eq!(
+        classify_checks(passed_checks.clone(), pending_statuses.clone()).assert_value(),
+        GitHubChecks::Pending
+    );
+    assert_eq!(
+        classify_checks(pending_checks, passed_statuses.clone()).assert_value(),
+        GitHubChecks::Pending
+    );
+    assert!(matches!(
+        classify_checks(failed_checks, pending_statuses).assert_value(),
+        GitHubChecks::Failed { .. }
+    ));
+    assert!(matches!(
+        classify_checks(passed_checks.clone(), failed_statuses).assert_value(),
+        GitHubChecks::Failed { .. }
+    ));
+    assert_eq!(
+        classify_checks(passed_checks, passed_statuses).assert_value(),
+        GitHubChecks::Passed
+    );
+}
+
+#[test]
+fn every_github_terminal_check_conclusion_is_classified() {
+    for conclusion in ["success", "neutral", "skipped"] {
+        assert_eq!(
+            classify_checks(
+                check_runs(vec![check_run("checks", "completed", Some(conclusion))]),
+                no_statuses()
+            )
+            .assert_value(),
+            GitHubChecks::Passed
+        );
+    }
+    for conclusion in [
+        "failure",
+        "cancelled",
+        "timed_out",
+        "action_required",
+        "stale",
+        "startup_failure",
+    ] {
+        let checks = check_runs(vec![check_run("checks", "completed", Some(conclusion))]);
+        assert!(matches!(
+            classify_checks(checks.clone(), no_statuses()).assert_value(),
+            GitHubChecks::Failed { .. }
+        ));
+        assert_eq!(failed_check_job_ids(&checks).assert_value(), vec![91]);
+    }
 }
 
 #[test]

--- a/zeroshot-rust/src/native_v2_delivery/github/tests.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/tests.rs
@@ -191,7 +191,7 @@ fn paginated_check_runs_are_classified_as_one_complete_set() {
         classify_checks(pages, no_statuses()).assert_value(),
         GitHubChecks::Pending
     );
-    assert!(
+    assert_eq!(
         classify_checks(
             json!([{
                 "total_count": 2,
@@ -199,8 +199,37 @@ fn paginated_check_runs_are_classified_as_one_complete_set() {
             }]),
             no_statuses()
         )
-        .is_err()
+        .assert_value(),
+        GitHubChecks::Pending
     );
+    assert_eq!(
+        classify_checks(
+            json!([
+                {
+                    "total_count": 2,
+                    "check_runs": [check_run("scope", "completed", Some("success"))]
+                },
+                {
+                    "total_count": 3,
+                    "check_runs": [check_run("matrix shard", "completed", Some("success"))]
+                }
+            ]),
+            no_statuses()
+        )
+        .assert_value(),
+        GitHubChecks::Pending
+    );
+    assert!(matches!(
+        classify_checks(
+            json!([{
+                "total_count": 2,
+                "check_runs": [check_run("failed shard", "completed", Some("failure"))]
+            }]),
+            no_statuses()
+        )
+        .assert_value(),
+        GitHubChecks::Failed { .. }
+    ));
 }
 
 #[test]

--- a/zeroshot-rust/src/native_v2_delivery/github/wire.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/wire.rs
@@ -176,12 +176,30 @@ pub(super) fn include_check_logs(checks: GitHubChecks, logs: &[String]) -> GitHu
 }
 
 fn decode_check_runs(check_runs: Value) -> Result<CheckRunsWire, GitHubAuthorityError> {
-    let check_runs: CheckRunsWire =
-        serde_json::from_value(check_runs).map_err(|_| GitHubAuthorityError::Rejected)?;
-    if check_runs.total_count != check_runs.check_runs.len() as u64 {
+    let pages = if check_runs.is_array() {
+        serde_json::from_value::<Vec<CheckRunsWire>>(check_runs)
+            .map_err(|_| GitHubAuthorityError::Rejected)?
+    } else {
+        vec![serde_json::from_value(check_runs).map_err(|_| GitHubAuthorityError::Rejected)?]
+    };
+    let total_count = pages
+        .first()
+        .map(|page| page.total_count)
+        .ok_or(GitHubAuthorityError::Rejected)?;
+    let mut runs = Vec::new();
+    for page in pages {
+        if page.total_count != total_count {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        runs.extend(page.check_runs);
+    }
+    if total_count != runs.len() as u64 {
         return Err(GitHubAuthorityError::Rejected);
     }
-    Ok(check_runs)
+    Ok(CheckRunsWire {
+        total_count,
+        check_runs: runs,
+    })
 }
 
 fn classify_check_runs(runs: &[CheckRunWire]) -> Result<CheckComponent, GitHubAuthorityError> {

--- a/zeroshot-rust/src/native_v2_delivery/github/wire.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/wire.rs
@@ -140,7 +140,14 @@ pub(super) fn failed_check_job_ids(check_runs: &Value) -> Result<Vec<u64>, GitHu
             run.status == "completed"
                 && matches!(
                     run.conclusion.as_deref(),
-                    Some("failure" | "cancelled" | "timed_out" | "action_required" | "stale")
+                    Some(
+                        "failure"
+                            | "cancelled"
+                            | "timed_out"
+                            | "action_required"
+                            | "stale"
+                            | "startup_failure"
+                    )
                 )
         })
         .filter_map(|run| run.id)
@@ -182,9 +189,7 @@ fn classify_check_runs(runs: &[CheckRunWire]) -> Result<CheckComponent, GitHubAu
     let mut failures = Vec::new();
     for run in runs {
         if run.status != "completed" || run.conclusion.is_none() {
-            if component == CheckComponent::Absent {
-                component = CheckComponent::Pending;
-            }
+            component = CheckComponent::Pending;
             continue;
         }
         let conclusion = run.conclusion.as_deref().unwrap_or_default();
@@ -194,7 +199,7 @@ fn classify_check_runs(runs: &[CheckRunWire]) -> Result<CheckComponent, GitHubAu
             }
         } else if matches!(
             conclusion,
-            "failure" | "cancelled" | "timed_out" | "action_required" | "stale"
+            "failure" | "cancelled" | "timed_out" | "action_required" | "stale" | "startup_failure"
         ) {
             failures.push(failure_item(
                 &run.name,

--- a/zeroshot-rust/src/native_v2_delivery/github/wire.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/wire.rs
@@ -47,6 +47,11 @@ struct CheckRunsWire {
     check_runs: Vec<CheckRunWire>,
 }
 
+struct CheckRunsSnapshot {
+    check_runs: Vec<CheckRunWire>,
+    complete: bool,
+}
+
 #[derive(Deserialize)]
 struct CheckRunWire {
     id: Option<u64>,
@@ -127,9 +132,12 @@ pub(super) fn classify_checks(
     let check_runs = decode_check_runs(check_runs)?;
     let statuses: CombinedStatusWire =
         serde_json::from_value(statuses).map_err(|_| GitHubAuthorityError::Rejected)?;
-    let check_runs = classify_check_runs(&check_runs.check_runs)?;
+    let mut check_runs_component = classify_check_runs(&check_runs.check_runs)?;
+    if !check_runs.complete && !matches!(check_runs_component, CheckComponent::Failed(_)) {
+        check_runs_component = CheckComponent::Pending;
+    }
     let statuses = classify_statuses(&statuses)?;
-    Ok(combine_checks(check_runs, statuses))
+    Ok(combine_checks(check_runs_component, statuses))
 }
 
 pub(super) fn failed_check_job_ids(check_runs: &Value) -> Result<Vec<u64>, GitHubAuthorityError> {
@@ -175,30 +183,33 @@ pub(super) fn include_check_logs(checks: GitHubChecks, logs: &[String]) -> GitHu
     }
 }
 
-fn decode_check_runs(check_runs: Value) -> Result<CheckRunsWire, GitHubAuthorityError> {
-    let pages = if check_runs.is_array() {
-        serde_json::from_value::<Vec<CheckRunsWire>>(check_runs)
-            .map_err(|_| GitHubAuthorityError::Rejected)?
-    } else {
-        vec![serde_json::from_value(check_runs).map_err(|_| GitHubAuthorityError::Rejected)?]
-    };
+fn decode_check_runs(check_runs: Value) -> Result<CheckRunsSnapshot, GitHubAuthorityError> {
+    if !check_runs.is_array() {
+        let wire: CheckRunsWire =
+            serde_json::from_value(check_runs).map_err(|_| GitHubAuthorityError::Rejected)?;
+        if wire.total_count != wire.check_runs.len() as u64 {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        return Ok(CheckRunsSnapshot {
+            check_runs: wire.check_runs,
+            complete: true,
+        });
+    }
+    let pages = serde_json::from_value::<Vec<CheckRunsWire>>(check_runs)
+        .map_err(|_| GitHubAuthorityError::Rejected)?;
     let total_count = pages
         .first()
         .map(|page| page.total_count)
         .ok_or(GitHubAuthorityError::Rejected)?;
+    let counts_match = pages.iter().all(|page| page.total_count == total_count);
     let mut runs = Vec::new();
     for page in pages {
-        if page.total_count != total_count {
-            return Err(GitHubAuthorityError::Rejected);
-        }
         runs.extend(page.check_runs);
     }
-    if total_count != runs.len() as u64 {
-        return Err(GitHubAuthorityError::Rejected);
-    }
-    Ok(CheckRunsWire {
-        total_count,
+    let complete = counts_match && total_count == runs.len() as u64;
+    Ok(CheckRunsSnapshot {
         check_runs: runs,
+        complete,
     })
 }
 


### PR DESCRIPTION
## Summary

- keep GitHub delivery pending whenever any check run is incomplete, regardless of result ordering
- classify GitHub startup failures as failed CI and retain their diagnostics
- cover GitHub Checks, legacy commit statuses, mixed backends, ordering, and terminal conclusions
- paginate matrix-heavy check sets and reject incomplete page sets

Reproduced by zero-cloud run 01a06c7c-125a-7f13-8066-84d1c55eaa6a: one completed check appeared before a still-running Frontend check, so delivery attempted the protected merge twice and terminated before the rest of CI completed.

## Verification

- cargo test -p zeroshot-rust native_v2_delivery
- cargo clippy -p zeroshot-rust --all-targets -- -D warnings
- cargo fmt --all -- --check
- opcore-zero check --repo . --changed --json
- pre-commit and pre-push repository gates