### PR TITLE
fix: harden GitHub review synchronization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 - GitHub delivery treats aggregate merge policy and required contexts as authority, waits through
   merge queues/deferrals, and succeeds only after observing the exact merged result. Outside merge
   queues, branch freshness advances only through an authorized compare-and-swap response.
+- GitHub review creation and rediscovery are shared by pull-request and merge delivery. They verify
+  the exact pushed ref and head, retry bounded transient visibility or API failures, refresh a
+  dynamic credential once on HTTP 401/403, and fail closed on identity mismatch or static-token
+  rejection.
 
 ## CLI and target contracts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,8 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   queues, branch freshness advances only through an authorized compare-and-swap response.
 - GitHub review creation and rediscovery are shared by pull-request and merge delivery. They verify
   the exact pushed ref and head, retry bounded transient visibility or API failures, refresh a
-  dynamic credential once on HTTP 401/403, and fail closed on identity mismatch or static-token
-  rejection.
+  dynamic credential once on HTTP 401/403 within the synchronization deadline and cancellation
+  boundary, and fail closed on identity mismatch or static-token rejection.
 
 ## CLI and target contracts
 

--- a/zeroshot/src/native_v2_delivery.rs
+++ b/zeroshot/src/native_v2_delivery.rs
@@ -6,6 +6,7 @@
 //! conflict and CI failure remain routable attempt results.
 
 mod adapter;
+mod authority_error;
 pub(crate) mod contract;
 mod git;
 #[doc(hidden)]
@@ -15,6 +16,7 @@ mod review_head;
 #[cfg(test)]
 mod tests;
 
+pub use authority_error::{GitHubApiFailure, GitHubAuthorityError};
 pub use github::{GhCliAuthorityConfig, GhCliDeliveryAuthority};
 pub use review_head::{GitHubHeadSynchronization, GitHubHeadUpdateOutcome, GitHubMergeRequestOutcome};
 pub use contract::{is_matching_success_receipt, validate_delivery_contract};
@@ -63,8 +65,10 @@ const DELIVERY_HEAD_REVISION_FIELD: &str = "headRevision";
 const DELIVERY_PULL_REQUEST_ID_FIELD: &str = "pullRequestId";
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(20);
-const REVIEW_SYNC_ATTEMPTS: usize = 5;
+const REVIEW_SYNC_ATTEMPTS: usize = 10;
+const REVIEW_SYNC_DEADLINE: Duration = Duration::from_secs(60);
 const REVIEW_SYNC_INTERVAL: Duration = Duration::from_secs(1);
+const REVIEW_SYNC_MAX_INTERVAL: Duration = Duration::from_secs(8);
 const MAX_TOKEN_BYTES: usize = 4_096;
 const MAX_REVIEW_ID_BYTES: usize = 32;
 
@@ -271,14 +275,6 @@ pub struct GitHubReviewObservation {
     pub head_branch: String,
     pub head_revision: String,
     pub state: GitHubReviewState,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
-pub enum GitHubAuthorityError {
-    #[error("GitHub delivery authority is unavailable")]
-    Unavailable,
-    #[error("GitHub rejected delivery")]
-    Rejected,
 }
 
 /// Target-owned, bounded GitHub effects. Implementations must bound every network operation.

--- a/zeroshot/src/native_v2_delivery/adapter.rs
+++ b/zeroshot/src/native_v2_delivery/adapter.rs
@@ -84,7 +84,7 @@ impl NodeDriver for NativeV2DeliveryAdapter {
         invocation: DriverInvocation,
         mut control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
-        let (session, credentials, mode) = match self.authorize(&invocation) {
+        let (session, mut credentials, mode) = match self.authorize(&invocation) {
             Ok(authority) => authority,
             Err(stop) => return stop.result(),
         };
@@ -95,7 +95,7 @@ impl NodeDriver for NativeV2DeliveryAdapter {
             .prepare_review(DeliveryPreparation {
                 invocation: &invocation,
                 session,
-                credential: credentials.current(),
+                credentials: &mut credentials,
                 control: &control,
             })
             .await
@@ -119,10 +119,10 @@ enum DeliveryStop {
     Outcome(WorkerOutcome),
 }
 
-struct DeliveryPreparation<'a> {
+struct DeliveryPreparation<'a, 'environment> {
     invocation: &'a DriverInvocation,
     session: &'a DeliverySession,
-    credential: GitHubCredential<'a>,
+    credentials: &'a mut DeliveryCredentials<'environment>,
     control: &'a DriverControl,
 }
 
@@ -157,6 +157,10 @@ struct DeliveryCredentials<'a> {
 impl<'a> DeliveryCredentials<'a> {
     fn current(&self) -> GitHubCredential<'_> {
         GitHubCredential(&self.token)
+    }
+
+    fn can_refresh(&self) -> bool {
+        self.environment.is_some()
     }
 
     async fn refresh(&mut self) -> Result<(), DeliveryStop> {
@@ -208,7 +212,7 @@ impl NativeV2DeliveryAdapter {
 
     async fn prepare_review(
         &self,
-        preparation: DeliveryPreparation<'_>,
+        preparation: DeliveryPreparation<'_, '_>,
     ) -> Result<GitHubReviewReceipt, DeliveryStop> {
         let source_issue = source_issue(&preparation.invocation.node.input)?;
         let head_revision = self
@@ -222,7 +226,11 @@ impl NativeV2DeliveryAdapter {
         };
         self.push_review_head(&preparation, &review_request).await?;
         let review = self
-            .synchronize_review(&review_request, preparation.credential, preparation.control)
+            .synchronize_review(
+                &review_request,
+                preparation.credentials,
+                preparation.control,
+            )
             .await?;
         if !valid_review(&review_request, &review) {
             return Err(DeliveryStop::Outcome(WorkerOutcome::malformed()));
@@ -262,7 +270,7 @@ impl NativeV2DeliveryAdapter {
 
     async fn push_review_head(
         &self,
-        preparation: &DeliveryPreparation<'_>,
+        preparation: &DeliveryPreparation<'_, '_>,
         review: &GitHubReviewRequest,
     ) -> Result<(), DeliveryStop> {
         let push = GitHubPushRequest {
@@ -273,7 +281,7 @@ impl NativeV2DeliveryAdapter {
         };
         emit(preparation.control, "delivery: pushing run branch").await?;
         self.authority
-            .push_branch(&push, preparation.credential)
+            .push_branch(&push, preparation.credentials.current())
             .await
             .map_err(|_| crash_outcome())?;
         Ok(())

--- a/zeroshot/src/native_v2_delivery/adapter.rs
+++ b/zeroshot/src/native_v2_delivery/adapter.rs
@@ -3,6 +3,7 @@ use super::*;
 mod head;
 mod input;
 mod review;
+mod sync;
 use input::source_issue;
 use review::{crash_outcome, review_completion, ReviewProgress, ReviewStep};
 
@@ -232,29 +233,6 @@ impl NativeV2DeliveryAdapter {
         )
         .await?;
         Ok(review)
-    }
-
-    async fn synchronize_review(
-        &self,
-        request: &GitHubReviewRequest,
-        credential: GitHubCredential<'_>,
-        control: &DriverControl,
-    ) -> Result<GitHubReviewReceipt, DeliveryStop> {
-        for attempt in 0..REVIEW_SYNC_ATTEMPTS {
-            match self
-                .authority
-                .open_or_update_review(request, credential)
-                .await
-            {
-                Ok(review) => return Ok(review),
-                Err(_) if attempt + 1 < REVIEW_SYNC_ATTEMPTS => {
-                    emit(control, "delivery: waiting for pushed review head").await?;
-                    tokio::time::sleep(REVIEW_SYNC_INTERVAL).await;
-                }
-                Err(_) => return Err(crash_outcome()),
-            }
-        }
-        Err(crash_outcome())
     }
 
     async fn prepare_head(

--- a/zeroshot/src/native_v2_delivery/adapter/head.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/head.rs
@@ -80,7 +80,7 @@ impl NativeV2DeliveryAdapter {
                     drive.credentials.refresh().await?;
                     wait_for_poll(drive.control, self.config.poll.interval).await?;
                 }
-                Err(GitHubAuthorityError::Unavailable | GitHubAuthorityError::Rejected) => {
+                Err(_) => {
                     return Err(crash_outcome());
                 }
             }

--- a/zeroshot/src/native_v2_delivery/adapter/sync.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/sync.rs
@@ -7,6 +7,42 @@ struct ReviewSyncInvocation<'a> {
     remaining: Duration,
 }
 
+struct ReviewSyncState<'a, 'environment> {
+    request: &'a GitHubReviewRequest,
+    credentials: &'a mut DeliveryCredentials<'environment>,
+    control: &'a DriverControl,
+    deadline: tokio::time::Instant,
+    credential_refreshed: bool,
+}
+
+impl ReviewSyncState<'_, '_> {
+    fn invocation(&self) -> ReviewSyncInvocation<'_> {
+        ReviewSyncInvocation {
+            request: self.request,
+            credential: self.credentials.current(),
+            control: self.control,
+            remaining: self
+                .deadline
+                .saturating_duration_since(tokio::time::Instant::now()),
+        }
+    }
+
+    fn should_refresh_credential(&self, progress: &ReviewSyncProgress) -> bool {
+        matches!(
+            progress,
+            ReviewSyncProgress::Failed(error) if error.authentication_failed()
+        ) && self.credentials.can_refresh()
+            && !self.credential_refreshed
+    }
+
+    async fn refresh_credential(&mut self) -> Result<(), DeliveryStop> {
+        emit(self.control, "delivery: refreshing GitHub credential").await?;
+        self.credentials.refresh().await?;
+        self.credential_refreshed = true;
+        Ok(())
+    }
+}
+
 enum ReviewSyncProgress {
     Complete(GitHubReviewReceipt),
     Failed(GitHubAuthorityError),
@@ -31,22 +67,21 @@ impl NativeV2DeliveryAdapter {
     pub(super) async fn synchronize_review(
         &self,
         request: &GitHubReviewRequest,
-        credential: GitHubCredential<'_>,
+        credentials: &mut DeliveryCredentials<'_>,
         control: &DriverControl,
     ) -> Result<GitHubReviewReceipt, DeliveryStop> {
         let deadline = tokio::time::Instant::now() + REVIEW_SYNC_DEADLINE;
         let mut retry_interval = REVIEW_SYNC_INTERVAL;
+        let mut state = ReviewSyncState {
+            request,
+            credentials,
+            control,
+            deadline,
+            credential_refreshed: false,
+        };
         for attempt in 1..=REVIEW_SYNC_ATTEMPTS {
-            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-            let error = match self
-                .review_sync_attempt(ReviewSyncInvocation {
-                    request,
-                    credential,
-                    control,
-                    remaining,
-                })
-                .await?
-            {
+            let progress = self.review_sync_progress(&mut state).await?;
+            let error = match progress {
                 ReviewSyncProgress::Complete(review) => return Ok(review),
                 ReviewSyncProgress::Failed(error) => error,
                 ReviewSyncProgress::TimedOut => return review_sync_timeout(control).await,
@@ -69,6 +104,18 @@ impl NativeV2DeliveryAdapter {
                 .min(REVIEW_SYNC_MAX_INTERVAL);
         }
         Err(crash_outcome())
+    }
+
+    async fn review_sync_progress(
+        &self,
+        state: &mut ReviewSyncState<'_, '_>,
+    ) -> Result<ReviewSyncProgress, DeliveryStop> {
+        let mut progress = self.review_sync_attempt(state.invocation()).await?;
+        if state.should_refresh_credential(&progress) {
+            state.refresh_credential().await?;
+            progress = self.review_sync_attempt(state.invocation()).await?;
+        }
+        Ok(progress)
     }
 
     async fn review_sync_attempt(

--- a/zeroshot/src/native_v2_delivery/adapter/sync.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/sync.rs
@@ -1,0 +1,147 @@
+use super::*;
+
+struct ReviewSyncInvocation<'a> {
+    request: &'a GitHubReviewRequest,
+    credential: GitHubCredential<'a>,
+    control: &'a DriverControl,
+    remaining: Duration,
+}
+
+enum ReviewSyncProgress {
+    Complete(GitHubReviewReceipt),
+    Failed(GitHubAuthorityError),
+    TimedOut,
+}
+
+struct ReviewSyncFailure<'a> {
+    control: &'a DriverControl,
+    attempt: usize,
+    error: GitHubAuthorityError,
+    deadline: tokio::time::Instant,
+    retry_interval: Duration,
+}
+
+enum ReviewSyncDisposition {
+    Retry,
+    Stop,
+    TimedOut,
+}
+
+impl NativeV2DeliveryAdapter {
+    pub(super) async fn synchronize_review(
+        &self,
+        request: &GitHubReviewRequest,
+        credential: GitHubCredential<'_>,
+        control: &DriverControl,
+    ) -> Result<GitHubReviewReceipt, DeliveryStop> {
+        let deadline = tokio::time::Instant::now() + REVIEW_SYNC_DEADLINE;
+        let mut retry_interval = REVIEW_SYNC_INTERVAL;
+        for attempt in 1..=REVIEW_SYNC_ATTEMPTS {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            let error = match self
+                .review_sync_attempt(ReviewSyncInvocation {
+                    request,
+                    credential,
+                    control,
+                    remaining,
+                })
+                .await?
+            {
+                ReviewSyncProgress::Complete(review) => return Ok(review),
+                ReviewSyncProgress::Failed(error) => error,
+                ReviewSyncProgress::TimedOut => return review_sync_timeout(control).await,
+            };
+            match handle_review_sync_failure(ReviewSyncFailure {
+                control,
+                attempt,
+                error,
+                deadline,
+                retry_interval,
+            })
+            .await?
+            {
+                ReviewSyncDisposition::Retry => {}
+                ReviewSyncDisposition::Stop => return Err(crash_outcome()),
+                ReviewSyncDisposition::TimedOut => return review_sync_timeout(control).await,
+            }
+            retry_interval = retry_interval
+                .saturating_mul(2)
+                .min(REVIEW_SYNC_MAX_INTERVAL);
+        }
+        Err(crash_outcome())
+    }
+
+    async fn review_sync_attempt(
+        &self,
+        invocation: ReviewSyncInvocation<'_>,
+    ) -> Result<ReviewSyncProgress, DeliveryStop> {
+        if invocation.remaining.is_zero() {
+            return Ok(ReviewSyncProgress::TimedOut);
+        }
+        ensure_active(invocation.control)?;
+        let mut cancellation = invocation.control.cancellation();
+        let result = tokio::select! {
+            _ = cancellation.cancelled() => return Err(NodeRunnerError::Cancelled.into()),
+            result = tokio::time::timeout(
+                invocation.remaining,
+                self.authority.open_or_update_review(
+                    invocation.request,
+                    invocation.credential,
+                ),
+            ) => result,
+        };
+        Ok(match result {
+            Ok(Ok(review)) => ReviewSyncProgress::Complete(review),
+            Ok(Err(error)) => ReviewSyncProgress::Failed(error),
+            Err(_) => ReviewSyncProgress::TimedOut,
+        })
+    }
+}
+
+async fn wait_for_review_sync(
+    control: &DriverControl,
+    deadline: tokio::time::Instant,
+    interval: Duration,
+) -> Result<bool, DeliveryStop> {
+    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+    let wait = interval.min(remaining);
+    if wait.is_zero() {
+        return Ok(false);
+    }
+    let mut cancellation = control.cancellation();
+    tokio::select! {
+        _ = cancellation.cancelled() => Err(NodeRunnerError::Cancelled.into()),
+        () = tokio::time::sleep(wait) => Ok(true),
+    }
+}
+
+async fn handle_review_sync_failure(
+    failure: ReviewSyncFailure<'_>,
+) -> Result<ReviewSyncDisposition, DeliveryStop> {
+    let retry = failure.attempt < REVIEW_SYNC_ATTEMPTS && failure.error.retryable_review_sync();
+    let diagnostic = if retry {
+        format!(
+            "delivery: GitHub review synchronization attempt {} failed: {}; retrying",
+            failure.attempt, failure.error
+        )
+    } else {
+        format!(
+            "delivery: GitHub review synchronization failed after {} attempt(s): {}",
+            failure.attempt, failure.error
+        )
+    };
+    emit(failure.control, &diagnostic).await?;
+    if !retry {
+        return Ok(ReviewSyncDisposition::Stop);
+    }
+    if wait_for_review_sync(failure.control, failure.deadline, failure.retry_interval).await? {
+        Ok(ReviewSyncDisposition::Retry)
+    } else {
+        Ok(ReviewSyncDisposition::TimedOut)
+    }
+}
+
+async fn review_sync_timeout(control: &DriverControl) -> Result<GitHubReviewReceipt, DeliveryStop> {
+    emit(control, "delivery: GitHub review synchronization timed out").await?;
+    Err(crash_outcome())
+}

--- a/zeroshot/src/native_v2_delivery/adapter/sync.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/sync.rs
@@ -1,4 +1,7 @@
+use std::future::Future;
+
 use super::*;
+use crate::execution::driver::DriverCancellation;
 
 struct ReviewSyncInvocation<'a> {
     request: &'a GitHubReviewRequest,
@@ -35,17 +38,33 @@ impl ReviewSyncState<'_, '_> {
             && !self.credential_refreshed
     }
 
-    async fn refresh_credential(&mut self) -> Result<(), DeliveryStop> {
+    async fn refresh_credential(&mut self) -> Result<CredentialRefreshProgress, DeliveryStop> {
         emit(self.control, "delivery: refreshing GitHub credential").await?;
-        self.credentials.refresh().await?;
-        self.credential_refreshed = true;
-        Ok(())
+        ensure_active(self.control)?;
+        let remaining = self
+            .deadline
+            .saturating_duration_since(tokio::time::Instant::now());
+        let progress = refresh_within_deadline(
+            self.credentials.refresh(),
+            self.control.cancellation(),
+            remaining,
+        )
+        .await?;
+        if matches!(progress, CredentialRefreshProgress::Complete) {
+            self.credential_refreshed = true;
+        }
+        Ok(progress)
     }
 }
 
 enum ReviewSyncProgress {
     Complete(GitHubReviewReceipt),
     Failed(GitHubAuthorityError),
+    TimedOut,
+}
+
+enum CredentialRefreshProgress {
+    Complete,
     TimedOut,
 }
 
@@ -112,8 +131,12 @@ impl NativeV2DeliveryAdapter {
     ) -> Result<ReviewSyncProgress, DeliveryStop> {
         let mut progress = self.review_sync_attempt(state.invocation()).await?;
         if state.should_refresh_credential(&progress) {
-            state.refresh_credential().await?;
-            progress = self.review_sync_attempt(state.invocation()).await?;
+            progress = match state.refresh_credential().await? {
+                CredentialRefreshProgress::Complete => {
+                    self.review_sync_attempt(state.invocation()).await?
+                }
+                CredentialRefreshProgress::TimedOut => ReviewSyncProgress::TimedOut,
+            };
         }
         Ok(progress)
     }
@@ -142,6 +165,29 @@ impl NativeV2DeliveryAdapter {
             Ok(Err(error)) => ReviewSyncProgress::Failed(error),
             Err(_) => ReviewSyncProgress::TimedOut,
         })
+    }
+}
+
+async fn refresh_within_deadline<F>(
+    refresh: F,
+    mut cancellation: DriverCancellation,
+    remaining: Duration,
+) -> Result<CredentialRefreshProgress, DeliveryStop>
+where
+    F: Future<Output = Result<(), DeliveryStop>>,
+{
+    if remaining.is_zero() {
+        return Ok(CredentialRefreshProgress::TimedOut);
+    }
+    let result = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(NodeRunnerError::Cancelled.into()),
+        result = tokio::time::timeout(remaining, refresh) => result,
+    };
+    match result {
+        Ok(Ok(())) => Ok(CredentialRefreshProgress::Complete),
+        Ok(Err(stop)) => Err(stop),
+        Err(_) => Ok(CredentialRefreshProgress::TimedOut),
     }
 }
 
@@ -191,4 +237,39 @@ async fn handle_review_sync_failure(
 async fn review_sync_timeout(control: &DriverControl) -> Result<GitHubReviewReceipt, DeliveryStop> {
     emit(control, "delivery: GitHub review synchronization timed out").await?;
     Err(crash_outcome())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn credential_refresh_respects_remaining_deadline() {
+        let (_sender, receiver) = tokio::sync::watch::channel(false);
+        let result = refresh_within_deadline(
+            std::future::pending::<Result<(), DeliveryStop>>(),
+            DriverCancellation::new(receiver),
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert!(matches!(result, Ok(CredentialRefreshProgress::TimedOut)));
+    }
+
+    #[tokio::test]
+    async fn credential_refresh_respects_cancellation() {
+        let (sender, receiver) = tokio::sync::watch::channel(false);
+        assert!(sender.send(true).is_ok());
+        let result = refresh_within_deadline(
+            std::future::pending::<Result<(), DeliveryStop>>(),
+            DriverCancellation::new(receiver),
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(DeliveryStop::Runner(NodeRunnerError::Cancelled))
+        ));
+    }
 }

--- a/zeroshot/src/native_v2_delivery/authority_error.rs
+++ b/zeroshot/src/native_v2_delivery/authority_error.rs
@@ -32,6 +32,10 @@ impl GitHubApiFailure {
         self.status
             .is_none_or(|status| matches!(status, 404 | 409 | 422 | 429 | 500..=599))
     }
+
+    fn authentication_failed(&self) -> bool {
+        matches!(self.status, Some(401 | 403))
+    }
 }
 
 impl fmt::Display for GitHubApiFailure {
@@ -61,6 +65,10 @@ impl GitHubAuthorityError {
             Self::Rejected => false,
             Self::Api(failure) => failure.retryable_review_sync(),
         }
+    }
+
+    pub(super) fn authentication_failed(&self) -> bool {
+        matches!(self, Self::Api(failure) if failure.authentication_failed())
     }
 
     pub(super) fn review_head_not_visible() -> Self {

--- a/zeroshot/src/native_v2_delivery/authority_error.rs
+++ b/zeroshot/src/native_v2_delivery/authority_error.rs
@@ -1,0 +1,69 @@
+use std::fmt;
+
+const MAX_GITHUB_API_DIAGNOSTIC_BYTES: usize = 1024;
+
+/// Bounded provider-owned GitHub API failure detail.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubApiFailure {
+    status: Option<u16>,
+    diagnostic: Box<str>,
+}
+
+impl GitHubApiFailure {
+    fn new(status: Option<u16>, diagnostic: impl Into<String>) -> Self {
+        let mut diagnostic = diagnostic.into();
+        if diagnostic.contains('\0') {
+            diagnostic = "GitHub API diagnostic redacted".to_owned();
+        }
+        if diagnostic.len() > MAX_GITHUB_API_DIAGNOSTIC_BYTES {
+            let mut boundary = MAX_GITHUB_API_DIAGNOSTIC_BYTES;
+            while !diagnostic.is_char_boundary(boundary) {
+                boundary = boundary.saturating_sub(1);
+            }
+            diagnostic.truncate(boundary);
+        }
+        Self {
+            status,
+            diagnostic: diagnostic.into_boxed_str(),
+        }
+    }
+
+    fn retryable_review_sync(&self) -> bool {
+        self.status
+            .is_none_or(|status| matches!(status, 404 | 409 | 422 | 429 | 500..=599))
+    }
+}
+
+impl fmt::Display for GitHubApiFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.diagnostic)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum GitHubAuthorityError {
+    #[error("GitHub delivery authority is unavailable")]
+    Unavailable,
+    #[error("GitHub rejected delivery")]
+    Rejected,
+    #[error("GitHub API request failed: {0}")]
+    Api(GitHubApiFailure),
+}
+
+impl GitHubAuthorityError {
+    pub(super) fn api(status: Option<u16>, diagnostic: impl Into<String>) -> Self {
+        Self::Api(GitHubApiFailure::new(status, diagnostic))
+    }
+
+    pub(super) fn retryable_review_sync(&self) -> bool {
+        match self {
+            Self::Unavailable => true,
+            Self::Rejected => false,
+            Self::Api(failure) => failure.retryable_review_sync(),
+        }
+    }
+
+    pub(super) fn review_head_not_visible() -> Self {
+        Self::api(None, "GitHub review head revision is not visible")
+    }
+}

--- a/zeroshot/src/native_v2_delivery/github.rs
+++ b/zeroshot/src/native_v2_delivery/github.rs
@@ -3,8 +3,6 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use serde_json::Value;
-use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::time::timeout;
 
@@ -17,10 +15,8 @@ use super::{
     GitHubReviewState, valid_head_update, valid_revision,
 };
 
-// A GitHub page may contain 100 checks or comments, including bounded user/check
-// output fields. Keep subprocess output bounded while allowing many pages.
-const MAX_API_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
-const MAX_CHECK_LOG_TAIL_BYTES: usize = 64 * 1024;
+mod api;
+
 const DEFAULT_API_DEADLINE: Duration = Duration::from_secs(2 * 60);
 const DEFAULT_PUSH_DEADLINE: Duration = Duration::from_secs(10 * 60);
 const PULL_REQUEST_TITLE: &str = "feat: complete Zeroshot task";
@@ -57,25 +53,6 @@ impl GhCliDeliveryAuthority {
     #[must_use]
     pub fn new(config: GhCliAuthorityConfig) -> Self {
         Self { config }
-    }
-
-    async fn api(
-        &self,
-        arguments: &[String],
-        credential: GitHubCredential<'_>,
-    ) -> Result<Value, GitHubAuthorityError> {
-        let output = self.api_output(arguments, credential).await?;
-        serde_json::from_slice(&output).map_err(|_| GitHubAuthorityError::Rejected)
-    }
-
-    async fn api_output(
-        &self,
-        arguments: &[String],
-        credential: GitHubCredential<'_>,
-    ) -> Result<Vec<u8>, GitHubAuthorityError> {
-        let mut command = clean_command(&self.config, &self.config.gh_program, credential);
-        command.arg("api").args(arguments).stdout(Stdio::piped());
-        bounded_output(command, self.config.api_deadline).await
     }
 
     async fn find_review(
@@ -242,7 +219,10 @@ impl GitHubDeliveryAuthority for GhCliDeliveryAuthority {
     ) -> Result<GitHubReviewReceipt, GitHubAuthorityError> {
         let review = match self.find_review(request, credential).await? {
             Some(review) => Ok(review),
-            None => self.create_review(request, credential).await,
+            None => {
+                self.confirm_review_head(request, credential).await?;
+                self.create_review(request, credential).await
+            }
         }?;
         connect_source_issue(self, request, &review, credential).await?;
         Ok(review)
@@ -369,6 +349,7 @@ mod source_issue;
 mod wire;
 use policy::{PolicySnapshot, classify_policy, include_check_logs, query_arguments};
 use source_issue::{connect_source_issue, pull_request_body};
+use api::check_log_tail;
 use wire::{PullRequestWire, review_receipt};
 
 fn clean_command(
@@ -440,47 +421,6 @@ async fn bounded_status(
         .success()
         .then_some(())
         .ok_or(GitHubAuthorityError::Rejected)
-}
-
-async fn bounded_output(
-    mut command: Command,
-    deadline: Duration,
-) -> Result<Vec<u8>, GitHubAuthorityError> {
-    command.stdout(Stdio::piped());
-    let mut child = command
-        .spawn()
-        .map_err(|_| GitHubAuthorityError::Unavailable)?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or(GitHubAuthorityError::Unavailable)?;
-    let mut output = Vec::new();
-    let mut bounded = stdout.take((MAX_API_OUTPUT_BYTES + 1) as u64);
-    let (status, ()) = timeout(deadline, async {
-        tokio::try_join!(child.wait(), async {
-            bounded.read_to_end(&mut output).await?;
-            Ok::<(), std::io::Error>(())
-        })
-    })
-    .await
-    .map_err(|_| GitHubAuthorityError::Unavailable)?
-    .map_err(|_| GitHubAuthorityError::Unavailable)?;
-    if !status.success() {
-        return Err(GitHubAuthorityError::Rejected);
-    }
-    validate_api_output(output)
-}
-
-fn validate_api_output(output: Vec<u8>) -> Result<Vec<u8>, GitHubAuthorityError> {
-    if output.is_empty() || output.len() > MAX_API_OUTPUT_BYTES {
-        return Err(GitHubAuthorityError::Rejected);
-    }
-    Ok(output)
-}
-
-fn check_log_tail(output: &[u8]) -> String {
-    let start = output.len().saturating_sub(MAX_CHECK_LOG_TAIL_BYTES);
-    String::from_utf8_lossy(output.get(start..).unwrap_or_default()).into_owned()
 }
 
 #[cfg(test)]

--- a/zeroshot/src/native_v2_delivery/github/api.rs
+++ b/zeroshot/src/native_v2_delivery/github/api.rs
@@ -1,0 +1,249 @@
+use serde_json::Value;
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+use super::wire::{GitReferenceWire, require_review_head};
+use super::*;
+
+const MAX_API_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_API_ERROR_BYTES: usize = 64 * 1024;
+const MAX_CHECK_LOG_TAIL_BYTES: usize = 64 * 1024;
+
+impl GhCliDeliveryAuthority {
+    pub(super) async fn api(
+        &self,
+        arguments: &[String],
+        credential: GitHubCredential<'_>,
+    ) -> Result<Value, GitHubAuthorityError> {
+        let output = self.api_output(arguments, credential).await?;
+        serde_json::from_slice(&output).map_err(|_| GitHubAuthorityError::Rejected)
+    }
+
+    pub(super) async fn api_output(
+        &self,
+        arguments: &[String],
+        credential: GitHubCredential<'_>,
+    ) -> Result<Vec<u8>, GitHubAuthorityError> {
+        let mut command = clean_command(&self.config, &self.config.gh_program, credential);
+        command.arg("api").args(arguments).stdout(Stdio::piped());
+        bounded_output(command, self.config.api_deadline).await
+    }
+
+    pub(super) async fn confirm_review_head(
+        &self,
+        request: &GitHubReviewRequest,
+        credential: GitHubCredential<'_>,
+    ) -> Result<(), GitHubAuthorityError> {
+        let value = self
+            .api(
+                &[format!(
+                    "repos/{}/git/ref/heads/{}",
+                    request.target.repository, request.head_branch
+                )],
+                credential,
+            )
+            .await?;
+        let reference: GitReferenceWire =
+            serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
+        require_review_head(reference, request)
+    }
+}
+
+async fn bounded_output(
+    mut command: Command,
+    deadline: Duration,
+) -> Result<Vec<u8>, GitHubAuthorityError> {
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|_| GitHubAuthorityError::Unavailable)?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or(GitHubAuthorityError::Unavailable)?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or(GitHubAuthorityError::Unavailable)?;
+    let mut output = Vec::new();
+    let mut error_output = Vec::new();
+    let (status, (), ()) = timeout(deadline, async {
+        tokio::try_join!(
+            child.wait(),
+            collect_bounded(stdout, &mut output, MAX_API_OUTPUT_BYTES),
+            collect_bounded(stderr, &mut error_output, MAX_API_ERROR_BYTES),
+        )
+    })
+    .await
+    .map_err(|_| GitHubAuthorityError::Unavailable)?
+    .map_err(|_| GitHubAuthorityError::Unavailable)?;
+    if !status.success() {
+        return Err(github_api_error(&error_output));
+    }
+    validate_api_output(output)
+}
+
+async fn collect_bounded<R>(
+    mut reader: R,
+    output: &mut Vec<u8>,
+    maximum_bytes: usize,
+) -> Result<(), std::io::Error>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            return Ok(());
+        }
+        let remaining = maximum_bytes.saturating_add(1).saturating_sub(output.len());
+        let retained = remaining.min(read);
+        output.extend_from_slice(&buffer[..retained]);
+    }
+}
+
+fn github_api_error(output: &[u8]) -> GitHubAuthorityError {
+    let text = String::from_utf8_lossy(output);
+    let value = github_api_error_value(&text);
+    let status = value
+        .as_ref()
+        .and_then(github_api_status)
+        .or_else(|| github_api_status_from_text(&text));
+    let mut parts = Vec::new();
+    if let Some(message) = value
+        .as_ref()
+        .and_then(|value| value.get("message"))
+        .and_then(Value::as_str)
+        .and_then(github_api_message)
+    {
+        parts.push(message);
+    }
+    if let Some(errors) = value
+        .as_ref()
+        .and_then(|value| value.get("errors"))
+        .and_then(Value::as_array)
+    {
+        parts.extend(errors.iter().take(3).filter_map(github_api_error_detail));
+    }
+    if parts.is_empty() {
+        parts.push("GitHub CLI returned a non-structured API error".to_owned());
+    }
+    let diagnostic = status.map_or_else(
+        || parts.join("; "),
+        |status| format!("HTTP {status}: {}", parts.join("; ")),
+    );
+    GitHubAuthorityError::api(status, diagnostic)
+}
+
+fn github_api_error_value(text: &str) -> Option<Value> {
+    text.lines()
+        .rev()
+        .find_map(|line| serde_json::from_str(line).ok())
+        .or_else(|| {
+            text.char_indices()
+                .filter(|(_, character)| *character == '{')
+                .find_map(|(index, _)| serde_json::from_str(&text[index..]).ok())
+        })
+}
+
+fn github_api_status(value: &Value) -> Option<u16> {
+    value.get("status").and_then(|status| {
+        status
+            .as_u64()
+            .and_then(|status| u16::try_from(status).ok())
+            .or_else(|| status.as_str()?.parse().ok())
+    })
+}
+
+fn github_api_status_from_text(text: &str) -> Option<u16> {
+    let marker = "(HTTP ";
+    let start = text.rfind(marker)? + marker.len();
+    let digits = text.get(start..)?.split(')').next()?;
+    digits.parse().ok()
+}
+
+fn github_api_error_detail(value: &Value) -> Option<String> {
+    if let Some(message) = value.as_str() {
+        return github_api_message(message);
+    }
+    let mut fields = ["resource", "field", "code"]
+        .into_iter()
+        .filter_map(|field| value.get(field).and_then(Value::as_str))
+        .filter_map(safe_api_identifier)
+        .collect::<Vec<_>>();
+    if let Some(message) = value
+        .get("message")
+        .and_then(Value::as_str)
+        .and_then(github_api_message)
+    {
+        fields.push(message);
+    }
+    (!fields.is_empty()).then(|| fields.join(" "))
+}
+
+fn safe_api_identifier(value: &str) -> Option<String> {
+    (!value.is_empty()
+        && value.len() <= 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')))
+    .then(|| value.to_owned())
+}
+
+fn github_api_message(value: &str) -> Option<String> {
+    let normalized = value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    exact_github_api_message(&normalized)
+        .or_else(|| classified_github_api_message(&normalized))
+        .map(str::to_owned)
+}
+
+fn exact_github_api_message(value: &str) -> Option<&'static str> {
+    Some(match value {
+        "validation failed" => "validation failed",
+        "not found" => "not found",
+        "bad credentials" => "bad credentials",
+        "server error" => "server error",
+        "service unavailable" => "service unavailable",
+        _ => return None,
+    })
+}
+
+fn classified_github_api_message(value: &str) -> Option<&'static str> {
+    if value.contains("head sha can't be blank") || value.contains("head is invalid") {
+        return Some("pull request head revision is not visible");
+    }
+    if value.contains("no commits between") {
+        return Some("no commits are visible between base and head");
+    }
+    if value.contains("pull request already exists") {
+        return Some("pull request already exists");
+    }
+    if value.contains("rate limit") {
+        return Some("rate limited");
+    }
+    if value.contains("resource not accessible by integration") {
+        return Some("resource not accessible by integration");
+    }
+    None
+}
+
+fn validate_api_output(output: Vec<u8>) -> Result<Vec<u8>, GitHubAuthorityError> {
+    if output.is_empty() || output.len() > MAX_API_OUTPUT_BYTES {
+        return Err(GitHubAuthorityError::Rejected);
+    }
+    Ok(output)
+}
+
+pub(super) fn check_log_tail(output: &[u8]) -> String {
+    let start = output.len().saturating_sub(MAX_CHECK_LOG_TAIL_BYTES);
+    String::from_utf8_lossy(output.get(start..).unwrap_or_default()).into_owned()
+}
+
+#[cfg(test)]
+#[path = "api/tests.rs"]
+mod tests;

--- a/zeroshot/src/native_v2_delivery/github/api.rs
+++ b/zeroshot/src/native_v2_delivery/github/api.rs
@@ -99,7 +99,7 @@ where
         }
         let remaining = maximum_bytes.saturating_add(1).saturating_sub(output.len());
         let retained = remaining.min(read);
-        output.extend_from_slice(&buffer[..retained]);
+        output.extend_from_slice(buffer.get(..retained).unwrap_or_default());
     }
 }
 
@@ -143,7 +143,10 @@ fn github_api_error_value(text: &str) -> Option<Value> {
         .or_else(|| {
             text.char_indices()
                 .filter(|(_, character)| *character == '{')
-                .find_map(|(index, _)| serde_json::from_str(&text[index..]).ok())
+                .find_map(|(index, _)| {
+                    text.get(index..)
+                        .and_then(|suffix| serde_json::from_str(suffix).ok())
+                })
         })
 }
 

--- a/zeroshot/src/native_v2_delivery/github/api/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/api/tests.rs
@@ -53,4 +53,5 @@ fn api_error_parser_preserves_bounded_provider_status_and_reason() {
 
     let unauthorized = GitHubAuthorityError::api(Some(401), "HTTP 401: Bad credentials");
     assert!(!unauthorized.retryable_review_sync());
+    assert!(unauthorized.authentication_failed());
 }

--- a/zeroshot/src/native_v2_delivery/github/api/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/api/tests.rs
@@ -1,0 +1,56 @@
+use openengine_cluster_testkit::assertions::AssertValue;
+
+use super::*;
+
+#[test]
+fn api_payload_budget_and_log_tail_are_bounded() {
+    let payload = vec![b'x'; 512 * 1024];
+    assert_eq!(
+        validate_api_output(payload).assert_value().len(),
+        512 * 1024
+    );
+    assert_eq!(
+        validate_api_output(vec![b'x'; MAX_API_OUTPUT_BYTES + 1]),
+        Err(GitHubAuthorityError::Rejected)
+    );
+
+    let mut output = b"discard".to_vec();
+    output.extend(vec![b'x'; MAX_CHECK_LOG_TAIL_BYTES]);
+    output.extend_from_slice(b"failure at end");
+    let tail = check_log_tail(&output);
+    assert_eq!(tail.len(), MAX_CHECK_LOG_TAIL_BYTES);
+    assert!(!tail.contains("discard"));
+    assert!(tail.ends_with("failure at end"));
+}
+
+#[test]
+fn api_error_parser_preserves_bounded_provider_status_and_reason() {
+    let error = github_api_error(
+        br#"gh: Validation Failed (HTTP 422)
+{
+  "message":"Validation Failed",
+  "errors":[{
+    "resource":"PullRequest",
+    "field":"head",
+    "code":"invalid",
+    "message":"Head sha can't be blank"
+  }],
+  "status":"422"
+}
+"#,
+    );
+    assert_eq!(
+        error,
+        GitHubAuthorityError::api(
+            Some(422),
+            concat!(
+                "HTTP 422: validation failed; PullRequest head invalid ",
+                "pull request head revision is not visible"
+            ),
+        )
+    );
+    assert!(error.retryable_review_sync());
+
+    let unauthorized = GitHubAuthorityError::api(Some(401), "HTTP 401: Bad credentials");
+    assert!(!unauthorized.retryable_review_sync());
+}

--- a/zeroshot/src/native_v2_delivery/github/head.rs
+++ b/zeroshot/src/native_v2_delivery/github/head.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use serde::Deserialize;
+use serde_json::Value;
 
 use super::*;
 

--- a/zeroshot/src/native_v2_delivery/github/head/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/head/tests.rs
@@ -1,5 +1,5 @@
 use openengine_cluster_testkit::assertions::AssertValue;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::*;
 use crate::native_v2_candidate::test_support::{TestGitRepository, git, git_output};

--- a/zeroshot/src/native_v2_delivery/github/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/tests.rs
@@ -1,5 +1,5 @@
 use openengine_cluster_testkit::assertions::AssertValue;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use super::*;
 use super::policy::MergeMethod;
@@ -106,27 +106,6 @@ fn classify_conclusion(conclusion: &str, merge_state: &str) -> PolicySnapshot {
         )]),
         (false, Some(conclusion)),
     ))
-}
-
-#[test]
-fn api_payload_budget_and_log_tail_are_bounded() {
-    let payload = vec![b'x'; 512 * 1024];
-    assert_eq!(
-        validate_api_output(payload).assert_value().len(),
-        512 * 1024
-    );
-    assert_eq!(
-        validate_api_output(vec![b'x'; MAX_API_OUTPUT_BYTES + 1]),
-        Err(GitHubAuthorityError::Rejected)
-    );
-
-    let mut output = b"discard".to_vec();
-    output.extend(vec![b'x'; MAX_CHECK_LOG_TAIL_BYTES]);
-    output.extend_from_slice(b"failure at end");
-    let tail = check_log_tail(&output);
-    assert_eq!(tail.len(), MAX_CHECK_LOG_TAIL_BYTES);
-    assert!(!tail.contains("discard"));
-    assert!(tail.ends_with("failure at end"));
 }
 
 #[test]

--- a/zeroshot/src/native_v2_delivery/github/wire.rs
+++ b/zeroshot/src/native_v2_delivery/github/wire.rs
@@ -21,6 +21,20 @@ pub(super) struct IssueWire {
 }
 
 #[derive(Deserialize)]
+pub(super) struct GitReferenceWire {
+    #[serde(rename = "ref")]
+    reference: String,
+    object: GitReferenceObjectWire,
+}
+
+#[derive(Deserialize)]
+struct GitReferenceObjectWire {
+    sha: String,
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+#[derive(Deserialize)]
 struct ReviewBranchWire {
     #[serde(rename = "ref")]
     branch: String,
@@ -45,16 +59,17 @@ pub(super) fn review_receipt(
         head_branch: wire.head.branch,
         head_revision: wire.head.sha,
     };
-    if receipt.repository == request.target.repository
+    let valid_identity = receipt.repository == request.target.repository
         && receipt.target_branch == request.target.target_branch
         && receipt.head_branch == request.head_branch
-        && receipt.head_revision == request.head_revision
-        && wire.head.repo.full_name == request.target.repository
-    {
-        Ok(receipt)
-    } else {
-        Err(GitHubAuthorityError::Rejected)
+        && wire.head.repo.full_name == request.target.repository;
+    if !valid_identity {
+        return Err(GitHubAuthorityError::Rejected);
     }
+    if receipt.head_revision != request.head_revision {
+        return Err(GitHubAuthorityError::review_head_not_visible());
+    }
+    Ok(receipt)
 }
 
 pub(super) fn require_review_identity(
@@ -69,3 +84,22 @@ pub(super) fn require_review_identity(
         && wire.head.sha == review.head_revision;
     valid.then_some(()).ok_or(GitHubAuthorityError::Rejected)
 }
+
+pub(super) fn require_review_head(
+    wire: GitReferenceWire,
+    request: &GitHubReviewRequest,
+) -> Result<(), GitHubAuthorityError> {
+    let valid_identity = wire.reference == format!("refs/heads/{}", request.head_branch)
+        && wire.object.kind == "commit";
+    if !valid_identity {
+        return Err(GitHubAuthorityError::Rejected);
+    }
+    if wire.object.sha != request.head_revision {
+        return Err(GitHubAuthorityError::review_head_not_visible());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "wire/tests.rs"]
+mod tests;

--- a/zeroshot/src/native_v2_delivery/github/wire/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/wire/tests.rs
@@ -1,4 +1,4 @@
-use openengine_cluster_testkit::assertions::AssertValue;
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
 use serde_json::json;
 
 use super::*;
@@ -35,11 +35,11 @@ fn stale_review_head_is_retryable_but_changed_identity_is_rejected() {
         }
     });
     let stale = serde_json::from_value(value.clone()).assert_value();
-    let error = review_receipt(stale, &request()).expect_err("stale head must defer");
+    let error = review_receipt(stale, &request()).assert_error_with("stale head must defer");
     assert_eq!(error, GitHubAuthorityError::review_head_not_visible());
     assert!(error.retryable_review_sync());
 
-    value["base"]["ref"] = json!("other");
+    *value.pointer_mut("/base/ref").assert_value() = json!("other");
     let changed = serde_json::from_value(value).assert_value();
     assert_eq!(
         review_receipt(changed, &request()),
@@ -57,11 +57,11 @@ fn stale_reference_head_is_retryable_but_changed_reference_is_rejected() {
         }
     });
     let stale = serde_json::from_value(value.clone()).assert_value();
-    let error = require_review_head(stale, &request()).expect_err("stale head must defer");
+    let error = require_review_head(stale, &request()).assert_error_with("stale head must defer");
     assert_eq!(error, GitHubAuthorityError::review_head_not_visible());
     assert!(error.retryable_review_sync());
 
-    value["ref"] = json!("refs/heads/other");
+    *value.get_mut("ref").assert_value() = json!("refs/heads/other");
     let changed = serde_json::from_value(value).assert_value();
     assert_eq!(
         require_review_head(changed, &request()),

--- a/zeroshot/src/native_v2_delivery/github/wire/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/wire/tests.rs
@@ -1,0 +1,70 @@
+use openengine_cluster_testkit::assertions::AssertValue;
+use serde_json::json;
+
+use super::*;
+use crate::native_v2_delivery::DeliveryTarget;
+
+fn request() -> GitHubReviewRequest {
+    GitHubReviewRequest {
+        target: DeliveryTarget::new(
+            "acme/project",
+            "main",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .assert_value(),
+        head_branch: "zeroshot/v2-run".to_owned(),
+        head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+        source_issue: None,
+    }
+}
+
+#[test]
+fn stale_review_head_is_retryable_but_changed_identity_is_rejected() {
+    let mut value = json!({
+        "number": 17,
+        "body": null,
+        "base": {
+            "ref": "main",
+            "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "repo": {"full_name": "acme/project"}
+        },
+        "head": {
+            "ref": "zeroshot/v2-run",
+            "sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "repo": {"full_name": "acme/project"}
+        }
+    });
+    let stale = serde_json::from_value(value.clone()).assert_value();
+    let error = review_receipt(stale, &request()).expect_err("stale head must defer");
+    assert_eq!(error, GitHubAuthorityError::review_head_not_visible());
+    assert!(error.retryable_review_sync());
+
+    value["base"]["ref"] = json!("other");
+    let changed = serde_json::from_value(value).assert_value();
+    assert_eq!(
+        review_receipt(changed, &request()),
+        Err(GitHubAuthorityError::Rejected)
+    );
+}
+
+#[test]
+fn stale_reference_head_is_retryable_but_changed_reference_is_rejected() {
+    let mut value = json!({
+        "ref": "refs/heads/zeroshot/v2-run",
+        "object": {
+            "sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "type": "commit"
+        }
+    });
+    let stale = serde_json::from_value(value.clone()).assert_value();
+    let error = require_review_head(stale, &request()).expect_err("stale head must defer");
+    assert_eq!(error, GitHubAuthorityError::review_head_not_visible());
+    assert!(error.retryable_review_sync());
+
+    value["ref"] = json!("refs/heads/other");
+    let changed = serde_json::from_value(value).assert_value();
+    assert_eq!(
+        require_review_head(changed, &request()),
+        Err(GitHubAuthorityError::Rejected)
+    );
+}

--- a/zeroshot/src/native_v2_delivery/tests.rs
+++ b/zeroshot/src/native_v2_delivery/tests.rs
@@ -190,6 +190,16 @@ struct RefreshedDeliveryEnvironment {
     binding: NodeRuntimeBinding,
 }
 
+async fn delivery_runtime_binding(repo: &TempRepo, mode: DeliveryMode) -> NodeRuntimeBinding {
+    let admitted = admitted(repo, mode).await;
+    admitted
+        .runtime
+        .nodes()
+        .get(&NodeName::new("deliver").assert_value())
+        .assert_value()
+        .clone()
+}
+
 #[async_trait]
 impl crate::native_v2_runner::RuntimeEnvironmentRefresh for RefreshedDeliveryEnvironment {
     async fn refresh(
@@ -213,13 +223,7 @@ async fn delivery_refreshes_an_expired_dynamic_github_credential() {
         repo.remote.clone(),
         Script::CredentialExpires,
     ));
-    let admitted = admitted(&repo, DeliveryMode::Merge).await;
-    let binding = admitted
-        .runtime
-        .nodes()
-        .get(&NodeName::new("deliver").assert_value())
-        .assert_value()
-        .clone();
+    let binding = delivery_runtime_binding(&repo, DeliveryMode::Merge).await;
     let outcome = run_delivery_with_id(
         DeliveryRunRequest {
             repo: &repo,

--- a/zeroshot/src/native_v2_delivery/tests.rs
+++ b/zeroshot/src/native_v2_delivery/tests.rs
@@ -37,6 +37,8 @@ use crate::v2_run_ledger::{CreateRun, RunLedger};
 mod github_fixture;
 #[path = "tests/head_update.rs"]
 mod head_update;
+#[path = "tests/review_sync.rs"]
+mod review_sync;
 #[path = "tests/routing.rs"]
 mod routing;
 
@@ -167,17 +169,6 @@ async fn repeated_merge_deferral_is_not_misclassified_as_policy_refusal() {
     );
     assert!(authority.merge_requests.load(Ordering::SeqCst) > 2);
     assert!(authority.inspections.load(Ordering::SeqCst) > 2);
-}
-
-#[tokio::test]
-async fn pushed_review_head_is_retried_during_github_visibility_lag() {
-    let repo = TempRepo::delivery();
-    let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), Script::ReviewSyncRace));
-
-    let outcome = run_delivery(&repo, authority.clone(), 3, DeliveryMode::Merge).await;
-
-    assert_delivery_signal(&outcome, DELIVERY_MERGED_LABEL);
-    assert_eq!(authority.review_sync_attempts.load(Ordering::SeqCst), 2);
 }
 
 #[tokio::test]

--- a/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
@@ -141,7 +141,7 @@ exit 1
     let error = authority
         .open_or_update_review(&request, GitHubCredential("test-token"))
         .await
-        .expect_err("GitHub API rejection should be preserved");
+        .assert_error_with("GitHub API rejection should be preserved");
 
     assert_eq!(
         error,
@@ -179,4 +179,4 @@ async fn production_gh_transport_rejects_malformed_or_changed_authority() {
     }
 }
 
-use openengine_cluster_testkit::assertions::{AssertValue};
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};

--- a/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
@@ -1,30 +1,42 @@
 use super::*;
 use std::path::Path;
 
+fn github_authority(
+    home: &Path,
+    git_program: PathBuf,
+    gh_program: PathBuf,
+) -> GhCliDeliveryAuthority {
+    GhCliDeliveryAuthority::new(GhCliAuthorityConfig {
+        git_program,
+        gh_program,
+        home_directory: home.to_owned(),
+        api_deadline: Duration::from_secs(10),
+        push_deadline: Duration::from_secs(10),
+    })
+}
+
+fn review_request(source_issue: Option<u64>) -> GitHubReviewRequest {
+    GitHubReviewRequest {
+        target: DeliveryTarget::new(
+            "acme/project",
+            "main",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .assert_value(),
+        head_branch: "zeroshot/v2-test".to_owned(),
+        head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+        source_issue: source_issue.map(|number| GitHubSourceIssue { number }),
+    }
+}
+
 #[tokio::test]
 async fn production_gh_transport_uses_exact_args_and_a_clean_environment() {
     let repo = TempRepo::delivery();
     let git_program = write_executable(repo.root.path(), "git-script", GIT_SCRIPT);
     let gh_program = write_executable(repo.root.path(), "gh-script", GH_SCRIPT);
-    let authority = GhCliDeliveryAuthority::new(GhCliAuthorityConfig {
-        git_program: git_program.clone(),
-        gh_program: gh_program.clone(),
-        home_directory: repo.root.path().to_owned(),
-        api_deadline: Duration::from_secs(10),
-        push_deadline: Duration::from_secs(10),
-    });
-    let target = DeliveryTarget::new(
-        "acme/project",
-        "main",
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    )
-    .assert_value();
-    let review_request = GitHubReviewRequest {
-        target: target.clone(),
-        head_branch: "zeroshot/v2-test".to_owned(),
-        head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
-        source_issue: Some(GitHubSourceIssue { number: 208 }),
-    };
+    let authority = github_authority(repo.root.path(), git_program.clone(), gh_program.clone());
+    let review_request = review_request(Some(208));
+    let target = review_request.target.clone();
     let credential = GitHubCredential("test-token");
     authority
         .push_branch(
@@ -78,6 +90,7 @@ fn assert_production_github_capture(gh_capture: &str, home: &Path) {
         home.display()
     )));
     assert!(gh_capture.contains("arg=repos/acme/project/pulls"));
+    assert!(gh_capture.contains("arg=repos/acme/project/git/ref/heads/zeroshot/v2-test"));
     assert!(gh_capture.contains("arg=state=all"));
     assert!(gh_capture.contains("arg=head=acme:zeroshot/v2-test"));
     assert!(gh_capture.contains("arg=body=Created by Zeroshot v2.\n\nCloses #208"));
@@ -100,6 +113,51 @@ fn assert_production_github_capture(gh_capture: &str, home: &Path) {
 }
 
 #[tokio::test]
+async fn production_gh_transport_preserves_safe_api_failure_detail() {
+    let repo = TempRepo::delivery();
+    let gh_program = write_executable(
+        repo.root.path(),
+        "gh-api-error",
+        r#"#!/bin/sh
+/usr/bin/printf '%s\n' 'gh: Validation Failed (HTTP 422)' >&2
+/usr/bin/cat >&2 <<'EOF'
+{
+  "message":"Validation Failed",
+  "errors":[{
+    "resource":"PullRequest",
+    "field":"head",
+    "code":"invalid",
+    "message":"Head sha can't be blank"
+  }],
+  "status":"422"
+}
+EOF
+exit 1
+"#,
+    );
+    let authority = github_authority(repo.root.path(), PathBuf::from("/usr/bin/git"), gh_program);
+    let request = review_request(None);
+
+    let error = authority
+        .open_or_update_review(&request, GitHubCredential("test-token"))
+        .await
+        .expect_err("GitHub API rejection should be preserved");
+
+    assert_eq!(
+        error,
+        GitHubAuthorityError::api(
+            Some(422),
+            concat!(
+                "HTTP 422: validation failed; PullRequest head invalid ",
+                "pull request head revision is not visible"
+            ),
+        )
+    );
+    assert!(error.retryable_review_sync());
+    assert!(!error.to_string().contains("test-token"));
+}
+
+#[tokio::test]
 async fn production_gh_transport_rejects_malformed_or_changed_authority() {
     let repo = TempRepo::delivery();
     let malformed = write_executable(
@@ -108,25 +166,10 @@ async fn production_gh_transport_rejects_malformed_or_changed_authority() {
         "#!/bin/sh\n/usr/bin/printf '%s\\n' '{'\n",
     );
     let mismatch = write_executable(repo.root.path(), "gh-mismatch", GH_MISMATCH_SCRIPT);
-    let request = GitHubReviewRequest {
-        target: DeliveryTarget::new(
-            "acme/project",
-            "main",
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
-        .assert_value(),
-        head_branch: "zeroshot/v2-test".to_owned(),
-        head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
-        source_issue: None,
-    };
+    let request = review_request(None);
     for gh_program in [malformed, mismatch] {
-        let authority = GhCliDeliveryAuthority::new(GhCliAuthorityConfig {
-            git_program: PathBuf::from("/usr/bin/git"),
-            gh_program,
-            home_directory: repo.root.path().to_owned(),
-            api_deadline: Duration::from_secs(10),
-            push_deadline: Duration::from_secs(10),
-        });
+        let authority =
+            github_authority(repo.root.path(), PathBuf::from("/usr/bin/git"), gh_program);
         assert_eq!(
             authority
                 .open_or_update_review(&request, GitHubCredential("test-token"))

--- a/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
@@ -193,7 +193,13 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         assert!(self.pushed.load(Ordering::SeqCst));
         let attempt = self.review_sync_attempts.fetch_add(1, Ordering::SeqCst) + 1;
         if matches!(self.script, Script::ReviewSyncRace) && attempt == 1 {
-            return Err(GitHubAuthorityError::Rejected);
+            return Err(GitHubAuthorityError::api(
+                Some(422),
+                concat!(
+                    "HTTP 422: validation failed; PullRequest head invalid ",
+                    "pull request head revision is not visible"
+                ),
+            ));
         }
         self.reviews
             .lock()
@@ -383,6 +389,11 @@ for argument in "$@"; do
   previous=$argument
 done
 case "$endpoint:$method" in
+  repos/acme/project/git/ref/heads/zeroshot/v2-test:GET)
+    /usr/bin/printf '%s%s\n' \
+      '{"ref":"refs/heads/zeroshot/v2-test","object":{"sha":' \
+      '"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","type":"commit"}}'
+    ;;
   repos/acme/project/pulls:GET)
     /usr/bin/printf '%s\n' '[]'
     ;;

--- a/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
@@ -28,6 +28,7 @@ pub(super) enum Script {
     CiFailsThenMerges,
     NeverConfirmsMerge,
     CredentialExpires,
+    ReviewSyncCredentialExpires,
 }
 
 pub(super) struct FakeGitHub {
@@ -62,6 +63,7 @@ impl FakeGitHub {
     fn review_state(&self, inspection: usize) -> GitHubReviewState {
         match self.script {
             Script::NoCi | Script::CredentialExpires | Script::ReviewSyncRace => self.no_ci_state(),
+            Script::ReviewSyncCredentialExpires => self.no_ci_state(),
             Script::RegistrationRace => self.registration_race_state(inspection),
             Script::MultipleRegistrationWaves => self.multiple_registration_waves_state(inspection),
             Script::CiFailsThenMerges => self.ci_repair_state(inspection),
@@ -136,6 +138,13 @@ impl FakeGitHub {
             _ => false,
         }
     }
+
+    fn uses_refreshed_credential(&self) -> bool {
+        matches!(
+            self.script,
+            Script::CredentialExpires | Script::ReviewSyncCredentialExpires
+        )
+    }
 }
 
 pub(super) fn delivery_harness(script: Script) -> (TempRepo, Arc<FakeGitHub>) {
@@ -189,9 +198,22 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         request: &GitHubReviewRequest,
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubReviewReceipt, GitHubAuthorityError> {
-        assert_eq!(credential.expose(), "test-token");
         assert!(self.pushed.load(Ordering::SeqCst));
         let attempt = self.review_sync_attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if matches!(self.script, Script::ReviewSyncCredentialExpires)
+            && credential.expose() == "test-token"
+        {
+            return Err(GitHubAuthorityError::api(
+                Some(401),
+                "HTTP 401: bad credentials",
+            ));
+        }
+        let expected = if matches!(self.script, Script::ReviewSyncCredentialExpires) {
+            "refreshed-token"
+        } else {
+            "test-token"
+        };
+        assert_eq!(credential.expose(), expected);
         if matches!(self.script, Script::ReviewSyncRace) && attempt == 1 {
             return Err(GitHubAuthorityError::api(
                 Some(422),
@@ -223,7 +245,7 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         if matches!(self.script, Script::CredentialExpires) && credential.expose() == "test-token" {
             return Err(GitHubAuthorityError::Rejected);
         }
-        let expected = if matches!(self.script, Script::CredentialExpires) {
+        let expected = if self.uses_refreshed_credential() {
             "refreshed-token"
         } else {
             "test-token"
@@ -238,7 +260,7 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         _review: &GitHubReviewReceipt,
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubMergeRequestOutcome, GitHubAuthorityError> {
-        let expected = if matches!(self.script, Script::CredentialExpires) {
+        let expected = if self.uses_refreshed_credential() {
             "refreshed-token"
         } else {
             "test-token"
@@ -476,13 +498,3 @@ pub(super) const GH_MISMATCH_SCRIPT: &str = r#"#!/bin/sh
   '"head":{"ref":"zeroshot/v2-test","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",' \
   '"repo":{"full_name":"acme/project"}}}]'
 "#;
-
-#[test]
-fn hosted_delivery_polling_has_no_work_duration_limit() {
-    assert!(DeliveryPollPolicy::default().has_next(usize::MAX));
-    assert!(
-        !DeliveryPollPolicy::new(3, Duration::ZERO)
-            .assert_value()
-            .has_next(3)
-    );
-}

--- a/zeroshot/src/native_v2_delivery/tests/review_sync.rs
+++ b/zeroshot/src/native_v2_delivery/tests/review_sync.rs
@@ -1,0 +1,17 @@
+use super::*;
+
+#[tokio::test]
+async fn pushed_review_head_is_retried_for_pr_and_ship_during_github_visibility_lag() {
+    for (mode, outcome) in [
+        (DeliveryMode::PullRequest, DELIVERY_OPENED_LABEL),
+        (DeliveryMode::Merge, DELIVERY_MERGED_LABEL),
+    ] {
+        let repo = TempRepo::delivery();
+        let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), Script::ReviewSyncRace));
+
+        let delivery = run_delivery(&repo, authority.clone(), 3, mode).await;
+
+        assert_delivery_signal(&delivery, outcome);
+        assert_eq!(authority.review_sync_attempts.load(Ordering::SeqCst), 2);
+    }
+}

--- a/zeroshot/src/native_v2_delivery/tests/review_sync.rs
+++ b/zeroshot/src/native_v2_delivery/tests/review_sync.rs
@@ -15,3 +15,28 @@ async fn pushed_review_head_is_retried_for_pr_and_ship_during_github_visibility_
         assert_eq!(authority.review_sync_attempts.load(Ordering::SeqCst), 2);
     }
 }
+
+#[tokio::test]
+async fn review_sync_refreshes_an_expired_dynamic_github_credential() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(
+        repo.remote.clone(),
+        Script::ReviewSyncCredentialExpires,
+    ));
+    let binding = delivery_runtime_binding(&repo, DeliveryMode::PullRequest).await;
+
+    let outcome = run_delivery_with_id(
+        DeliveryRunRequest {
+            repo: &repo,
+            attempts: 2,
+            mode: DeliveryMode::PullRequest,
+            run_id: "refresh-review-sync-credential",
+            refresh: Some(Arc::new(RefreshedDeliveryEnvironment { binding })),
+        },
+        authority.clone(),
+    )
+    .await;
+
+    assert_delivery_signal(&outcome, DELIVERY_OPENED_LABEL);
+    assert_eq!(authority.review_sync_attempts.load(Ordering::SeqCst), 2);
+}

--- a/zeroshot/src/native_v2_delivery/tests/routing.rs
+++ b/zeroshot/src/native_v2_delivery/tests/routing.rs
@@ -1,6 +1,16 @@
 use super::*;
 use openengine_cluster_protocol::GraphSpec;
 
+#[test]
+fn hosted_delivery_polling_has_no_work_duration_limit() {
+    assert!(DeliveryPollPolicy::default().has_next(usize::MAX));
+    assert!(
+        !DeliveryPollPolicy::new(3, Duration::ZERO)
+            .assert_value()
+            .has_next(3)
+    );
+}
+
 struct RepairSession;
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- retry transient GitHub review creation and rediscovery failures within a bounded 60-second deadline
- preflight the exact pushed branch ref and treat stale ref/PR head observations as retryable without weakening identity checks
- refresh dynamic GitHub credentials once on HTTP 401/403 within the same synchronization deadline and cancellation boundary while static credentials fail closed
- preserve bounded, sanitized GitHub API status/reason diagnostics
- cover visibility lag in pull-request and ship modes, credential expiry, refresh timeout, and refresh cancellation
- document the shared GitHub review synchronization runtime invariant

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p zeroshot --all-targets`
- `cargo clippy -p zeroshot --all-targets -- -D warnings -D clippy::indexing_slicing -D clippy::expect_used`
- `cargo test -p zeroshot native_v2_delivery:: --lib` (53 passed)
- `cargo test -p zeroshot` (426 unit tests plus integration/doc tests)
- `npm run opcore:check -- --base fe63b1f262020c670baab77bc9de67a3e9223231`
- `opcore-zero check --repo . --staged --json`
- `opcore-zero sense --repo . --staged --json` (partial Rust interface coverage; no issues, cycles, duplicates, or documentation requirements)