### PR TITLE
fix: provide repository context to SDK release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -389,6 +389,7 @@ jobs:
       - name: Create or complete independent SDK GitHub Release
         shell: bash
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_COMMIT: ${{ needs.plan.outputs.commit }}
           SDK_TAG: ${{ needs.plan.outputs.sdk-tag }}

--- a/tests/tooling/release-contract.test.js
+++ b/tests/tooling/release-contract.test.js
@@ -61,6 +61,7 @@ describe('v8 hard cutover contract', () => {
     );
     assert.match(pythonRelease, /git show -s --format=%ct/);
     assert.match(pythonRelease, /if remote != local:/);
+    assert.match(pythonRelease, /GH_REPO: \$\{\{ github\.repository \}\}/);
     assert.match(pythonRelease, /gh release download "\$SDK_TAG"/);
     assert.match(pythonRelease, /"\$local_sha" == "\$remote_sha"/);
     assert.match(pythonRelease, /if: steps\.pypi\.outputs\.exists == 'false'/);


### PR DESCRIPTION
## Summary
- provide explicit `GH_REPO` context to the no-checkout Python SDK release job
- guard the release contract with a regression assertion

## Validation
- `node --test tests/tooling/release-contract.test.js`
- `npm test`
- `npm run lint`
- `npm run format:check`
- `./sdks/python/.venv/bin/python -m pytest sdks/python/tests/test_release_contract.py`
- `CARGO_BUILD_JOBS=1 npm run opcore:check -- --base origin/main`
- `opcore-zero check --repo . --staged --json`