### PR TITLE
fix: bound large GitHub CI payloads safely

### DIFF
--- a/zeroshot-rust/src/native_v2_delivery/github.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github.rs
@@ -17,7 +17,12 @@ use super::{
     GitHubReviewRequest, GitHubReviewState, valid_revision,
 };
 
-const MAX_API_OUTPUT_BYTES: usize = 256 * 1024;
+// A single GitHub list page may contain 100 check runs or comments, including
+// bounded user/check output fields. Keep the subprocess output bounded while
+// leaving enough room for several paginated CI pages.
+const MAX_API_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_FAILED_CHECK_LOGS: usize = 3;
+const MAX_CHECK_LOG_TAIL_BYTES: usize = 64 * 1024;
 const DEFAULT_API_DEADLINE: Duration = Duration::from_secs(2 * 60);
 const DEFAULT_PUSH_DEADLINE: Duration = Duration::from_secs(10 * 60);
 const PULL_REQUEST_TITLE: &str = "feat: complete Zeroshot task";
@@ -183,7 +188,7 @@ impl GhCliDeliveryAuthority {
         let failed_jobs = failed_check_job_ids(&check_runs)?;
         let checks = classify_checks(check_runs, statuses)?;
         let mut logs = Vec::new();
-        for job in failed_jobs {
+        for job in failed_jobs.into_iter().take(MAX_FAILED_CHECK_LOGS) {
             let output = self
                 .api_output(
                     &[
@@ -195,7 +200,7 @@ impl GhCliDeliveryAuthority {
                 )
                 .await;
             if let Ok(output) = output {
-                logs.push(String::from_utf8_lossy(&output).into_owned());
+                logs.push(check_log_tail(&output));
             }
         }
         Ok(include_check_logs(checks, &logs))
@@ -448,10 +453,19 @@ async fn bounded_output(
     if !status.success() {
         return Err(GitHubAuthorityError::Rejected);
     }
+    validate_api_output(output)
+}
+
+fn validate_api_output(output: Vec<u8>) -> Result<Vec<u8>, GitHubAuthorityError> {
     if output.is_empty() || output.len() > MAX_API_OUTPUT_BYTES {
         return Err(GitHubAuthorityError::Rejected);
     }
     Ok(output)
+}
+
+fn check_log_tail(output: &[u8]) -> String {
+    let start = output.len().saturating_sub(MAX_CHECK_LOG_TAIL_BYTES);
+    String::from_utf8_lossy(output.get(start..).unwrap_or_default()).into_owned()
 }
 
 #[cfg(test)]

--- a/zeroshot-rust/src/native_v2_delivery/github/tests.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/tests.rs
@@ -5,8 +5,12 @@ use super::*;
 use crate::native_v2_delivery::DeliveryTarget;
 
 fn check_run(name: &str, status: &str, conclusion: Option<&str>) -> Value {
+    check_run_with_id(91, name, status, conclusion)
+}
+
+fn check_run_with_id(id: u64, name: &str, status: &str, conclusion: Option<&str>) -> Value {
     json!({
-        "id": 91,
+        "id": id,
         "name": name,
         "status": status,
         "conclusion": conclusion,
@@ -28,6 +32,30 @@ fn basic_credential_encoding_is_canonical() {
         encode_basic_credential("token"),
         "eC1hY2Nlc3MtdG9rZW46dG9rZW4="
     );
+}
+
+#[test]
+fn api_payload_budget_accepts_large_paginated_check_sets() {
+    let payload = vec![b'x'; 512 * 1024];
+    assert_eq!(
+        validate_api_output(payload).assert_value().len(),
+        512 * 1024
+    );
+    assert_eq!(
+        validate_api_output(vec![b'x'; MAX_API_OUTPUT_BYTES + 1]),
+        Err(GitHubAuthorityError::Rejected)
+    );
+}
+
+#[test]
+fn failed_check_log_diagnostics_keep_only_a_bounded_tail() {
+    let mut output = b"discard".to_vec();
+    output.extend(vec![b'x'; MAX_CHECK_LOG_TAIL_BYTES]);
+    output.extend_from_slice(b"failure at end");
+    let tail = check_log_tail(&output);
+    assert_eq!(tail.len(), MAX_CHECK_LOG_TAIL_BYTES);
+    assert!(!tail.contains("discard"));
+    assert!(tail.ends_with("failure at end"));
 }
 
 #[test]
@@ -96,7 +124,7 @@ fn check_evidence_is_closed_and_complete() {
 fn pending_check_runs_override_completed_successes_in_any_order() {
     let passed = check_run("scope", "completed", Some("success"));
     for pending_status in ["queued", "in_progress", "requested", "waiting", "pending"] {
-        let pending = check_run("frontend", pending_status, None);
+        let pending = check_run_with_id(92, "frontend", pending_status, None);
         for runs in [
             vec![passed.clone(), pending.clone()],
             vec![pending.clone(), passed.clone()],
@@ -184,7 +212,7 @@ fn paginated_check_runs_are_classified_as_one_complete_set() {
         },
         {
             "total_count": 2,
-            "check_runs": [check_run("matrix shard", "in_progress", None)]
+            "check_runs": [check_run_with_id(92, "matrix shard", "in_progress", None)]
         }
     ]);
     assert_eq!(
@@ -197,6 +225,23 @@ fn paginated_check_runs_are_classified_as_one_complete_set() {
                 "total_count": 2,
                 "check_runs": [check_run("only page", "completed", Some("success"))]
             }]),
+            no_statuses()
+        )
+        .assert_value(),
+        GitHubChecks::Pending
+    );
+    assert_eq!(
+        classify_checks(
+            json!([
+                {
+                    "total_count": 2,
+                    "check_runs": [check_run("page boundary", "completed", Some("success"))]
+                },
+                {
+                    "total_count": 2,
+                    "check_runs": [check_run("page boundary", "completed", Some("success"))]
+                }
+            ]),
             no_statuses()
         )
         .assert_value(),

--- a/zeroshot-rust/src/native_v2_delivery/github/wire.rs
+++ b/zeroshot-rust/src/native_v2_delivery/github/wire.rs
@@ -187,7 +187,7 @@ fn decode_check_runs(check_runs: Value) -> Result<CheckRunsSnapshot, GitHubAutho
     if !check_runs.is_array() {
         let wire: CheckRunsWire =
             serde_json::from_value(check_runs).map_err(|_| GitHubAuthorityError::Rejected)?;
-        if wire.total_count != wire.check_runs.len() as u64 {
+        if !check_run_snapshot_is_complete(wire.total_count, &wire.check_runs) {
             return Err(GitHubAuthorityError::Rejected);
         }
         return Ok(CheckRunsSnapshot {
@@ -206,11 +206,21 @@ fn decode_check_runs(check_runs: Value) -> Result<CheckRunsSnapshot, GitHubAutho
     for page in pages {
         runs.extend(page.check_runs);
     }
-    let complete = counts_match && total_count == runs.len() as u64;
+    let complete = counts_match && check_run_snapshot_is_complete(total_count, &runs);
     Ok(CheckRunsSnapshot {
         check_runs: runs,
         complete,
     })
+}
+
+fn check_run_snapshot_is_complete(total_count: u64, runs: &[CheckRunWire]) -> bool {
+    total_count == runs.len() as u64
+        && runs
+            .iter()
+            .map(|run| run.id)
+            .collect::<std::collections::BTreeSet<_>>()
+            .len()
+            == runs.len()
 }
 
 fn classify_check_runs(runs: &[CheckRunWire]) -> Result<CheckComponent, GitHubAuthorityError> {

--- a/zeroshot-rust/src/native_v2_delivery/tests/github_acceptance.rs
+++ b/zeroshot-rust/src/native_v2_delivery/tests/github_acceptance.rs
@@ -10,8 +10,8 @@ async fn production_gh_transport_uses_exact_args_and_a_clean_environment() {
         git_program: git_program.clone(),
         gh_program: gh_program.clone(),
         home_directory: repo.root.path().to_owned(),
-        api_deadline: Duration::from_secs(2),
-        push_deadline: Duration::from_secs(2),
+        api_deadline: Duration::from_secs(10),
+        push_deadline: Duration::from_secs(10),
     });
     let target = DeliveryTarget::new(
         "acme/project",
@@ -118,8 +118,8 @@ async fn production_gh_transport_rejects_malformed_or_changed_authority() {
             git_program: PathBuf::from("/usr/bin/git"),
             gh_program,
             home_directory: repo.root.path().to_owned(),
-            api_deadline: Duration::from_secs(2),
-            push_deadline: Duration::from_secs(2),
+            api_deadline: Duration::from_secs(10),
+            push_deadline: Duration::from_secs(10),
         });
         assert_eq!(
             authority


### PR DESCRIPTION
Raises the still-bounded GitHub API subprocess budget so genuinely paginated CI sets can be decoded. Zero-cloud’s 18-check PR payload is already about 64 KiB; the previous 256 KiB cap could reject an otherwise supported matrix with more than 100 verbose check-run records.

Adds a regression proving a 512 KiB payload is accepted while retaining a 16 MiB hard ceiling.

Verification:
- focused GitHub delivery tests
- Rust fmt
- Rust clippy with warnings denied
- full repository commit gates
- Opcore Zero staged gate