### PR TITLE
fix: keep long GitHub delivery alive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,9 @@ Native-v2 provider continuation is fixed and bounded: Claude continues once only
 `system/api_retry` event, Codex continues once after any terminal execution error, and both send
 the literal `Continue` in the same session (or rerun the original prompt only when no session was
 created). Agent output gets at most two correction turns before `malformed`. Direct GitHub merge
-rejection is reobserved once for CI registration races, then terminates as a policy refusal.
+rejection is reobserved once for CI registration races; each subsequently observed pending-check
+wave re-arms that single retry, while consecutive rejection without an intervening pending wave
+terminates as a policy refusal.
 
 Native-v2 Claude and Codex JSONL readers never cap cumulative stdout bytes or event counts. They
 share only a 64 MiB unfinished-record allocation guard, tolerate whitespace and a complete final
@@ -307,10 +309,15 @@ sourceful run plus any explicitly available declared environment values. Runtime
 connection keys to their exact required environment names; the runner injects only the names
 declared by that node. Local runs resolve missing values from the private user connection store,
 hosted targets may resolve them from advertised user or organization connection management, and
-direct targets still require an exact environment without advertising connection management. Run
-branch selection overrides the local target-profile default; otherwise the remote default branch is
-used. `target setup` mutates only the local named-target registry and never calls a remote setup
-route. The separate ephemeral `githubToken` remains trusted only for source checkout and Git
+direct targets still require an exact environment without advertising connection management.
+Resolved snapshots retain only an optional run- and node-scoped refresh authority, never the
+resolver token as an injected value. Refresh recomputes the same node binding, preserves that
+authority on the replacement snapshot, and cannot broaden the node's declared environment. Trusted
+GitHub delivery uses it only after an authority error so expiring installation credentials can be
+replaced during long CI without minting a token on every poll. Run branch selection overrides the
+local target-profile default; otherwise the remote default branch is used. `target setup` mutates
+only the local named-target registry and never calls a remote setup route. The separate ephemeral
+`githubToken` remains trusted only for source checkout and Git
 delivery; a provider receives `GH_TOKEN` only when the materialized runtime declares it. Admission,
 the ledger, observations, and target configuration never retain secret values. Exact
 submission retry identity covers the sourceful submission (including the resolved revision) while

--- a/zeroshot-rust/src/native_v2_delivery.rs
+++ b/zeroshot-rust/src/native_v2_delivery.rs
@@ -60,7 +60,6 @@ const DELIVERY_TARGET_BRANCH_FIELD: &str = "targetBranch";
 const DELIVERY_HEAD_REVISION_FIELD: &str = "headRevision";
 const DELIVERY_PULL_REQUEST_ID_FIELD: &str = "pullRequestId";
 
-const DEFAULT_POLL_ATTEMPTS: usize = 90;
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(20);
 const REVIEW_SYNC_ATTEMPTS: usize = 5;
 const REVIEW_SYNC_INTERVAL: Duration = Duration::from_secs(1);
@@ -143,7 +142,7 @@ pub enum DeliveryConfigError {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct DeliveryPollPolicy {
-    pub attempts: usize,
+    maximum_attempts: Option<usize>,
     pub interval: Duration,
 }
 
@@ -152,16 +151,30 @@ impl DeliveryPollPolicy {
         if attempts == 0 {
             return Err(DeliveryConfigError::PollAttempts);
         }
-        Ok(Self { attempts, interval })
+        Ok(Self {
+            maximum_attempts: Some(attempts),
+            interval,
+        })
+    }
+
+    const fn until_cancelled(interval: Duration) -> Self {
+        Self {
+            maximum_attempts: None,
+            interval,
+        }
+    }
+
+    const fn has_next(self, completed_attempts: usize) -> bool {
+        match self.maximum_attempts {
+            Some(maximum) => completed_attempts < maximum,
+            None => true,
+        }
     }
 }
 
 impl Default for DeliveryPollPolicy {
     fn default() -> Self {
-        Self {
-            attempts: DEFAULT_POLL_ATTEMPTS,
-            interval: DEFAULT_POLL_INTERVAL,
-        }
+        Self::until_cancelled(DEFAULT_POLL_INTERVAL)
     }
 }
 
@@ -422,18 +435,6 @@ async fn wait_for_poll(
     tokio::select! {
         _ = control.cancelled() => Err(NodeRunnerError::Cancelled),
         () = tokio::time::sleep(interval) => Ok(()),
-    }
-}
-
-async fn poll_before_next(
-    control: &mut DriverControl,
-    interval: Duration,
-    has_next: bool,
-) -> Result<(), NodeRunnerError> {
-    if has_next {
-        wait_for_poll(control, interval).await
-    } else {
-        Ok(())
     }
 }
 

--- a/zeroshot-rust/src/native_v2_delivery/adapter.rs
+++ b/zeroshot-rust/src/native_v2_delivery/adapter.rs
@@ -82,7 +82,7 @@ impl NodeDriver for NativeV2DeliveryAdapter {
         invocation: DriverInvocation,
         mut control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
-        let (session, credential, mode) = match self.authorize(&invocation) {
+        let (session, credentials, mode) = match self.authorize(&invocation) {
             Ok(authority) => authority,
             Err(stop) => return stop.result(),
         };
@@ -93,7 +93,7 @@ impl NodeDriver for NativeV2DeliveryAdapter {
             .prepare_review(DeliveryPreparation {
                 invocation: &invocation,
                 session,
-                credential,
+                credential: credentials.current(),
                 control: &control,
             })
             .await
@@ -105,7 +105,7 @@ impl NodeDriver for NativeV2DeliveryAdapter {
             mode,
             response: &invocation.response,
             review: &review,
-            credential,
+            credentials,
             control: &mut control,
             merge_requested: false,
             merge_rejection_reobserved: false,
@@ -145,17 +145,38 @@ struct ReviewDrive<'a> {
     mode: DeliveryMode,
     response: &'a NodeResponseContract,
     review: &'a GitHubReviewReceipt,
-    credential: GitHubCredential<'a>,
+    credentials: DeliveryCredentials<'a>,
     control: &'a mut DriverControl,
     merge_requested: bool,
     merge_rejection_reobserved: bool,
+}
+
+struct DeliveryCredentials<'a> {
+    environment: Option<&'a ResolvedEnvironment>,
+    token: String,
+}
+
+impl<'a> DeliveryCredentials<'a> {
+    fn current(&self) -> GitHubCredential<'_> {
+        GitHubCredential(&self.token)
+    }
+
+    async fn refresh(&mut self) -> Result<(), DeliveryStop> {
+        let environment = self.environment.ok_or_else(crash_outcome)?;
+        let refreshed = crate::native_v2_runner::refresh_environment(environment)
+            .await
+            .map_err(|_| crash_outcome())?;
+        let credential = github_credential(&refreshed).ok_or_else(crash_outcome)?;
+        self.token = credential.expose().to_owned();
+        Ok(())
+    }
 }
 
 impl NativeV2DeliveryAdapter {
     fn authorize<'a>(
         &'a self,
         invocation: &'a DriverInvocation,
-    ) -> Result<(&'a DeliverySession, GitHubCredential<'a>, DeliveryMode), DeliveryStop> {
+    ) -> Result<(&'a DeliverySession, DeliveryCredentials<'a>, DeliveryMode), DeliveryStop> {
         if invocation.role != NodeRole::GitDelivery
             || !matches!(
                 invocation.node.binding,
@@ -167,17 +188,22 @@ impl NativeV2DeliveryAdapter {
         let mode = DeliveryMode::from_worker(&invocation.node.worker)
             .ok_or(DeliveryStop::Runner(NodeRunnerError::InvalidRole))?;
         validate_delivery_contract(mode, &invocation.response)?;
-        let credential = match self.trusted_github_token.as_deref() {
-            Some(token) => GitHubCredential(token),
-            None => github_credential(&invocation.environment)
-                .ok_or_else(|| DeliveryStop::Outcome(WorkerOutcome::authentication_refusal()))?,
+        let (token, environment) = match self.trusted_github_token.as_deref() {
+            Some(token) => (token.to_owned(), None),
+            None => (
+                github_credential(&invocation.environment)
+                    .ok_or_else(|| DeliveryStop::Outcome(WorkerOutcome::authentication_refusal()))?
+                    .expose()
+                    .to_owned(),
+                Some(&invocation.environment),
+            ),
         };
         let session = invocation
             .session
             .as_any()
             .downcast_ref::<DeliverySession>()
             .ok_or(DeliveryStop::Runner(NodeRunnerError::InvalidRole))?;
-        Ok((session, credential, mode))
+        Ok((session, DeliveryCredentials { environment, token }, mode))
     }
 
     async fn prepare_review(
@@ -280,30 +306,38 @@ impl NativeV2DeliveryAdapter {
         &self,
         mut drive: ReviewDrive<'_>,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
-        for attempt in 0..self.config.poll.attempts {
-            ensure_active(drive.control)?;
-            let progress = match self.observe_review(drive.review, drive.credential).await {
-                Ok(progress) => progress,
-                Err(stop) => return stop.result(),
-            };
-            match self.advance_review(&mut drive, progress).await {
-                Ok(ReviewStep::Continue) => {}
-                Ok(ReviewStep::Complete(outcome)) => return Ok(outcome),
-                Err(stop) => return stop.result(),
+        let mut completed_attempts = 0usize;
+        loop {
+            if let Some(outcome) = self.drive_review_step(&mut drive).await? {
+                return Ok(outcome);
             }
-            poll_before_next(
-                drive.control,
-                self.config.poll.interval,
-                attempt + 1 < self.config.poll.attempts,
-            )
-            .await?;
+            completed_attempts = completed_attempts.saturating_add(1);
+            if !self.config.poll.has_next(completed_attempts) {
+                emit(
+                    drive.control,
+                    "delivery: authoritative confirmation timed out",
+                )
+                .await?;
+                return Ok(WorkerOutcome::declared_failure(WorkerErrorCode::Timeout));
+            }
+            wait_for_poll(drive.control, self.config.poll.interval).await?;
         }
-        emit(
-            drive.control,
-            "delivery: authoritative confirmation timed out",
-        )
-        .await?;
-        Ok(WorkerOutcome::declared_failure(WorkerErrorCode::Timeout))
+    }
+
+    async fn drive_review_step(
+        &self,
+        drive: &mut ReviewDrive<'_>,
+    ) -> Result<Option<WorkerOutcome>, NodeRunnerError> {
+        ensure_active(drive.control)?;
+        let progress = match self.observe_review(drive).await {
+            Ok(progress) => progress,
+            Err(stop) => return stop.result().map(Some),
+        };
+        match self.advance_review(drive, progress).await {
+            Ok(ReviewStep::Continue) => Ok(None),
+            Ok(ReviewStep::Complete(outcome)) => Ok(Some(outcome)),
+            Err(stop) => stop.result().map(Some),
+        }
     }
 
     async fn advance_review(
@@ -365,6 +399,7 @@ impl NativeV2DeliveryAdapter {
             }
             ReviewProgress::Mergeable => self.advance_mergeable(drive).await,
             ReviewProgress::Pending => {
+                drive.merge_rejection_reobserved = false;
                 emit(drive.control, "delivery: waiting for required CI checks").await?;
                 Ok(ReviewStep::Continue)
             }
@@ -383,10 +418,7 @@ impl NativeV2DeliveryAdapter {
             )
             .await?;
         } else {
-            match self
-                .request_merge(drive.review, drive.credential, drive.control)
-                .await?
-            {
+            match self.request_merge(drive).await? {
                 GitHubMergeRequestOutcome::Accepted => drive.merge_requested = true,
                 GitHubMergeRequestOutcome::Pending => {
                     if let Some(completion) = rejected_merge_step(drive).await? {
@@ -408,15 +440,24 @@ impl NativeV2DeliveryAdapter {
 
     async fn observe_review(
         &self,
-        review: &GitHubReviewReceipt,
-        credential: GitHubCredential<'_>,
+        drive: &mut ReviewDrive<'_>,
     ) -> Result<ReviewProgress, DeliveryStop> {
-        let observation = self
+        let observation = match self
             .authority
-            .inspect_review(review, credential)
+            .inspect_review(drive.review, drive.credentials.current())
             .await
-            .map_err(|_| crash_outcome())?;
-        if !valid_observation(review, &observation) {
+        {
+            Ok(observation) => observation,
+            Err(_) => {
+                emit(drive.control, "delivery: refreshing GitHub credential").await?;
+                drive.credentials.refresh().await?;
+                self.authority
+                    .inspect_review(drive.review, drive.credentials.current())
+                    .await
+                    .map_err(|_| crash_outcome())?
+            }
+        };
+        if !valid_observation(drive.review, &observation) {
             return Err(DeliveryStop::Outcome(WorkerOutcome::malformed()));
         }
         ReviewProgress::from_state(observation.state)
@@ -424,14 +465,23 @@ impl NativeV2DeliveryAdapter {
 
     async fn request_merge(
         &self,
-        review: &GitHubReviewReceipt,
-        credential: GitHubCredential<'_>,
-        control: &DriverControl,
+        drive: &mut ReviewDrive<'_>,
     ) -> Result<GitHubMergeRequestOutcome, DeliveryStop> {
-        emit(control, "delivery: requesting merge").await?;
-        self.authority
-            .request_merge(review, credential)
+        emit(drive.control, "delivery: requesting merge").await?;
+        match self
+            .authority
+            .request_merge(drive.review, drive.credentials.current())
             .await
-            .map_err(|_| crash_outcome())
+        {
+            Ok(outcome) => Ok(outcome),
+            Err(_) => {
+                emit(drive.control, "delivery: refreshing GitHub credential").await?;
+                drive.credentials.refresh().await?;
+                self.authority
+                    .request_merge(drive.review, drive.credentials.current())
+                    .await
+                    .map_err(|_| crash_outcome())
+            }
+        }
     }
 }

--- a/zeroshot-rust/src/native_v2_delivery/github.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github.rs
@@ -161,6 +161,8 @@ impl GhCliDeliveryAuthority {
                     "--slurp".to_owned(),
                     "-f".to_owned(),
                     "per_page=100".to_owned(),
+                    "-f".to_owned(),
+                    "filter=latest".to_owned(),
                 ],
                 credential,
             )

--- a/zeroshot-rust/src/native_v2_delivery/tests.rs
+++ b/zeroshot-rust/src/native_v2_delivery/tests.rs
@@ -118,6 +118,21 @@ async fn merge_rejection_before_ci_registration_is_reobserved() {
 }
 
 #[tokio::test]
+async fn multiple_ci_registration_waves_each_allow_a_fresh_merge_attempt() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(
+        repo.remote.clone(),
+        Script::MultipleRegistrationWaves,
+    ));
+
+    let outcome = run_delivery(&repo, authority.clone(), 7, DeliveryMode::Merge).await;
+
+    assert_delivery_signal(&outcome, DELIVERY_MERGED_LABEL);
+    assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 3);
+    assert_eq!(authority.inspections.load(Ordering::SeqCst), 6);
+}
+
+#[tokio::test]
 async fn protected_branch_rejects_unsupported_direct_merge_promptly() {
     let repo = TempRepo::delivery();
     let authority = Arc::new(FakeGitHub::new(
@@ -158,6 +173,66 @@ async fn accepted_merge_request_is_not_shipping_success() {
     assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 1);
 }
 
+#[test]
+fn hosted_delivery_polling_has_no_work_duration_limit() {
+    assert!(DeliveryPollPolicy::default().has_next(usize::MAX));
+    assert!(
+        !DeliveryPollPolicy::new(3, Duration::ZERO)
+            .assert_value()
+            .has_next(3)
+    );
+}
+
+struct RefreshedDeliveryEnvironment {
+    binding: NodeRuntimeBinding,
+}
+
+#[async_trait]
+impl crate::native_v2_runner::RuntimeEnvironmentRefresh for RefreshedDeliveryEnvironment {
+    async fn refresh(
+        &self,
+    ) -> Result<ResolvedEnvironment, crate::native_v2_runner::EnvironmentRefreshUnavailable> {
+        ResolvedEnvironment::exact(
+            &self.binding,
+            BTreeMap::from([(
+                EnvironmentVariableName::new(GITHUB_TOKEN_ENV).assert_value(),
+                "refreshed-token".to_owned(),
+            )]),
+        )
+        .map_err(|_| crate::native_v2_runner::EnvironmentRefreshUnavailable)
+    }
+}
+
+#[tokio::test]
+async fn delivery_refreshes_an_expired_dynamic_github_credential() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(
+        repo.remote.clone(),
+        Script::CredentialExpires,
+    ));
+    let admitted = admitted(&repo, DeliveryMode::Merge).await;
+    let binding = admitted
+        .runtime
+        .nodes()
+        .get(&NodeName::new("deliver").assert_value())
+        .assert_value()
+        .clone();
+    let outcome = run_delivery_with_id(
+        DeliveryRunRequest {
+            repo: &repo,
+            attempts: 3,
+            mode: DeliveryMode::Merge,
+            run_id: "refresh-delivery-credential",
+            refresh: Some(Arc::new(RefreshedDeliveryEnvironment { binding })),
+        },
+        authority.clone(),
+    )
+    .await;
+
+    assert_delivery_signal(&outcome, DELIVERY_MERGED_LABEL);
+    assert_eq!(authority.inspections.load(Ordering::SeqCst), 3);
+}
+
 #[tokio::test]
 async fn exact_merge_retry_rediscovers_the_same_review_and_receipt() {
     let repo = TempRepo::delivery();
@@ -168,6 +243,7 @@ async fn exact_merge_retry_rediscovers_the_same_review_and_receipt() {
             attempts: 3,
             mode: DeliveryMode::Merge,
             run_id: "stable-delivery-run",
+            refresh: None,
         },
         authority.clone(),
     )
@@ -178,6 +254,7 @@ async fn exact_merge_retry_rediscovers_the_same_review_and_receipt() {
             attempts: 3,
             mode: DeliveryMode::Merge,
             run_id: "stable-delivery-run",
+            refresh: None,
         },
         authority.clone(),
     )
@@ -246,6 +323,7 @@ async fn run_delivery(
             attempts,
             mode,
             run_id: "delivery-run",
+            refresh: None,
         },
         authority,
     )
@@ -257,6 +335,7 @@ struct DeliveryRunRequest<'a> {
     attempts: usize,
     mode: DeliveryMode,
     run_id: &'a str,
+    refresh: Option<Arc<dyn crate::native_v2_runner::RuntimeEnvironmentRefresh>>,
 }
 
 async fn run_delivery_with_id(
@@ -278,7 +357,7 @@ async fn run_delivery_with_id(
         .get(&NodeName::new("deliver").assert_value())
         .assert_value()
         .clone();
-    let environment = ResolvedEnvironment::exact(
+    let mut environment = ResolvedEnvironment::exact(
         &binding,
         BTreeMap::from([(
             EnvironmentVariableName::new(GITHUB_TOKEN_ENV).assert_value(),
@@ -286,6 +365,9 @@ async fn run_delivery_with_id(
         )]),
     )
     .assert_value();
+    if let Some(refresh) = request.refresh {
+        environment = crate::native_v2_runner::with_environment_refresh(environment, refresh);
+    }
     let mut handle = runner
         .start(NodeRunRequest {
             invocation: NodeInvocation {

--- a/zeroshot-rust/src/native_v2_delivery/tests/github_acceptance.rs
+++ b/zeroshot-rust/src/native_v2_delivery/tests/github_acceptance.rs
@@ -84,6 +84,7 @@ fn assert_production_github_capture(gh_capture: &str, home: &Path) {
     assert!(gh_capture.contains("arg=repos/acme/project/issues/208"));
     assert!(gh_capture.contains("arg=repos/acme/project/issues/208/comments"));
     assert!(gh_capture.contains("arg=page=1"));
+    assert!(gh_capture.contains("arg=filter=latest"));
     assert!(gh_capture.contains(
         "arg=body=Zeroshot opened pull request #17 for this issue.\n\n<!-- zeroshot-delivery:zeroshot/v2-test -->"
     ));

--- a/zeroshot-rust/src/native_v2_delivery/tests/github_fixture.rs
+++ b/zeroshot-rust/src/native_v2_delivery/tests/github_fixture.rs
@@ -16,10 +16,12 @@ pub(super) enum Script {
     Conflict,
     ConflictAtMerge,
     RegistrationRace,
+    MultipleRegistrationWaves,
     ProtectedBranch,
     ReviewSyncRace,
     CiFailsThenMerges,
     NeverConfirmsMerge,
+    CredentialExpires,
 }
 
 pub(super) struct FakeGitHub {
@@ -49,13 +51,13 @@ impl FakeGitHub {
 
     fn review_state(&self, inspection: usize) -> GitHubReviewState {
         match self.script {
-            Script::NoCi => self.no_ci_state(),
+            Script::NoCi | Script::CredentialExpires | Script::ReviewSyncRace => self.no_ci_state(),
             Script::CiFailed => open_review(failed_checks()),
             Script::Conflict => GitHubReviewState::Conflict,
             Script::ConflictAtMerge => open_review(GitHubChecks::NotRequired),
             Script::RegistrationRace => self.registration_race_state(inspection),
+            Script::MultipleRegistrationWaves => self.multiple_registration_waves_state(inspection),
             Script::ProtectedBranch => open_review(GitHubChecks::Passed),
-            Script::ReviewSyncRace => self.no_ci_state(),
             Script::CiFailsThenMerges => self.ci_repair_state(inspection),
             Script::NeverConfirmsMerge => open_review(GitHubChecks::Passed),
         }
@@ -85,6 +87,16 @@ impl FakeGitHub {
             merged_review()
         } else if inspection == 1 {
             open_review(GitHubChecks::NotRequired)
+        } else {
+            open_review(GitHubChecks::Passed)
+        }
+    }
+
+    fn multiple_registration_waves_state(&self, inspection: usize) -> GitHubReviewState {
+        if self.merge_requested.load(Ordering::SeqCst) {
+            merged_review()
+        } else if matches!(inspection, 2 | 4) {
+            open_review(GitHubChecks::Pending)
         } else {
             open_review(GitHubChecks::Passed)
         }
@@ -160,8 +172,16 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         review: &GitHubReviewReceipt,
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubReviewObservation, GitHubAuthorityError> {
-        assert_eq!(credential.expose(), "test-token");
         let inspection = self.inspections.fetch_add(1, Ordering::SeqCst) + 1;
+        if matches!(self.script, Script::CredentialExpires) && credential.expose() == "test-token" {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        let expected = if matches!(self.script, Script::CredentialExpires) {
+            "refreshed-token"
+        } else {
+            "test-token"
+        };
+        assert_eq!(credential.expose(), expected);
         let state = self.review_state(inspection);
         Ok(review.observation(state))
     }
@@ -171,7 +191,12 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         _review: &GitHubReviewReceipt,
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubMergeRequestOutcome, GitHubAuthorityError> {
-        assert_eq!(credential.expose(), "test-token");
+        let expected = if matches!(self.script, Script::CredentialExpires) {
+            "refreshed-token"
+        } else {
+            "test-token"
+        };
+        assert_eq!(credential.expose(), expected);
         self.merge_requests.fetch_add(1, Ordering::SeqCst);
         if matches!(self.script, Script::ConflictAtMerge) {
             return Ok(GitHubMergeRequestOutcome::Conflict);
@@ -179,6 +204,8 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         if matches!(self.script, Script::ProtectedBranch)
             || matches!(self.script, Script::RegistrationRace)
                 && self.merge_requests.load(Ordering::SeqCst) == 1
+            || matches!(self.script, Script::MultipleRegistrationWaves)
+                && self.merge_requests.load(Ordering::SeqCst) <= 2
         {
             return Ok(GitHubMergeRequestOutcome::Pending);
         }

--- a/zeroshot-rust/src/native_v2_runner.rs
+++ b/zeroshot-rust/src/native_v2_runner.rs
@@ -49,6 +49,21 @@ pub use plan::NodeRole;
 use plan::NodeRolePlan;
 mod workspace;
 pub use workspace::{EnvironmentResolutionError, ResolvedEnvironment, WorkspaceAccess, WorkspaceGate};
+pub(crate) use workspace::{EnvironmentRefreshUnavailable, RuntimeEnvironmentRefresh};
+
+pub(crate) fn with_environment_refresh(
+    environment: ResolvedEnvironment,
+    refresh: Arc<dyn RuntimeEnvironmentRefresh>,
+) -> ResolvedEnvironment {
+    workspace::with_refresh(environment, refresh)
+}
+
+pub(crate) async fn refresh_environment(
+    environment: &ResolvedEnvironment,
+) -> Result<ResolvedEnvironment, EnvironmentRefreshUnavailable> {
+    workspace::refreshed(environment).await
+}
+
 #[derive(Clone, Debug)]
 pub struct NodeRunRequest {
     pub invocation: NodeInvocation,

--- a/zeroshot-rust/src/native_v2_runner/workspace.rs
+++ b/zeroshot-rust/src/native_v2_runner/workspace.rs
@@ -39,7 +39,17 @@ pub(super) enum WorkspacePermit {
 #[derive(Clone)]
 pub struct ResolvedEnvironment {
     values: Arc<BTreeMap<EnvironmentVariableName, String>>,
+    refresh: Option<Arc<dyn RuntimeEnvironmentRefresh>>,
 }
+
+#[async_trait]
+pub(crate) trait RuntimeEnvironmentRefresh: Send + Sync {
+    async fn refresh(&self) -> Result<ResolvedEnvironment, EnvironmentRefreshUnavailable>;
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("runtime environment refresh is unavailable")]
+pub(crate) struct EnvironmentRefreshUnavailable;
 
 impl ResolvedEnvironment {
     pub fn exact(
@@ -62,6 +72,7 @@ impl ResolvedEnvironment {
         }
         Ok(Self {
             values: Arc::new(values),
+            refresh: None,
         })
     }
 
@@ -74,6 +85,23 @@ impl ResolvedEnvironment {
         self.values
             .iter()
             .map(|(name, value)| (name, value.as_str()))
+    }
+}
+
+pub(super) fn with_refresh(
+    mut environment: ResolvedEnvironment,
+    refresh: Arc<dyn RuntimeEnvironmentRefresh>,
+) -> ResolvedEnvironment {
+    environment.refresh = Some(refresh);
+    environment
+}
+
+pub(super) async fn refreshed(
+    environment: &ResolvedEnvironment,
+) -> Result<ResolvedEnvironment, EnvironmentRefreshUnavailable> {
+    match &environment.refresh {
+        Some(refresh) => refresh.refresh().await,
+        None => Ok(environment.clone()),
     }
 }
 

--- a/zeroshot-rust/src/native_v2_supervisor/environment.rs
+++ b/zeroshot-rust/src/native_v2_supervisor/environment.rs
@@ -10,7 +10,10 @@ use openengine_cluster_protocol::{
 use thiserror::Error;
 
 use crate::native_v2_contract::NodeRuntimeBinding;
-use crate::native_v2_runner::ResolvedEnvironment;
+use crate::native_v2_runner::{
+    EnvironmentRefreshUnavailable, ResolvedEnvironment, RuntimeEnvironmentRefresh,
+    with_environment_refresh,
+};
 
 const MAX_RUN_ENVIRONMENT_BYTES: usize = 256 * 1024;
 
@@ -128,6 +131,20 @@ impl RunEnvironment {
         &self,
         binding: &NodeRuntimeBinding,
     ) -> Result<ResolvedEnvironment, RunEnvironmentError> {
+        let resolved = self.resolve_snapshot(binding).await?;
+        Ok(with_environment_refresh(
+            resolved,
+            Arc::new(NodeEnvironmentRefresh {
+                environment: self.clone(),
+                binding: binding.clone(),
+            }),
+        ))
+    }
+
+    async fn resolve_snapshot(
+        &self,
+        binding: &NodeRuntimeBinding,
+    ) -> Result<ResolvedEnvironment, RunEnvironmentError> {
         let requirements = binding
             .declared_connections()
             .iter()
@@ -181,6 +198,24 @@ impl RunEnvironment {
         }
         validate_size(&selected)?;
         Ok(selected)
+    }
+}
+
+#[derive(Clone)]
+struct NodeEnvironmentRefresh {
+    environment: RunEnvironment,
+    binding: NodeRuntimeBinding,
+}
+
+#[async_trait]
+impl RuntimeEnvironmentRefresh for NodeEnvironmentRefresh {
+    async fn refresh(&self) -> Result<ResolvedEnvironment, EnvironmentRefreshUnavailable> {
+        let resolved = self
+            .environment
+            .resolve_snapshot(&self.binding)
+            .await
+            .map_err(|_| EnvironmentRefreshUnavailable)?;
+        Ok(with_environment_refresh(resolved, Arc::new(self.clone())))
     }
 }
 
@@ -360,126 +395,5 @@ pub enum RunEnvironmentError {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use super::*;
-    use openengine_cluster_protocol::{
-        CodexProvider, DeclaredConnections, DeclaredEnvironment, ModelId, NodeName, RunSize,
-        SessionScope,
-    };
-    use openengine_cluster_testkit::assertions::AssertValue;
-
-    #[derive(Default)]
-    struct RotatingResolver {
-        calls: AtomicUsize,
-    }
-
-    #[async_trait]
-    impl RunConnectionResolver for RotatingResolver {
-        async fn resolve(
-            &self,
-            requirements: RunConnectionRequirements,
-        ) -> Result<RunConnectionValues, ConnectionResolutionUnavailable> {
-            let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
-            requirements
-                .into_iter()
-                .map(|(key, fields)| {
-                    let values = fields
-                        .into_iter()
-                        .map(|field| (field, format!("dynamic-{call}")))
-                        .collect();
-                    StaticConnectionValues::new(values)
-                        .map(|values| (key, values))
-                        .map_err(|_| ConnectionResolutionUnavailable)
-                })
-                .collect()
-        }
-    }
-
-    fn binding(key: &str, name: &EnvironmentVariableName) -> NodeRuntimeBinding {
-        NodeRuntimeBinding::Agent {
-            model: ModelId::new("gpt-5.6").assert_value(),
-            effort: None,
-            session_scope: SessionScope::Execution,
-            connections: DeclaredConnections::single(
-                key,
-                DeclaredEnvironment::new([name.clone()]).assert_value(),
-            )
-            .assert_value(),
-        }
-    }
-
-    #[tokio::test]
-    async fn same_environment_name_can_resolve_from_different_keys_on_different_nodes() {
-        let name = EnvironmentVariableName::new("TOKEN").assert_value();
-        let first = binding("first", &name);
-        let second = binding("second", &name);
-        let runtime = RuntimePlan::Codex {
-            provider: CodexProvider::OpenAi,
-            size: RunSize::Small,
-            nodes: BTreeMap::from([
-                (NodeName::new("one").assert_value(), first.clone()),
-                (NodeName::new("two").assert_value(), second.clone()),
-            ]),
-        };
-        let connection = |value: &str| {
-            StaticConnectionValues::new(BTreeMap::from([(name.clone(), value.to_owned())]))
-                .assert_value()
-        };
-        let environment = RunEnvironment::exact(
-            &runtime,
-            BTreeMap::from([
-                (
-                    ConnectionKey::new("first").assert_value(),
-                    connection("first-secret"),
-                ),
-                (
-                    ConnectionKey::new("second").assert_value(),
-                    connection("second-secret"),
-                ),
-            ]),
-        )
-        .assert_value();
-
-        assert_eq!(
-            environment.resolve(&first).await.assert_value().get(&name),
-            Some("first-secret")
-        );
-        assert_eq!(
-            environment.resolve(&second).await.assert_value().get(&name),
-            Some("second-secret")
-        );
-    }
-
-    #[tokio::test]
-    async fn dynamic_values_are_refreshed_for_every_node_start() {
-        let name = EnvironmentVariableName::new("GH_TOKEN").assert_value();
-        let node = binding("github", &name);
-        let runtime = RuntimePlan::Codex {
-            provider: CodexProvider::OpenAi,
-            size: RunSize::Small,
-            nodes: BTreeMap::from([(NodeName::new("deliver").assert_value(), node.clone())]),
-        };
-        let key = ConnectionKey::new("github").assert_value();
-        let environment = RunEnvironment::with_resolver(
-            &runtime,
-            BTreeMap::new(),
-            DynamicConnectionPlan {
-                keys: BTreeSet::from([key.clone()]),
-                source_connection: Some(key),
-                resolver: Arc::new(RotatingResolver::default()),
-            },
-        )
-        .assert_value();
-
-        assert_eq!(
-            environment.resolve(&node).await.assert_value().get(&name),
-            Some("dynamic-1")
-        );
-        assert_eq!(
-            environment.resolve(&node).await.assert_value().get(&name),
-            Some("dynamic-2")
-        );
-    }
-}
+#[path = "environment/tests.rs"]
+mod tests;

--- a/zeroshot-rust/src/native_v2_supervisor/environment/tests.rs
+++ b/zeroshot-rust/src/native_v2_supervisor/environment/tests.rs
@@ -1,0 +1,126 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::*;
+use openengine_cluster_protocol::{
+    CodexProvider, DeclaredConnections, DeclaredEnvironment, ModelId, NodeName, RunSize,
+    SessionScope,
+};
+use openengine_cluster_testkit::assertions::AssertValue;
+
+#[derive(Default)]
+struct RotatingResolver {
+    calls: AtomicUsize,
+}
+
+#[async_trait]
+impl RunConnectionResolver for RotatingResolver {
+    async fn resolve(
+        &self,
+        requirements: RunConnectionRequirements,
+    ) -> Result<RunConnectionValues, ConnectionResolutionUnavailable> {
+        let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+        requirements
+            .into_iter()
+            .map(|(key, fields)| {
+                let values = fields
+                    .into_iter()
+                    .map(|field| (field, format!("dynamic-{call}")))
+                    .collect();
+                StaticConnectionValues::new(values)
+                    .map(|values| (key, values))
+                    .map_err(|_| ConnectionResolutionUnavailable)
+            })
+            .collect()
+    }
+}
+
+fn binding(key: &str, name: &EnvironmentVariableName) -> NodeRuntimeBinding {
+    NodeRuntimeBinding::Agent {
+        model: ModelId::new("gpt-5.6").assert_value(),
+        effort: None,
+        session_scope: SessionScope::Execution,
+        connections: DeclaredConnections::single(
+            key,
+            DeclaredEnvironment::new([name.clone()]).assert_value(),
+        )
+        .assert_value(),
+    }
+}
+
+#[tokio::test]
+async fn same_environment_name_can_resolve_from_different_keys_on_different_nodes() {
+    let name = EnvironmentVariableName::new("TOKEN").assert_value();
+    let first = binding("first", &name);
+    let second = binding("second", &name);
+    let runtime = RuntimePlan::Codex {
+        provider: CodexProvider::OpenAi,
+        size: RunSize::Small,
+        nodes: BTreeMap::from([
+            (NodeName::new("one").assert_value(), first.clone()),
+            (NodeName::new("two").assert_value(), second.clone()),
+        ]),
+    };
+    let connection = |value: &str| {
+        StaticConnectionValues::new(BTreeMap::from([(name.clone(), value.to_owned())]))
+            .assert_value()
+    };
+    let environment = RunEnvironment::exact(
+        &runtime,
+        BTreeMap::from([
+            (
+                ConnectionKey::new("first").assert_value(),
+                connection("first-secret"),
+            ),
+            (
+                ConnectionKey::new("second").assert_value(),
+                connection("second-secret"),
+            ),
+        ]),
+    )
+    .assert_value();
+
+    assert_eq!(
+        environment.resolve(&first).await.assert_value().get(&name),
+        Some("first-secret")
+    );
+    assert_eq!(
+        environment.resolve(&second).await.assert_value().get(&name),
+        Some("second-secret")
+    );
+}
+
+#[tokio::test]
+async fn dynamic_values_are_refreshed_for_node_start_and_runtime_refresh() {
+    let name = EnvironmentVariableName::new("GH_TOKEN").assert_value();
+    let node = binding("github", &name);
+    let runtime = RuntimePlan::Codex {
+        provider: CodexProvider::OpenAi,
+        size: RunSize::Small,
+        nodes: BTreeMap::from([(NodeName::new("deliver").assert_value(), node.clone())]),
+    };
+    let key = ConnectionKey::new("github").assert_value();
+    let environment = RunEnvironment::with_resolver(
+        &runtime,
+        BTreeMap::new(),
+        DynamicConnectionPlan {
+            keys: BTreeSet::from([key.clone()]),
+            source_connection: Some(key),
+            resolver: Arc::new(RotatingResolver::default()),
+        },
+    )
+    .assert_value();
+
+    let first = environment.resolve(&node).await.assert_value();
+    assert_eq!(first.get(&name), Some("dynamic-1"));
+    assert_eq!(
+        crate::native_v2_runner::refresh_environment(&first)
+            .await
+            .assert_value()
+            .get(&name),
+        Some("dynamic-2")
+    );
+    assert_eq!(
+        environment.resolve(&node).await.assert_value().get(&name),
+        Some("dynamic-3")
+    );
+}


### PR DESCRIPTION
Removes the hosted delivery worker’s 30-minute work-duration cap so it waits until authoritative completion or run cancellation. Carries the existing run-scoped connection resolver into the resolved node environment and refreshes the GitHub credential after an authority error, allowing an expired one-hour GitHub App installation token to be replaced during long CI. Bounded poll policies remain available for tests and explicit callers.

This complements #1066: dynamic or multi-stage checks are now classified correctly, normal long-running CI is not cut off by either the poll budget or token lifetime, each newly observed CI registration wave permits a fresh merge attempt, and check reruns explicitly use GitHub’s latest-run view.

Verification:
- cargo test -p zeroshot-rust native_v2_delivery (29 passed)
- cargo test -p zeroshot-rust dynamic_values_are_refreshed_for_node_start_and_runtime_refresh
- cargo fmt --all -- --check
- cargo clippy -p zeroshot-rust --all-targets -- -D warnings
- repository pre-commit and pre-push gates
- opcore-zero check --repo . --staged --json