### PR TITLE
feat: add Amazon Bedrock provider support

### DIFF
--- a/crates/openengine-cluster-protocol/src/native_v2_run.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_run.rs
@@ -367,6 +367,7 @@ pub enum CodexProvider {
     OpenAi,
     #[serde(rename = "openrouter")]
     OpenRouter,
+    Bedrock,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
@@ -375,6 +376,7 @@ pub enum ClaudeProvider {
     Anthropic,
     #[serde(rename = "openrouter")]
     OpenRouter,
+    Bedrock,
 }
 
 #[derive(

--- a/crates/openengine-cluster-protocol/src/native_v2_run.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_run.rs
@@ -200,7 +200,7 @@ fn validate_revision(value: &str) -> Result<(), NativeV2RunValueError> {
 }
 
 fn validate_model(value: &str) -> Result<(), NativeV2RunValueError> {
-    validate_non_control_bytes(value, 128, "model ID must be 1..=128 non-control bytes")
+    validate_non_control_bytes(value, 2_048, "model ID must be 1..=2048 non-control bytes")
 }
 
 fn validate_environment_name(value: &str) -> Result<(), NativeV2RunValueError> {
@@ -304,7 +304,7 @@ native_v2_string_kind!(
     ModelIdKind,
     ModelId,
     validate_model,
-    json_schema!({ "type": "string", "minLength": 1, "maxLength": 128 })
+    json_schema!({ "type": "string", "minLength": 1, "maxLength": 2048 })
 );
 native_v2_string_kind!(
     EnvironmentVariableNameKind,
@@ -425,6 +425,17 @@ mod tests {
     use openengine_cluster_testkit::assertions::AssertValue;
 
     use super::*;
+
+    #[test]
+    fn model_ids_allow_bedrock_application_inference_profile_arns() {
+        let profile = format!(
+            "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/{}",
+            "profile".repeat(20)
+        );
+        assert!(profile.len() > 128);
+        assert!(ModelId::new(profile).is_ok());
+        assert!(ModelId::new("x".repeat(2_049)).is_err());
+    }
 
     #[test]
     fn node_connections_reject_ambiguous_or_empty_shapes() {

--- a/crates/openengine-cluster-protocol/src/native_v2_run.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_run.rs
@@ -200,7 +200,11 @@ fn validate_revision(value: &str) -> Result<(), NativeV2RunValueError> {
 }
 
 fn validate_model(value: &str) -> Result<(), NativeV2RunValueError> {
-    validate_non_control_bytes(value, 2_048, "model ID must be 1..=2048 non-control bytes")
+    validate_non_control_text(
+        value,
+        2_048,
+        "model ID must be 1..=2048 non-control characters",
+    )
 }
 
 fn validate_environment_name(value: &str) -> Result<(), NativeV2RunValueError> {
@@ -434,7 +438,12 @@ mod tests {
         );
         assert!(profile.len() > 128);
         assert!(ModelId::new(profile).is_ok());
-        assert!(ModelId::new("x".repeat(2_049)).is_err());
+    }
+
+    #[test]
+    fn model_id_length_matches_json_schema_character_semantics() {
+        assert!(ModelId::new("é".repeat(2_048)).is_ok());
+        assert!(ModelId::new("é".repeat(2_049)).is_err());
     }
 
     #[test]

--- a/crates/openengine-cluster-protocol/tests/native_v2_run.rs
+++ b/crates/openengine-cluster-protocol/tests/native_v2_run.rs
@@ -9,9 +9,9 @@ mod json_read;
 
 use assert_value::AssertValue;
 use openengine_cluster_protocol::{
-    RunId, RunListParams, RunListResult, RunSize, RunStatus, RunStatusResult, RunSubmitParams,
-    RunSubmitResult, RunTitle, SourceBranchId, SourceRepositoryId, SourceRevisionId,
-    ResolvedSource,
+    ClaudeProvider, CodexProvider, ResolvedSource, RunId, RunListParams, RunListResult, RunSize,
+    RunStatus, RunStatusResult, RunSubmitParams, RunSubmitResult, RunTitle, SourceBranchId,
+    SourceRepositoryId, SourceRevisionId,
 };
 use serde_json::{json, Value};
 
@@ -99,6 +99,26 @@ fn legacy_run_sizes_reopen_and_serialize_with_current_names() {
         assert_eq!(size, expected);
         assert_eq!(serde_json::to_value(size).assert_value(), json!(current));
     }
+}
+
+#[test]
+fn both_harness_provider_enums_round_trip_bedrock() {
+    assert_eq!(
+        serde_json::to_value(CodexProvider::Bedrock).assert_value(),
+        json!("bedrock")
+    );
+    assert_eq!(
+        serde_json::from_value::<CodexProvider>(json!("bedrock")).assert_value(),
+        CodexProvider::Bedrock
+    );
+    assert_eq!(
+        serde_json::to_value(ClaudeProvider::Bedrock).assert_value(),
+        json!("bedrock")
+    );
+    assert_eq!(
+        serde_json::from_value::<ClaudeProvider>(json!("bedrock")).assert_value(),
+        ClaudeProvider::Bedrock
+    );
 }
 
 #[test]

--- a/docs/zeroshot-cli.html
+++ b/docs/zeroshot-cli.html
@@ -569,9 +569,10 @@ RUNTIME CONFIGURATION
         }
       }
 
-    Known-incompatible harness/provider pairs are codex/anthropic and claude/openai. Model IDs are
-    passed unchanged to the selected harness and provider; Zeroshot does not maintain or validate
-    provider model catalogs.
+    Provider choices are codex/openai, codex/openrouter, codex/bedrock, claude/anthropic,
+    claude/openrouter, and claude/bedrock. Known-incompatible harness/provider pairs are
+    codex/anthropic and claude/openai. Model IDs are passed unchanged to the selected harness and
+    provider; Zeroshot does not maintain or validate provider model catalogs.
 
     Sizes are small, medium, and large.
 

--- a/docs/zeroshot-cli.md
+++ b/docs/zeroshot-cli.md
@@ -613,9 +613,10 @@ RUNTIME CONFIGURATION
         }
       }
 
-    Known-incompatible harness/provider pairs are codex/anthropic and claude/openai. Model IDs are
-    passed unchanged to the selected harness and provider; Zeroshot does not maintain or validate
-    provider model catalogs.
+    Provider choices are codex/openai, codex/openrouter, codex/bedrock, claude/anthropic,
+    claude/openrouter, and claude/bedrock. Known-incompatible harness/provider pairs are
+    codex/anthropic and claude/openai. Model IDs are passed unchanged to the selected harness and
+    provider; Zeroshot does not maintain or validate provider model catalogs.
 
     Sizes are small, medium, and large.
 

--- a/protocol/openengine-cluster/v1/schema.json
+++ b/protocol/openengine-cluster/v1/schema.json
@@ -3208,7 +3208,7 @@
               "type": "string"
             },
             "model": {
-              "maxLength": 128,
+              "maxLength": 2048,
               "minLength": 1,
               "type": "string"
             },

--- a/protocol/openengine-cluster/v1/schema.json
+++ b/protocol/openengine-cluster/v1/schema.json
@@ -415,7 +415,8 @@
     "ClaudeProvider": {
       "enum": [
         "anthropic",
-        "openrouter"
+        "openrouter",
+        "bedrock"
       ],
       "type": "string"
     },
@@ -463,7 +464,8 @@
     "CodexProvider": {
       "enum": [
         "openai",
-        "openrouter"
+        "openrouter",
+        "bedrock"
       ],
       "type": "string"
     },

--- a/zeroshot/src/native_v2_admission/tests.rs
+++ b/zeroshot/src/native_v2_admission/tests.rs
@@ -317,14 +317,14 @@ async fn rejects_inconsistent_worker_reuse() {
 }
 
 #[tokio::test]
-async fn preserves_provider_owned_models_and_effort() {
+async fn admits_bedrock_for_both_harnesses_and_preserves_provider_owned_models() {
     let graph = graph(vec![null_step("work", "agent.work@1"), succeed("done")]);
     let codex_runtime = RunSubmission {
         title: RunTitle::new("Opaque Codex model").assert_value(),
         graph: graph.clone(),
         initial_input: json!({"items":[null]}),
         runtime: RuntimePlan::Codex {
-            provider: CodexProvider::OpenAi,
+            provider: CodexProvider::Bedrock,
             size: RunSize::Small,
             nodes: BTreeMap::from([(
                 named("work"),
@@ -335,20 +335,38 @@ async fn preserves_provider_owned_models_and_effort() {
         submission_key: IdempotencyKey::new("opaque-codex-model").assert_value(),
     };
     let admitted = NativeV2Admission.admit(codex_runtime).await.assert_value();
+    let provider = match &admitted.runtime {
+        RuntimePlan::Codex { provider, .. } => Some(provider),
+        RuntimePlan::Claude { .. } => None,
+    };
+    let provider = provider.assert_value_with("admission preserves the Codex harness");
+    assert_eq!(*provider, CodexProvider::Bedrock);
     assert!(matches!(
         admitted.runtime.nodes().get(&named("work")),
         Some(NodeRuntimeBinding::Agent { model, effort: Some(ReasoningEffort::Max), .. })
             if model.as_str() == "provider/future-model"
     ));
 
-    let claude_runtime = submission(
+    let mut claude_runtime = submission(
         graph,
         BTreeMap::from([(
             named("work"),
             binding("claude-haiku-4-5", Some(ReasoningEffort::Low)),
         )]),
     );
+    let provider = match &mut claude_runtime.runtime {
+        RuntimePlan::Claude { provider, .. } => Some(provider),
+        RuntimePlan::Codex { .. } => None,
+    };
+    let provider = provider.assert_value_with("submission fixture uses Claude");
+    *provider = ClaudeProvider::Bedrock;
     let admitted = NativeV2Admission.admit(claude_runtime).await.assert_value();
+    let provider = match &admitted.runtime {
+        RuntimePlan::Claude { provider, .. } => Some(provider),
+        RuntimePlan::Codex { .. } => None,
+    };
+    let provider = provider.assert_value_with("admission preserves the Claude harness");
+    assert_eq!(*provider, ClaudeProvider::Bedrock);
     assert!(matches!(
         admitted.runtime.nodes().get(&named("work")),
         Some(NodeRuntimeBinding::Agent { model, effort: Some(ReasoningEffort::Low), .. })

--- a/zeroshot/src/native_v2_claude.rs
+++ b/zeroshot/src/native_v2_claude.rs
@@ -1,8 +1,9 @@
 //! Claude CLI adapter for native-v2 graph nodes.
 //!
-//! One adapter is constructed for the graph-wide Anthropic or OpenRouter lane. Admission has
-//! already selected the model, effort, session scope, and declared environment for each node;
-//! It preserves those choices without consulting legacy coordination or ambient process state.
+//! One adapter is constructed for the graph-wide Anthropic, OpenRouter, or Amazon Bedrock lane.
+//! Admission has already selected the model, effort, session scope, and declared environment for
+//! each node; it preserves those choices without consulting legacy coordination or ambient process
+//! state.
 
 #[path = "native_v2_claude/command.rs"]
 mod command;
@@ -30,8 +31,8 @@ use crate::native_v2_runner::{
     LiveOutputStream, NodeRunnerError, ProviderSchemaDialect, ResolvedEnvironment,
 };
 use command::{
-    ClaudeTurnArguments, claude_arguments, configure_openrouter, extend_declared_environment,
-    prompt, reject_provider_controls, workspace_access,
+    ClaudeTurnArguments, claude_arguments, configure_bedrock, configure_openrouter,
+    extend_declared_environment, prompt, reject_provider_controls, workspace_access,
 };
 use session::{ClaudeSession, attempt_session_id, observe_session};
 use transcript::{ClaudeAttempt, ClaudeEmission, ClaudeTranscript};
@@ -252,13 +253,24 @@ impl ClaudeAdapter {
                 "Claude declared environment contains a provider-owned control variable",
             )
         })?;
-        if self.provider == ClaudeProvider::OpenRouter {
-            configure_openrouter(&mut environment).map_err(|error| {
-                with_driver_detail(
-                    error,
-                    "Claude OpenRouter credentials are missing or conflict with Anthropic credentials",
-                )
-            })?;
+        match self.provider {
+            ClaudeProvider::Anthropic => {}
+            ClaudeProvider::OpenRouter => {
+                configure_openrouter(&mut environment).map_err(|error| {
+                    with_driver_detail(
+                        error,
+                        "Claude OpenRouter credentials are missing or conflict with Anthropic credentials",
+                    )
+                })?;
+            }
+            ClaudeProvider::Bedrock => {
+                configure_bedrock(&mut environment).map_err(|error| {
+                    with_driver_detail(
+                        error,
+                        "Claude Bedrock credentials are missing or conflict with other provider credentials",
+                    )
+                })?;
+            }
         }
         Ok(environment)
     }

--- a/zeroshot/src/native_v2_claude/command.rs
+++ b/zeroshot/src/native_v2_claude/command.rs
@@ -7,11 +7,17 @@ use crate::native_v2_runner::{
 };
 use crate::worker_catalog::ReasoningEffort;
 
+pub(super) const AWS_BEARER_TOKEN_BEDROCK: &str = "AWS_BEARER_TOKEN_BEDROCK";
+pub(super) const AWS_REGION: &str = "AWS_REGION";
 pub(super) const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api";
 pub(super) const OPENROUTER_KEY: &str = "OPENROUTER_API_KEY";
 const ANTHROPIC_TOKEN: &str = "ANTHROPIC_AUTH_TOKEN";
 pub(super) const ANTHROPIC_KEY: &str = "ANTHROPIC_API_KEY";
 const ANTHROPIC_BASE_URL: &str = "ANTHROPIC_BASE_URL";
+const ANTHROPIC_BEDROCK_BASE_URL: &str = "ANTHROPIC_BEDROCK_BASE_URL";
+const ANTHROPIC_BEDROCK_MANTLE_BASE_URL: &str = "ANTHROPIC_BEDROCK_MANTLE_BASE_URL";
+const CLAUDE_CODE_OAUTH_REFRESH_TOKEN: &str = "CLAUDE_CODE_OAUTH_REFRESH_TOKEN";
+const CLAUDE_CODE_OAUTH_TOKEN: &str = "CLAUDE_CODE_OAUTH_TOKEN";
 
 pub(super) struct ClaudeTurnArguments<'a> {
     pub(super) model: &'a str,
@@ -78,10 +84,16 @@ pub(super) fn extend_declared_environment(
 pub(super) fn reject_provider_controls(
     environment: &BTreeMap<String, String>,
 ) -> Result<(), NodeRunnerError> {
-    const CONTROLS: [&str; 5] = [
+    const CONTROLS: [&str; 11] = [
         ANTHROPIC_BASE_URL,
+        ANTHROPIC_BEDROCK_BASE_URL,
+        ANTHROPIC_BEDROCK_MANTLE_BASE_URL,
         "CLAUDE_CONFIG_DIR",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+        "CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD",
         "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_GATEWAY",
+        "CLAUDE_CODE_USE_MANTLE",
         "CLAUDE_CODE_USE_VERTEX",
         "CLAUDE_CODE_USE_FOUNDRY",
     ];
@@ -90,6 +102,29 @@ pub(super) fn reject_provider_controls(
         .all(|name| !environment.contains_key(*name))
         .then_some(())
         .ok_or(NodeRunnerError::Driver)
+}
+
+pub(super) fn configure_bedrock(
+    environment: &mut BTreeMap<String, String>,
+) -> Result<(), NodeRunnerError> {
+    if [AWS_BEARER_TOKEN_BEDROCK, AWS_REGION].iter().any(|name| {
+        !environment
+            .get(*name)
+            .is_some_and(|value| !value.is_empty())
+    }) || [
+        ANTHROPIC_TOKEN,
+        ANTHROPIC_KEY,
+        CLAUDE_CODE_OAUTH_REFRESH_TOKEN,
+        CLAUDE_CODE_OAUTH_TOKEN,
+        OPENROUTER_KEY,
+    ]
+    .iter()
+    .any(|name| environment.contains_key(*name))
+    {
+        return Err(NodeRunnerError::Driver);
+    }
+    environment.insert("CLAUDE_CODE_USE_BEDROCK".to_owned(), "1".to_owned());
+    Ok(())
 }
 
 pub(super) fn configure_openrouter(

--- a/zeroshot/src/native_v2_claude/tests.rs
+++ b/zeroshot/src/native_v2_claude/tests.rs
@@ -24,7 +24,9 @@ use openengine_cluster_protocol::{
 use openengine_cluster_testkit::assertions::AssertValue;
 use serde_json::{json, Value};
 
-use super::command::{ANTHROPIC_KEY, OPENROUTER_BASE_URL, OPENROUTER_KEY};
+use super::command::{
+    ANTHROPIC_KEY, AWS_BEARER_TOKEN_BEDROCK, AWS_REGION, OPENROUTER_BASE_URL, OPENROUTER_KEY,
+};
 use super::{ClaudeAdapter, ClaudeAdapterConfig, ClaudeProcessEnvironment};
 use crate::execution::{SessionScope, process::HostedProcessPool};
 use crate::native_v2_candidate::test_support::{
@@ -320,6 +322,9 @@ printf '%s\n' "${ANTHROPIC_API_KEY-unset}" > anthropic-key.txt
 printf '%s\n' "${ANTHROPIC_AUTH_TOKEN-unset}" > anthropic-token.txt
 printf '%s\n' "${ANTHROPIC_BASE_URL-unset}" > anthropic-base-url.txt
 printf '%s\n' "${OPENROUTER_API_KEY-unset}" > openrouter-key.txt
+printf '%s\n' "${AWS_BEARER_TOKEN_BEDROCK-unset}" > bedrock-key.txt
+printf '%s\n' "${AWS_REGION-unset}" > aws-region.txt
+printf '%s\n' "${CLAUDE_CODE_USE_BEDROCK-unset}" > use-bedrock.txt
 printf '%s\n' "${UNDECLARED_AMBIENT_SENTINEL-unset}" > ambient.txt
 printf '%s\n' "$HOME" >> homes.txt
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-1"}'
@@ -337,30 +342,6 @@ printf '%s%s%s%s\n' \
   '","session_id":"session-1","usage":{"input_tokens":11,"output_tokens":4,' \
   '"cache_read_input_tokens":6,"cache_creation_input_tokens":2}}'
 "#;
-
-fn assert_provider_environment(
-    workspace: &TestDirectory,
-    provider: ClaudeProvider,
-    provider_value: &str,
-) {
-    match provider {
-        ClaudeProvider::Anthropic => {
-            assert_eq!(workspace.read("anthropic-key.txt").trim(), provider_value);
-            assert_eq!(workspace.read("anthropic-token.txt").trim(), "unset");
-            assert_eq!(workspace.read("anthropic-base-url.txt").trim(), "unset");
-            assert_eq!(workspace.read("openrouter-key.txt").trim(), "unset");
-        }
-        ClaudeProvider::OpenRouter => {
-            assert_eq!(workspace.read("anthropic-key.txt"), "\n");
-            assert_eq!(workspace.read("anthropic-token.txt").trim(), provider_value);
-            assert_eq!(
-                workspace.read("anthropic-base-url.txt").trim(),
-                OPENROUTER_BASE_URL
-            );
-            assert_eq!(workspace.read("openrouter-key.txt").trim(), provider_value);
-        }
-    }
-}
 
 #[tokio::test]
 async fn node_instance_scope_resumes_the_exact_claude_session() {

--- a/zeroshot/src/native_v2_claude/tests/command.rs
+++ b/zeroshot/src/native_v2_claude/tests/command.rs
@@ -1,34 +1,112 @@
 use super::*;
 
+struct ProviderFixture {
+    model: &'static str,
+    provider_value: &'static str,
+    environment: Vec<&'static str>,
+    values: Vec<(&'static str, &'static str)>,
+}
+
+fn provider_fixture(provider: ClaudeProvider) -> ProviderFixture {
+    match provider {
+        ClaudeProvider::Anthropic => ProviderFixture {
+            model: "claude-sonnet-5",
+            provider_value: "anthropic-fake",
+            environment: vec![ANTHROPIC_KEY],
+            values: vec![(ANTHROPIC_KEY, "anthropic-fake")],
+        },
+        ClaudeProvider::OpenRouter => ProviderFixture {
+            model: "anthropic/provider-owned-model",
+            provider_value: "openrouter-fake",
+            environment: vec![OPENROUTER_KEY],
+            values: vec![(OPENROUTER_KEY, "openrouter-fake")],
+        },
+        ClaudeProvider::Bedrock => ProviderFixture {
+            model: "global.anthropic.provider-owned-model",
+            provider_value: "bedrock-fake",
+            environment: vec![AWS_BEARER_TOKEN_BEDROCK, AWS_REGION],
+            values: vec![
+                (AWS_BEARER_TOKEN_BEDROCK, "bedrock-fake"),
+                (AWS_REGION, "us-east-1"),
+            ],
+        },
+    }
+}
+
+fn assert_provider_environment(
+    workspace: &TestDirectory,
+    provider: ClaudeProvider,
+    provider_value: &str,
+) {
+    let observed = [
+        workspace.read("anthropic-key.txt"),
+        workspace.read("anthropic-token.txt"),
+        workspace.read("anthropic-base-url.txt"),
+        workspace.read("openrouter-key.txt"),
+        workspace.read("bedrock-key.txt"),
+        workspace.read("aws-region.txt"),
+        workspace.read("use-bedrock.txt"),
+    ]
+    .map(|value| value.trim().to_owned());
+    let expected = match provider {
+        ClaudeProvider::Anthropic => [
+            provider_value,
+            "unset",
+            "unset",
+            "unset",
+            "unset",
+            "unset",
+            "unset",
+        ],
+        ClaudeProvider::OpenRouter => [
+            "",
+            provider_value,
+            OPENROUTER_BASE_URL,
+            provider_value,
+            "unset",
+            "unset",
+            "unset",
+        ],
+        ClaudeProvider::Bedrock => [
+            "unset",
+            "unset",
+            "unset",
+            "unset",
+            provider_value,
+            "us-east-1",
+            "1",
+        ],
+    }
+    .map(str::to_owned);
+    assert_eq!(observed, expected);
+}
+
 #[tokio::test]
-async fn scripted_anthropic_and_openrouter_commands_are_exact_and_ambient_free() {
-    for provider in [ClaudeProvider::Anthropic, ClaudeProvider::OpenRouter] {
+async fn scripted_provider_commands_are_exact_and_ambient_free() {
+    for provider in [
+        ClaudeProvider::Anthropic,
+        ClaudeProvider::OpenRouter,
+        ClaudeProvider::Bedrock,
+    ] {
         let workspace = TestDirectory::new("claude-command");
         workspace.write("fake-claude.sh", SUCCESS_SCRIPT);
-        let (provider_name, provider_value) = match provider {
-            ClaudeProvider::Anthropic => (ANTHROPIC_KEY, "anthropic-fake"),
-            ClaudeProvider::OpenRouter => (OPENROUTER_KEY, "openrouter-fake"),
-        };
-        let model = match provider {
-            ClaudeProvider::Anthropic => "claude-sonnet-5",
-            ClaudeProvider::OpenRouter => "anthropic/provider-owned-model",
-        };
+        let ProviderFixture {
+            model,
+            provider_value,
+            mut environment,
+            mut values,
+        } = provider_fixture(provider);
+        environment.push("TEST_SECRET");
+        values.push(("TEST_SECRET", "sentinel-secret"));
         let binding = agent_binding(
             model,
             Some(ReasoningEffort::Max),
             SessionScope::Execution,
-            &[provider_name, "TEST_SECRET"],
+            &environment,
         );
         let runner = runner(&workspace, provider, binding.clone(), false).await;
         let mut handle = runner
-            .start(request(
-                binding,
-                1,
-                &[
-                    (provider_name, provider_value),
-                    ("TEST_SECRET", "sentinel-secret"),
-                ],
-            ))
+            .start(request(binding, 1, &values))
             .await
             .assert_value();
         let mut attach = handle.take_initial_output().assert_value();

--- a/zeroshot/src/native_v2_claude/tests/environment.rs
+++ b/zeroshot/src/native_v2_claude/tests/environment.rs
@@ -3,7 +3,8 @@ use std::path::Path;
 
 use openengine_cluster_testkit::assertions::AssertValue;
 
-use super::super::ClaudeProcessEnvironment;
+use super::*;
+use crate::native_v2_runner::ResolvedEnvironment;
 
 #[test]
 fn base_environment_is_explicit_non_secret_and_allows_large_values() {
@@ -66,4 +67,100 @@ fn capsule_environment_roots_home_defaults_path_and_preserves_minimal_values() {
             ("PATH".to_owned(), "/explicit/bin".to_owned()),
         ])
     );
+}
+
+fn bedrock_environment(
+    values: &[(&str, &str)],
+) -> Result<BTreeMap<String, String>, NodeRunnerError> {
+    let workspace = TestDirectory::new("claude-bedrock-environment");
+    let binding = agent_binding(
+        "global.anthropic.provider-owned-model",
+        Some(ReasoningEffort::Max),
+        SessionScope::Execution,
+        &values.iter().map(|(name, _)| *name).collect::<Vec<_>>(),
+    );
+    let resolved = ResolvedEnvironment::exact(
+        &binding,
+        values
+            .iter()
+            .map(|(name, value)| (environment_name(name), (*value).to_owned()))
+            .collect(),
+    )
+    .assert_value();
+    let adapter = ClaudeAdapter::new_for_test(ClaudeAdapterConfig {
+        provider: ClaudeProvider::Bedrock,
+        executable: "claude".to_owned(),
+        prefix_arguments: Vec::new(),
+        workspace: workspace.path().to_owned(),
+        runtime_home: workspace.child("runtime"),
+        local_user_home: None,
+        base_environment: ClaudeProcessEnvironment::new(BTreeMap::from([(
+            "PATH".to_owned(),
+            "/usr/bin:/bin".to_owned(),
+        )]))
+        .assert_value(),
+        turn_timeout: Duration::from_secs(1),
+        process_pool: HostedProcessPool::new(10_002, 10_002, 20_000, 20_000).assert_value(),
+    })
+    .assert_value();
+    adapter.process_environment(&resolved, Path::new("/private/session"))
+}
+
+#[test]
+fn bedrock_environment_sets_control_and_rejects_missing_or_conflicting_values() {
+    let valid = bedrock_environment(&[
+        (AWS_BEARER_TOKEN_BEDROCK, "bedrock-secret"),
+        (AWS_REGION, "us-east-1"),
+    ])
+    .assert_value();
+    assert_eq!(
+        valid.get(AWS_BEARER_TOKEN_BEDROCK).map(String::as_str),
+        Some("bedrock-secret")
+    );
+    assert_eq!(valid.get(AWS_REGION).map(String::as_str), Some("us-east-1"));
+    assert_eq!(
+        valid.get("CLAUDE_CODE_USE_BEDROCK").map(String::as_str),
+        Some("1")
+    );
+
+    for values in [
+        vec![(AWS_REGION, "us-east-1")],
+        vec![(AWS_BEARER_TOKEN_BEDROCK, "bedrock-secret")],
+        vec![(AWS_BEARER_TOKEN_BEDROCK, ""), (AWS_REGION, "us-east-1")],
+        vec![
+            (AWS_BEARER_TOKEN_BEDROCK, "bedrock-secret"),
+            (AWS_REGION, ""),
+        ],
+    ] {
+        assert!(bedrock_environment(&values).is_err(), "accepted {values:?}");
+    }
+
+    for conflict in [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "ANTHROPIC_BEDROCK_MANTLE_BASE_URL",
+        "CLAUDE_CONFIG_DIR",
+        "CLAUDE_CODE_OAUTH_REFRESH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+        "CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_GATEWAY",
+        "CLAUDE_CODE_USE_MANTLE",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+    ] {
+        let values = [
+            (AWS_BEARER_TOKEN_BEDROCK, "bedrock-secret"),
+            (AWS_REGION, "us-east-1"),
+            (conflict, "conflict"),
+        ];
+        assert!(
+            bedrock_environment(&values).is_err(),
+            "accepted conflicting {conflict}"
+        );
+    }
 }

--- a/zeroshot/src/native_v2_cli/execution/submission.rs
+++ b/zeroshot/src/native_v2_cli/execution/submission.rs
@@ -303,6 +303,7 @@ enum UniformProvider {
     #[serde(rename = "openrouter")]
     OpenRouter,
     Anthropic,
+    Bedrock,
 }
 
 const KNOWN_INCOMPATIBLE_HARNESS_PROVIDER_PAIRS: &[(UniformHarness, UniformProvider)] = &[
@@ -336,7 +337,7 @@ impl UniformRuntimePlan {
         let connections = self
             .connections
             .clone()
-            .map_or_else(|| default_uniform_connections(self.provider), Ok)?;
+            .map_or_else(|| default_connections(self.provider), Ok)?;
         let mut nodes = BTreeMap::new();
         for (name, delivery) in executable_runtime_roles(&graph.root) {
             nodes.insert(name, self.binding(delivery, &connections)?);
@@ -382,6 +383,11 @@ impl UniformRuntimePlan {
                 size: self.size,
                 nodes,
             }),
+            (UniformHarness::Codex, UniformProvider::Bedrock) => Ok(RuntimePlan::Codex {
+                provider: CodexProvider::Bedrock,
+                size: self.size,
+                nodes,
+            }),
             (UniformHarness::Claude, UniformProvider::Anthropic) => Ok(RuntimePlan::Claude {
                 provider: ClaudeProvider::Anthropic,
                 size: self.size,
@@ -392,6 +398,11 @@ impl UniformRuntimePlan {
                 size: self.size,
                 nodes,
             }),
+            (UniformHarness::Claude, UniformProvider::Bedrock) => Ok(RuntimePlan::Claude {
+                provider: ClaudeProvider::Bedrock,
+                size: self.size,
+                nodes,
+            }),
             _ => Err(NativeV2CliError::Usage(
                 "unsupported harness/provider pair".to_owned(),
             )),
@@ -399,29 +410,31 @@ impl UniformRuntimePlan {
     }
 }
 
-fn default_uniform_connections(
-    provider: UniformProvider,
-) -> Result<DeclaredConnections, NativeV2CliError> {
-    let (key, name) = match provider {
-        UniformProvider::OpenAi => ("openai", "OPENAI_API_KEY"),
-        UniformProvider::OpenRouter => ("openrouter", "OPENROUTER_API_KEY"),
-        UniformProvider::Anthropic => ("anthropic", "ANTHROPIC_API_KEY"),
+fn default_connections(provider: UniformProvider) -> Result<DeclaredConnections, NativeV2CliError> {
+    let (key, names): (&str, &[&str]) = match provider {
+        UniformProvider::OpenAi => ("openai", &["OPENAI_API_KEY"]),
+        UniformProvider::OpenRouter => ("openrouter", &["OPENROUTER_API_KEY"]),
+        UniformProvider::Anthropic => ("anthropic", &["ANTHROPIC_API_KEY"]),
+        UniformProvider::Bedrock => ("bedrock", &["AWS_BEARER_TOKEN_BEDROCK", "AWS_REGION"]),
     };
-    single_connection(key, name)
+    connection(key, names)
 }
 
 fn git_delivery_binding() -> Result<NodeRuntimeBinding, NativeV2CliError> {
-    let connections = single_connection(
+    let connections = connection(
         crate::native_v2_contract::GITHUB_CONNECTION_KEY,
-        GITHUB_TOKEN_ENV,
+        &[GITHUB_TOKEN_ENV],
     )?;
     Ok(NodeRuntimeBinding::GitDelivery { connections })
 }
 
-fn single_connection(key: &str, name: &str) -> Result<DeclaredConnections, NativeV2CliError> {
-    let name = EnvironmentVariableName::new(name)
+fn connection(key: &str, names: &[&str]) -> Result<DeclaredConnections, NativeV2CliError> {
+    let names = names
+        .iter()
+        .map(|name| EnvironmentVariableName::new(*name))
+        .collect::<Result<Vec<_>, _>>()
         .map_err(|error| NativeV2CliError::Usage(error.to_string()))?;
-    let environment = DeclaredEnvironment::new([name])
+    let environment = DeclaredEnvironment::new(names)
         .map_err(|error| NativeV2CliError::Usage(error.to_string()))?;
     DeclaredConnections::single(key, environment)
         .map_err(|error| NativeV2CliError::Usage(error.to_string()))

--- a/zeroshot/src/native_v2_cli/parser.rs
+++ b/zeroshot/src/native_v2_cli/parser.rs
@@ -298,9 +298,10 @@ struct TemplateShowArgs {
         }
       }
 
-    Known-incompatible harness/provider pairs are codex/anthropic and claude/openai. Model IDs are
-    passed unchanged to the selected harness and provider; Zeroshot does not maintain or validate
-    provider model catalogs.
+    Provider choices are codex/openai, codex/openrouter, codex/bedrock, claude/anthropic,
+    claude/openrouter, and claude/bedrock. Known-incompatible harness/provider pairs are
+    codex/anthropic and claude/openai. Model IDs are passed unchanged to the selected harness and
+    provider; Zeroshot does not maintain or validate provider model catalogs.
 
     Sizes are small, medium, and large.
 

--- a/zeroshot/src/native_v2_cli/tests/environment.rs
+++ b/zeroshot/src/native_v2_cli/tests/environment.rs
@@ -275,6 +275,58 @@ async fn uniform_runtime_is_materialized_by_rust_against_the_selected_graph() {
 }
 
 #[tokio::test]
+async fn uniform_bedrock_runtime_materializes_for_both_harnesses_with_exact_defaults() {
+    for harness in ["codex", "claude"] {
+        let (_files, command) = uniform_runtime_command(
+            &format!("Uniform Bedrock {harness} runtime"),
+            json!({
+                "harness":harness,
+                "provider":"bedrock",
+                "model":"provider-owned-model"
+            }),
+        );
+        let backend = FakeBackend::default();
+        let available = |name: &str| match name {
+            "AWS_BEARER_TOKEN_BEDROCK" => Some(OsString::from("bedrock-secret")),
+            "AWS_REGION" => Some(OsString::from("us-east-1")),
+            _ => None,
+        };
+        execute_with_environment(command, &backend, &available)
+            .await
+            .assert_value();
+
+        let calls = backend.calls();
+        let (runtime, connections) = match calls.as_slice() {
+            [
+                Call::Submit {
+                    runtime,
+                    connections,
+                    ..
+                },
+            ] => Some((runtime, connections)),
+            _ => None,
+        }
+        .assert_value();
+        let runtime = serde_json::to_value(runtime).assert_value();
+        assert_eq!(runtime.pointer("/harness"), Some(&json!(harness)));
+        assert_eq!(runtime.pointer("/provider"), Some(&json!("bedrock")));
+        assert_eq!(
+            runtime.pointer("/nodes/worker/connections/bedrock"),
+            Some(&json!(["AWS_BEARER_TOKEN_BEDROCK", "AWS_REGION"]))
+        );
+        assert_eq!(
+            serde_json::to_value(connections).assert_value(),
+            json!({
+                "bedrock": {
+                    "AWS_BEARER_TOKEN_BEDROCK": "bedrock-secret",
+                    "AWS_REGION": "us-east-1"
+                }
+            })
+        );
+    }
+}
+
+#[tokio::test]
 async fn uniform_runtime_requires_harness_without_contacting_backend() {
     let (_files, command) = uniform_runtime_command(
         "Explicit harness",

--- a/zeroshot/src/native_v2_codex.rs
+++ b/zeroshot/src/native_v2_codex.rs
@@ -1,4 +1,4 @@
-//! Native-v2 Codex harness for the OpenAI and OpenRouter provider lanes.
+//! Native-v2 Codex harness for the OpenAI, OpenRouter, and Amazon Bedrock provider lanes.
 //!
 //! The graph-wide provider is fixed when the adapter is constructed. Model, effort, session
 //! scope, input, and declared environment remain per-node admitted values. Provider sessions are
@@ -66,7 +66,7 @@ pub struct NativeV2CodexUser {
     pub codex_home: PathBuf,
 }
 
-/// One graph-wide Codex/OpenAI-or-OpenRouter adapter.
+/// One graph-wide Codex provider adapter.
 pub struct NativeV2CodexAdapter {
     config: NativeV2CodexConfig,
     runners: ProviderProcessRunners,

--- a/zeroshot/src/native_v2_codex/command.rs
+++ b/zeroshot/src/native_v2_codex/command.rs
@@ -7,6 +7,8 @@ use crate::native_v2_contract::{CodexProvider, NodeRuntimeBinding};
 use crate::native_v2_runner::{NodeRole, NodeRunnerError, ResolvedEnvironment};
 use crate::worker_catalog::{ModelId, ReasoningEffort};
 
+pub(super) const AWS_BEARER_TOKEN_BEDROCK: &str = "AWS_BEARER_TOKEN_BEDROCK";
+pub(super) const AWS_REGION: &str = "AWS_REGION";
 const CODEX_HOME: &str = "CODEX_HOME";
 const CODEX_API_KEY: &str = "CODEX_API_KEY";
 const HOME: &str = "HOME";
@@ -43,12 +45,26 @@ pub(super) fn configure_provider_auth(
 ) -> Result<(), NodeRunnerError> {
     match provider {
         CodexProvider::OpenAi => configure_openai_auth(values, has_local_user),
+        CodexProvider::Bedrock => configure_bedrock_auth(values),
         CodexProvider::OpenRouter => values
             .get("OPENROUTER_API_KEY")
             .is_some_and(|value| !value.is_empty())
             .then_some(())
             .ok_or(NodeRunnerError::Driver),
     }
+}
+
+fn configure_bedrock_auth(values: &BTreeMap<String, String>) -> Result<(), NodeRunnerError> {
+    if [AWS_BEARER_TOKEN_BEDROCK, AWS_REGION]
+        .iter()
+        .any(|name| !values.get(*name).is_some_and(|value| !value.is_empty()))
+        || [CODEX_API_KEY, OPENAI_API_KEY, "OPENROUTER_API_KEY"]
+            .iter()
+            .any(|name| values.contains_key(*name))
+    {
+        return Err(NodeRunnerError::Driver);
+    }
+    Ok(())
 }
 
 fn configure_openai_auth(
@@ -70,6 +86,7 @@ pub(super) fn add_provider_args(argv: &mut Vec<String>, provider: CodexProvider)
         match provider {
             CodexProvider::OpenAi => "model_provider=\"openai\"".to_owned(),
             CodexProvider::OpenRouter => "model_provider=\"openrouter\"".to_owned(),
+            CodexProvider::Bedrock => "model_provider=\"amazon-bedrock\"".to_owned(),
         },
     ]);
     if provider == CodexProvider::OpenRouter {

--- a/zeroshot/src/native_v2_codex/tests.rs
+++ b/zeroshot/src/native_v2_codex/tests.rs
@@ -29,6 +29,7 @@ use openengine_cluster_testkit::assertions::AssertValue;
 use serde_json::{json, Value};
 
 use super::*;
+use super::command::{AWS_BEARER_TOKEN_BEDROCK, AWS_REGION};
 use crate::execution::SessionScope;
 use crate::native_v2_candidate::test_support::{
     NodeRequestFixture, TestDirectory, admit, environment_name, full_graph, success_node,
@@ -53,7 +54,10 @@ prompt=$(/usr/bin/cat)
   /usr/bin/printf 'prompt=%s\n' "$prompt"
   /usr/bin/printf 'codex_home=%s\n' "$CODEX_HOME"
   /usr/bin/printf 'openrouter_key=%s\n' "${OPENROUTER_API_KEY-unset}"
+  /usr/bin/printf 'openai_key=%s\n' "${OPENAI_API_KEY-unset}"
   /usr/bin/printf 'codex_key=%s\n' "${CODEX_API_KEY-unset}"
+  /usr/bin/printf 'bedrock_key=%s\n' "${AWS_BEARER_TOKEN_BEDROCK-unset}"
+  /usr/bin/printf 'aws_region=%s\n' "${AWS_REGION-unset}"
   /usr/bin/printf 'path=%s\n' "${PATH-unset}"
   /usr/bin/printf 'home=%s\n' "${HOME-unset}"
   /usr/bin/printf 'ambient=%s\n' "${AMBIENT_SENTINEL-unset}"

--- a/zeroshot/src/native_v2_codex/tests/correction.rs
+++ b/zeroshot/src/native_v2_codex/tests/correction.rs
@@ -5,15 +5,18 @@ async fn corrected_output(
     provider: CodexProvider,
 ) -> (WorkerOutcome, String) {
     let capture = directory.child("capture");
-    let (credential_name, credential_value) = match provider {
-        CodexProvider::OpenAi => ("OPENAI_API_KEY", "fake-openai-key"),
-        CodexProvider::OpenRouter => ("OPENROUTER_API_KEY", "fake-openrouter-key"),
-    };
+    let configuration = match provider {
+        CodexProvider::OpenAi => Some(("OPENAI_API_KEY", "fake-openai-key", "gpt-5.6-sol")),
+        CodexProvider::OpenRouter => Some((
+            "OPENROUTER_API_KEY",
+            "fake-openrouter-key",
+            "openai/gpt-5.6-sol",
+        )),
+        CodexProvider::Bedrock => None,
+    }
+    .assert_value_with("correction fixture supports OpenAI and OpenRouter");
+    let (credential_name, credential_value, model) = configuration;
     let adapter = scripted_adapter(directory, provider);
-    let model = match provider {
-        CodexProvider::OpenAi => "gpt-5.6-sol",
-        CodexProvider::OpenRouter => "openai/gpt-5.6-sol",
-    };
     let admitted = admitted(
         binding_with_model(
             model,

--- a/zeroshot/src/native_v2_codex/tests/environment.rs
+++ b/zeroshot/src/native_v2_codex/tests/environment.rs
@@ -49,6 +49,135 @@ fn command_is_exact_and_rejects_adapter_owned_collisions() {
     );
 }
 
+fn bedrock_environment(
+    values: &[(&str, &str)],
+) -> Result<BTreeMap<String, String>, NodeRunnerError> {
+    let directory = TestDirectory::new("codex-bedrock-environment");
+    let declared = values.iter().map(|(name, _)| *name).collect::<Vec<_>>();
+    let binding = binding(SessionScope::Execution, declared.as_slice());
+    let resolved_values = BTreeMap::from_iter(
+        values
+            .iter()
+            .copied()
+            .map(|(name, value)| (environment_name(name), value.to_owned())),
+    );
+    let resolved = ResolvedEnvironment::exact(&binding, resolved_values).assert_value();
+    scripted_adapter(&directory, CodexProvider::Bedrock)
+        .provider_environment(&resolved, &directory.child("runtime-home"))
+}
+
+#[test]
+fn bedrock_environment_requires_aws_values_and_rejects_conflicting_codex_controls() {
+    let required = [
+        (AWS_BEARER_TOKEN_BEDROCK, "bedrock-secret"),
+        (AWS_REGION, "us-east-1"),
+    ];
+    let valid = bedrock_environment(&required).assert_value();
+    for (name, expected) in required {
+        assert_eq!(valid.get(name).map(String::as_str), Some(expected));
+    }
+
+    for omitted_or_empty in [AWS_BEARER_TOKEN_BEDROCK, AWS_REGION] {
+        let omitted = required
+            .into_iter()
+            .filter(|(name, _)| *name != omitted_or_empty)
+            .collect::<Vec<_>>();
+        assert!(
+            bedrock_environment(&omitted).is_err(),
+            "accepted missing {omitted_or_empty}"
+        );
+        let empty = required.map(|(name, value)| {
+            if name == omitted_or_empty {
+                (name, "")
+            } else {
+                (name, value)
+            }
+        });
+        assert!(
+            bedrock_environment(&empty).is_err(),
+            "accepted empty {omitted_or_empty}"
+        );
+    }
+
+    for conflict in [
+        "CODEX_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "CODEX_BASE_URL",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+    ] {
+        let values = [
+            (AWS_BEARER_TOKEN_BEDROCK, "bedrock-secret"),
+            (AWS_REGION, "us-east-1"),
+            (conflict, "conflict"),
+        ];
+        assert!(
+            bedrock_environment(&values).is_err(),
+            "accepted conflicting {conflict}"
+        );
+    }
+}
+
+fn assert_bedrock_capture(capture: &str) {
+    for expected in [
+        "arg=model_provider=\"amazon-bedrock\"",
+        "arg=--model\narg=global.anthropic.provider-owned-model",
+        "bedrock_key=fake-bedrock-key",
+        "aws_region=us-east-1",
+        "openai_key=unset",
+        "openrouter_key=unset",
+        "codex_key=unset",
+    ] {
+        assert!(
+            capture.contains(expected),
+            "missing capture evidence: {expected}"
+        );
+    }
+    for forbidden in [
+        "model_providers.amazon-bedrock",
+        "bedrock-runtime.",
+        "base_url=",
+    ] {
+        assert!(
+            !capture.contains(forbidden),
+            "unexpected custom Bedrock configuration: {forbidden}"
+        );
+    }
+    assert_schema_capture(capture);
+}
+
+#[tokio::test]
+async fn bedrock_script_uses_the_builtin_provider_and_preserves_aws_environment() {
+    let directory = TestDirectory::new("codex-bedrock");
+    let capture = directory.child("capture");
+    let adapter = scripted_adapter(&directory, CodexProvider::Bedrock);
+    let admitted = admitted(
+        binding_with_model(
+            "global.anthropic.provider-owned-model",
+            SessionScope::Execution,
+            &["CAPTURE_PATH", AWS_BEARER_TOKEN_BEDROCK, AWS_REGION],
+        ),
+        CodexProvider::Bedrock,
+    )
+    .await;
+    let runtime = runner(&admitted, adapter);
+    let handle = start(
+        &runtime,
+        &admitted,
+        1,
+        &[
+            ("CAPTURE_PATH", capture.display().to_string()),
+            (AWS_BEARER_TOKEN_BEDROCK, "fake-bedrock-key".to_owned()),
+            (AWS_REGION, "us-east-1".to_owned()),
+        ],
+    )
+    .await;
+    complete_verified_with_logs(handle).await;
+
+    assert_bedrock_capture(&fs::read_to_string(capture).assert_value());
+}
+
 #[test]
 fn log_redactions_are_longest_first_and_do_not_leave_overlapping_suffixes() {
     let binding = binding(SessionScope::Execution, &["LONG_SECRET", "SHORT_SECRET"]);

--- a/zeroshot/tests/native_v2_cli_help.rs
+++ b/zeroshot/tests/native_v2_cli_help.rs
@@ -91,6 +91,11 @@ fn help_explains_runtime_configuration() {
         SessionScope::NodeInstance,
     ]));
     let contract_prose = [
+        concat!(
+            "provider choices are codex/openai, codex/openrouter, codex/bedrock, ",
+            "claude/anthropic, claude/openrouter, and claude/bedrock."
+        )
+        .to_owned(),
         "known-incompatible harness/provider pairs are codex/anthropic and claude/openai."
             .to_owned(),
         concat!(


### PR DESCRIPTION
## Summary
- add serialized `bedrock` provider support for both Codex and Claude runtime plans
- use Codex's built-in `amazon-bedrock` provider with `AWS_BEARER_TOKEN_BEDROCK` and `AWS_REGION`
- configure Claude Code Bedrock mode and reject conflicting endpoint, alternate-cloud, Anthropic, OpenRouter, and OAuth controls
- materialize the default Bedrock connection, update CLI help, and regenerate source-owned protocol/docs artifacts
- allow opaque model identifiers up to 2,048 non-control characters so Claude Bedrock application inference-profile ARNs pass unchanged
- keep Rust validation aligned with published JSON Schema character-length semantics
- add focused serialization, admission, environment, command, conflict, model-boundary, and CLI regression coverage

## Validation
- published Zeroshot v8 worker/reviewer loop completed three implementation passes
- Bedrock-backed reviewer final verdict: accepted with no blocking defects
- `cargo fmt --all -- --check`
- `cargo test -p openengine-cluster-protocol`
- `cargo test -p zeroshot`
- `cargo test -p zeroshot --lib bedrock`
- `cargo test -p zeroshot native_v2_claude::tests::`
- `cargo clippy -p openengine-cluster-protocol --all-targets -- -D warnings`
- `cargo clippy -p zeroshot --all-targets -- -D warnings`
- `npm run protocol:check`
- `npm run opcore:graph:update`
- `npm run opcore:check`
- `opcore-zero check --repo . --staged --json` (clean)
- `opcore-zero sense --repo . --staged --json` (no introduced cycles, duplicates, or interface findings)

## Delivery note
Zeroshot's PR delivery node prepared and pushed the original reviewed commit `6f027134`. Focused post-delivery audits added `7a3fe2ab` for valid long Bedrock application inference-profile ARNs and `96bcbe04` to align Rust and JSON Schema model-length semantics.