### PR TITLE
feat: materialize omitted empty root state fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,9 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 
 - Protocol Rust types are the source of truth. Generated files under
   `protocol/openengine-cluster/v1/` must be regenerated through the Rust testkit, not hand-edited.
+- Initial input remains caller-owned and is validated unchanged. A root group may add required
+  state fields only when their payload types have deterministic implicit empty values; verification
+  proves this and reduction materializes missing null, string, and recursively empty record values.
 - Model identifiers are opaque provider-owned strings. Do not infer a harness from a provider/model,
   maintain model catalogs, or validate provider availability. Admission may reject only known
   incompatible harness/provider pairs.

--- a/crates/openengine-cluster-protocol/src/graph.rs
+++ b/crates/openengine-cluster-protocol/src/graph.rs
@@ -456,4 +456,16 @@ impl GraphNode {
             Self::Fail(node) => &node.name,
         }
     }
+
+    #[must_use]
+    pub fn state(&self) -> Option<&PayloadType> {
+        match self {
+            Self::Seq(node) => Some(&node.state),
+            Self::Choice(node) => Some(&node.state),
+            Self::Par(node) => Some(&node.state),
+            Self::Loop(node) => Some(&node.state),
+            Self::Map(node) => Some(&node.state),
+            Self::Step(_) | Self::Verifier(_) | Self::Succeed(_) | Self::Fail(_) => None,
+        }
+    }
 }

--- a/crates/openengine-cluster-protocol/src/payload_value.rs
+++ b/crates/openengine-cluster-protocol/src/payload_value.rs
@@ -14,6 +14,30 @@ impl PayloadType {
         self.validate_value_at(value, "$".to_owned())
     }
 
+    /// Returns the effective source type after target-owned deterministic empties are added.
+    #[must_use]
+    pub fn materialized_subtype_of(&self, target: &Self) -> Option<Self> {
+        materialized_source_type(self, target).filter(|source| source.is_subtype_of(target))
+    }
+
+    /// Adds deterministic empty values for missing required null, string, and record fields.
+    pub fn materialize_missing_fields(&self, value: &mut Value) {
+        let (Self::Record { fields }, Value::Object(object)) = (self, value) else {
+            return;
+        };
+        for (name, field) in fields {
+            if let Some(value) = object.get_mut(name.as_str()) {
+                field.value_type.materialize_missing_fields(value);
+                continue;
+            }
+            if field.required {
+                if let Some(value) = implicit_empty_value(&field.value_type) {
+                    object.insert(name.as_str().to_owned(), value);
+                }
+            }
+        }
+    }
+
     fn validate_value_at(&self, value: &Value, path: String) -> Result<(), PayloadValueError> {
         match self {
             Self::Null => expect_type(value.is_null(), path, "null"),
@@ -25,6 +49,73 @@ impl PayloadType {
             Self::Array { items } => validate_array(items, value, path),
             Self::Record { fields } => validate_record(fields, value, path),
         }
+    }
+}
+
+fn materialized_source_type(source: &PayloadType, target: &PayloadType) -> Option<PayloadType> {
+    let (PayloadType::Record { fields: source }, PayloadType::Record { fields: target }) =
+        (source, target)
+    else {
+        return source.is_subtype_of(target).then(|| source.clone());
+    };
+    materialized_record_fields(source, target).map(|fields| PayloadType::Record { fields })
+}
+
+fn materialized_record_fields(
+    source: &BTreeMap<FieldName, RecordField>,
+    target: &BTreeMap<FieldName, RecordField>,
+) -> Option<BTreeMap<FieldName, RecordField>> {
+    let mut materialized = source.clone();
+    for (name, target_field) in target {
+        materialize_record_field(&mut materialized, name, target_field)?;
+    }
+    Some(materialized)
+}
+
+fn materialize_record_field(
+    materialized: &mut BTreeMap<FieldName, RecordField>,
+    name: &FieldName,
+    target: &RecordField,
+) -> Option<()> {
+    let Some(source) = materialized.get_mut(name) else {
+        if target.required {
+            implicit_empty_value(&target.value_type)?;
+            materialized.insert(name.clone(), target.clone());
+        }
+        return Some(());
+    };
+    let materialized_type = materialized_source_type(&source.value_type, &target.value_type)?;
+    if target.required && !source.required {
+        implicit_empty_value(&target.value_type)?;
+        source.required = true;
+        source.value_type = target.value_type.clone();
+    } else {
+        source.value_type = materialized_type;
+    }
+    Some(())
+}
+
+fn implicit_empty_value(payload: &PayloadType) -> Option<Value> {
+    match payload {
+        PayloadType::Null => Some(Value::Null),
+        PayloadType::String => Some(Value::String(String::new())),
+        PayloadType::Record { fields } => {
+            let mut object = serde_json::Map::new();
+            for (name, field) in fields {
+                if field.required {
+                    object.insert(
+                        name.as_str().to_owned(),
+                        implicit_empty_value(&field.value_type)?,
+                    );
+                }
+            }
+            Some(Value::Object(object))
+        }
+        PayloadType::Boolean
+        | PayloadType::Integer
+        | PayloadType::Number
+        | PayloadType::Array { .. }
+        | PayloadType::Enum { .. } => None,
     }
 }
 

--- a/crates/openengine-cluster-protocol/tests/payload_subtyping.rs
+++ b/crates/openengine-cluster-protocol/tests/payload_subtyping.rs
@@ -2,6 +2,7 @@
 mod assert_value;
 
 use assert_value::AssertValue;
+use serde_json::json;
 use std::collections::BTreeMap;
 
 use openengine_cluster_protocol::{EnumLabel, FieldName, NonEmptyEnumSet, PayloadType, RecordField};
@@ -103,6 +104,71 @@ fn closed_payload_subtyping_matches_the_normative_rules() {
     );
     assert!(record(&[]).is_subtype_of(&record(&[("x", PayloadType::String, false)])));
     assert!(!record(&[]).is_subtype_of(&record(&[("x", PayloadType::String, true)])));
+}
+
+#[test]
+fn required_empty_root_state_fields_are_materializable() {
+    let input = record(&[("task", PayloadType::String, true)]);
+    let state = record(&[
+        ("task", PayloadType::String, true),
+        ("feedback", PayloadType::String, true),
+        ("marker", PayloadType::Null, true),
+        (
+            "nested",
+            record(&[
+                ("feedback", PayloadType::String, true),
+                ("marker", PayloadType::Null, true),
+            ]),
+            true,
+        ),
+    ]);
+
+    assert!(input.materialized_subtype_of(&state).is_some());
+    let mut value = json!({"task":"ship it"});
+    state.materialize_missing_fields(&mut value);
+    assert_eq!(
+        value,
+        json!({
+            "task":"ship it",
+            "feedback":"",
+            "marker":null,
+            "nested":{"feedback":"","marker":null}
+        })
+    );
+
+    let non_empty_state = record(&[
+        ("task", PayloadType::String, true),
+        ("attempts", PayloadType::Integer, true),
+    ]);
+    assert!(input.materialized_subtype_of(&non_empty_state).is_none());
+}
+
+#[test]
+fn optional_record_defaults_do_not_require_source_only_descendants() {
+    let input = record(&[(
+        "config",
+        record(&[("note", PayloadType::String, true)]),
+        false,
+    )]);
+    let state = record(&[(
+        "config",
+        record(&[
+            ("note", PayloadType::String, false),
+            ("marker", PayloadType::String, true),
+        ]),
+        true,
+    )]);
+    let effective = input.materialized_subtype_of(&state).assert_value();
+
+    let mut omitted = json!({});
+    state.materialize_missing_fields(&mut omitted);
+    assert_eq!(omitted, json!({"config":{"marker":""}}));
+    effective.validate_value(&omitted).assert_value();
+
+    let mut provided = json!({"config":{"note":"keep"}});
+    state.materialize_missing_fields(&mut provided);
+    assert_eq!(provided, json!({"config":{"note":"keep","marker":""}}));
+    effective.validate_value(&provided).assert_value();
 }
 
 #[test]

--- a/crates/openengine-cluster-server/src/graph_verifier/analyzer_index.rs
+++ b/crates/openengine-cluster-server/src/graph_verifier/analyzer_index.rs
@@ -26,15 +26,23 @@ impl<'a> Analyzer<'a> {
         self.index_node(&self.graph.root, root_path, 1);
         self.validate_global_limits();
 
+        let materialized_state = self
+            .graph
+            .root
+            .state()
+            .and_then(|state| self.graph.initial_input.materialized_subtype_of(state));
+        let initial_state = materialized_state
+            .as_ref()
+            .unwrap_or(&self.graph.initial_input);
         let initial = Flow {
-            defined: required_paths_with_types(&self.graph.initial_input),
+            defined: required_paths_with_types(initial_state),
             ..Flow::default()
         };
         self.validate_node(
             &self.graph.root,
             NodeValidationContext {
                 incoming: &initial,
-                state: &self.graph.initial_input,
+                state: initial_state,
                 item: None,
                 map_index_targets: None,
             },

--- a/crates/openengine-cluster-server/src/graph_verifier/analyzer_nodes.rs
+++ b/crates/openengine-cluster-server/src/graph_verifier/analyzer_nodes.rs
@@ -85,7 +85,7 @@ impl<'a> Analyzer<'a> {
         node: &GraphNode,
         context: &LocatedNodeValidationContext<'_>,
     ) {
-        if node_state(node).is_some_and(|state| {
+        if node.state().is_some_and(|state| {
             !is_subtype_with_definitions(context.node.state, state, &context.node.incoming.defined)
         }) {
             emit_diagnostic!(

--- a/crates/openengine-cluster-server/src/graph_verifier/payload.rs
+++ b/crates/openengine-cluster-server/src/graph_verifier/payload.rs
@@ -8,20 +8,6 @@ pub(super) fn executable_output(node: &GraphNode) -> Option<&PayloadType> {
     }
 }
 
-pub(super) fn node_state(node: &GraphNode) -> Option<&PayloadType> {
-    match node {
-        GraphNode::Seq(group) => Some(&group.state),
-        GraphNode::Choice(group) => Some(&group.state),
-        GraphNode::Par(group) => Some(&group.state),
-        GraphNode::Loop(group) => Some(&group.state),
-        GraphNode::Map(group) => Some(&group.state),
-        GraphNode::Step(_)
-        | GraphNode::Verifier(_)
-        | GraphNode::Succeed(_)
-        | GraphNode::Fail(_) => None,
-    }
-}
-
 pub(super) fn required_leaf_paths(payload: &PayloadType) -> Vec<FieldPath> {
     fn collect(
         payload: &PayloadType,

--- a/crates/openengine-cluster-server/tests/graph_verifier/cases_dataflow.rs
+++ b/crates/openengine-cluster-server/tests/graph_verifier/cases_dataflow.rs
@@ -53,6 +53,84 @@ async fn required_initial_paths_survive_optional_group_state_widening() {
 }
 
 #[tokio::test]
+async fn root_state_additions_require_implicit_empty_values() {
+    let mut materializable = valid_graph();
+    let fields = materializable
+        .assert_at_mut("root")
+        .assert_at_mut("state")
+        .assert_at_mut("fields")
+        .as_object_mut()
+        .assert_value();
+    fields.insert(
+        "feedback".to_owned(),
+        json!({"type":{"kind":"string"},"required":true}),
+    );
+    fields.insert(
+        "marker".to_owned(),
+        json!({"type":{"kind":"null"},"required":true}),
+    );
+    let graph: GraphSpec = serde_json::from_value(materializable).assert_value();
+    assert_graph_accepted(&graph).await;
+
+    let mut rejected = valid_graph();
+    rejected
+        .assert_at_mut("root")
+        .assert_at_mut("state")
+        .assert_at_mut("fields")
+        .as_object_mut()
+        .assert_value()
+        .insert(
+            "attempts".to_owned(),
+            json!({"type":{"kind":"integer"},"required":true}),
+        );
+    let graph: GraphSpec = serde_json::from_value(rejected).assert_value();
+    assert_graph_rejected_with(&graph, GraphDiagnosticCode::SchemaSafety).await;
+}
+
+#[tokio::test]
+async fn materialized_optional_records_do_not_define_source_only_descendants() {
+    let mut value = valid_graph();
+    let insert_config = |value: &mut Value, pointer: &str, config: Value| {
+        value
+            .pointer_mut(pointer)
+            .assert_value()
+            .as_object_mut()
+            .assert_value()
+            .insert("config".to_owned(), config);
+    };
+    insert_config(
+        &mut value,
+        "/initialInput/fields",
+        json!({"type":{"kind":"record","fields":{
+                "note":{"type":{"kind":"string"},"required":true}
+            }},"required":false}),
+    );
+    insert_config(
+        &mut value,
+        "/root/state/fields",
+        json!({"type":{"kind":"record","fields":{
+                "note":{"type":{"kind":"string"},"required":false},
+                "marker":{"type":{"kind":"string"},"required":true}
+            }},"required":true}),
+    );
+    set_root_children(&mut value, |_| {
+        json!([{
+            "kind":"succeed","name":"done",
+            "output":{"kind":"record","fields":{
+                "note":{"type":{"kind":"string"},"required":true}
+            }},
+            "bindings":[{
+                "target":["note"],
+                "value":{"source":"state","path":["config","note"]}
+            }]
+        }])
+    });
+    let graph: GraphSpec = serde_json::from_value(value).assert_value();
+
+    assert_undefined_read_without_schema_error(&graph).await;
+}
+
+#[tokio::test]
 async fn success_routing_does_not_define_an_optional_output_path() {
     let mut value = valid_graph();
     *value

--- a/zeroshot/src/full_v1_reducer.rs
+++ b/zeroshot/src/full_v1_reducer.rs
@@ -127,9 +127,12 @@ impl<'a> FullV1Reducer<'a> {
     }
 
     pub fn reduce(&self, input: ReductionInput<'_>) -> Result<Reduction, ReducerError> {
-        let initial_input = input.initial_input.clone();
+        let mut initial_state = input.initial_input.clone();
+        if let Some(state) = self.graph.compiled_ir.root.state() {
+            state.materialize_missing_fields(&mut initial_state);
+        }
         let mut engine = Engine::new(input, &self.graph.compiled_ir.root, self.execution_mode)?;
-        let mut context = Context::new(initial_input);
+        let mut context = Context::new(initial_state);
         let status = engine.eval(
             &self.graph.compiled_ir.root,
             &mut context,

--- a/zeroshot/src/native_v2_cli/execution/submission.rs
+++ b/zeroshot/src/native_v2_cli/execution/submission.rs
@@ -189,10 +189,6 @@ fn prepare_intent(
 ) -> Result<TargetRunIntent, NativeV2CliError> {
     validate_graph_profile(&graph)?;
     let initial_input = read_json::<serde_json::Value>("input", &run.input)?;
-    let initial_input = match &run.selection {
-        RunSelection::Inline { graph, .. } => materialize_initial_input(graph, initial_input)?,
-        RunSelection::Profile(_) => initial_input,
-    };
     graph
         .initial_input
         .validate_value(&initial_input)
@@ -239,18 +235,6 @@ where
         }
     }
     Ok(selected)
-}
-
-fn materialize_initial_input(
-    selection: &RunGraph,
-    input: serde_json::Value,
-) -> Result<serde_json::Value, NativeV2CliError> {
-    match selection {
-        RunGraph::File(_) => Ok(input),
-        RunGraph::Template { template, .. } => template
-            .materialize_input(input)
-            .map_err(|error| NativeV2CliError::InitialInput(error.to_string())),
-    }
 }
 
 fn materialize_graph(selection: &RunGraph) -> Result<GraphSpec, NativeV2CliError> {

--- a/zeroshot/src/native_v2_cli/tests.rs
+++ b/zeroshot/src/native_v2_cli/tests.rs
@@ -223,15 +223,24 @@ fn template_list_and_show_are_static_and_emit_ordinary_json() {
         Some(&json!("openengine.graph.full/v1"))
     );
     assert_eq!(
-        shown.pointer("/initialInput/fields/acceptanceFeedback/required"),
+        shown.pointer("/initialInput/fields/task/required"),
+        Some(&json!(true))
+    );
+    assert!(
+        shown
+            .pointer("/initialInput/fields/acceptanceFeedback")
+            .is_none()
+    );
+    assert_eq!(
+        shown.pointer("/root/state/fields/acceptanceFeedback/required"),
         Some(&json!(true))
     );
     assert_eq!(
-        shown.pointer("/initialInput/fields/codeFeedback/required"),
+        shown.pointer("/root/state/fields/codeFeedback/required"),
         Some(&json!(true))
     );
     assert_eq!(
-        shown.pointer("/initialInput/fields/deliveryFeedback/required"),
+        shown.pointer("/root/state/fields/deliveryFeedback/required"),
         Some(&json!(true))
     );
     assert!(shown.to_string().contains("builtin.git-delivery.pr@1"));

--- a/zeroshot/src/native_v2_cli/tests/environment.rs
+++ b/zeroshot/src/native_v2_cli/tests/environment.rs
@@ -77,7 +77,7 @@ async fn assert_declared_environment_rejected(
 }
 
 #[tokio::test]
-async fn template_run_materializes_internal_input_and_owned_delivery_binding() {
+async fn template_run_preserves_authored_input_and_owned_delivery_binding() {
     let files = FixtureFiles::with_runtime(
         graph(),
         json!({"task":"ship it"}),
@@ -120,9 +120,9 @@ async fn template_run_materializes_internal_input_and_owned_delivery_binding() {
     }
     .assert_value();
     assert_eq!(submitted.1.pointer("/task"), Some(&json!("ship it")));
-    assert_eq!(submitted.1.pointer("/acceptanceFeedback"), Some(&json!("")));
-    assert_eq!(submitted.1.pointer("/codeFeedback"), Some(&json!("")));
-    assert_eq!(submitted.1.pointer("/deliveryFeedback"), Some(&json!("")));
+    assert!(submitted.1.pointer("/acceptanceFeedback").is_none());
+    assert!(submitted.1.pointer("/codeFeedback").is_none());
+    assert!(submitted.1.pointer("/deliveryFeedback").is_none());
     let authored_input = std::fs::read(&files.input).assert_value();
     assert_eq!(
         serde_json::from_slice::<serde_json::Value>(&authored_input).assert_value(),

--- a/zeroshot/src/native_v2_templates/catalog.rs
+++ b/zeroshot/src/native_v2_templates/catalog.rs
@@ -1,7 +1,6 @@
 //! Public built-in template selection and local materialization seams.
 
 use openengine_cluster_protocol::{GraphSpec, NodeName};
-use serde_json::Value;
 use thiserror::Error;
 
 use crate::native_v2_contract::{
@@ -10,10 +9,7 @@ use crate::native_v2_contract::{
 };
 use crate::native_v2_delivery::GITHUB_TOKEN_ENV;
 
-use super::{
-    node_name, single_worker_graph, software_change_graph, static_value, ACCEPTANCE_FEEDBACK_FIELD,
-    CODE_FEEDBACK_FIELD, DELIVERY_FEEDBACK_FIELD, DELIVERY_NODE,
-};
+use super::{node_name, single_worker_graph, software_change_graph, static_value, DELIVERY_NODE};
 
 /// The deliberately small set of built-in graph templates.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -76,25 +72,6 @@ impl BuiltinGraphTemplate {
         )))
     }
 
-    /// Adds template-owned state fields while preserving the user-authored task value.
-    pub(crate) fn materialize_input(self, mut input: Value) -> Result<Value, BuiltinTemplateError> {
-        if self == Self::SoftwareChange {
-            let object = input
-                .as_object_mut()
-                .ok_or(BuiltinTemplateError::InputMustBeObject)?;
-            object.insert(
-                ACCEPTANCE_FEEDBACK_FIELD.to_owned(),
-                Value::String(String::new()),
-            );
-            object.insert(CODE_FEEDBACK_FIELD.to_owned(), Value::String(String::new()));
-            object.insert(
-                DELIVERY_FEEDBACK_FIELD.to_owned(),
-                Value::String(String::new()),
-            );
-        }
-        Ok(input)
-    }
-
     fn validate_delivery(self, delivery: TemplateDelivery) -> Result<(), BuiltinTemplateError> {
         if self == Self::SingleWorker && delivery != TemplateDelivery::None {
             Err(BuiltinTemplateError::UnsupportedDelivery {
@@ -141,6 +118,4 @@ pub(crate) enum BuiltinTemplateError {
     },
     #[error("a built-in graph template contains an invalid static contract")]
     InvalidStaticContract,
-    #[error("built-in template input must be a JSON object")]
-    InputMustBeObject,
 }

--- a/zeroshot/src/native_v2_templates/tests.rs
+++ b/zeroshot/src/native_v2_templates/tests.rs
@@ -19,7 +19,7 @@ mod support;
 use support::*;
 
 #[test]
-fn catalog_and_template_owned_input_are_closed() {
+fn catalog_and_template_inputs_are_closed() {
     assert_eq!(
         BuiltinGraphTemplate::all(),
         &[
@@ -38,22 +38,25 @@ fn catalog_and_template_owned_input_are_closed() {
     ));
 
     let authored = json!({"task":"repair checkout"});
-    assert_eq!(
-        BuiltinGraphTemplate::SingleWorker
-            .materialize_input(authored.clone())
-            .assert_value(),
-        authored
-    );
-    assert_eq!(
-        BuiltinGraphTemplate::SoftwareChange
-            .materialize_input(authored)
-            .assert_value(),
-        json!({
-            "task":"repair checkout",
-            "acceptanceFeedback":"",
-            "codeFeedback":"",
-            "deliveryFeedback":""
-        })
+    let single = BuiltinGraphTemplate::SingleWorker
+        .materialize(TemplateDelivery::None)
+        .assert_value();
+    single
+        .initial_input
+        .validate_value(&authored)
+        .assert_value();
+    let software = BuiltinGraphTemplate::SoftwareChange
+        .materialize(TemplateDelivery::None)
+        .assert_value();
+    software
+        .initial_input
+        .validate_value(&authored)
+        .assert_value();
+    assert!(
+        software
+            .initial_input
+            .validate_value(&json!({"task":"repair checkout","acceptanceFeedback":""}))
+            .is_err()
     );
 }
 
@@ -357,9 +360,7 @@ async fn assert_admissible(
     assert_instruction_ownership(&leaves);
 
     let runtime = runtime_for(template, delivery, &leaves);
-    let initial_input = template
-        .materialize_input(json!({"task":"implement the requested change"}))
-        .assert_value();
+    let initial_input = json!({"task":"implement the requested change"});
     let policy = if delivery == TemplateDelivery::None {
         DeliveryPolicy::Optional
     } else {
@@ -395,9 +396,7 @@ async fn verified_software_template(
     let template = BuiltinGraphTemplate::SoftwareChange;
     let graph = template.materialize(delivery).assert_value();
     let runtime = runtime_for(template, delivery, &executable_leaves(&graph.root));
-    let initial_input = template
-        .materialize_input(json!({"task":"repair checkout"}))
-        .assert_value();
+    let initial_input = json!({"task":"repair checkout"});
     let admitted = NativeV2Admission
         .admit(RunSubmission {
             title: RunTitle::new("Template behavior").assert_value(),

--- a/zeroshot/src/native_v2_templates/values.rs
+++ b/zeroshot/src/native_v2_templates/values.rs
@@ -95,7 +95,7 @@ pub(super) fn review_repair_input_type() -> Result<PayloadType, BuiltinTemplateE
 }
 
 pub(super) fn software_input_type() -> Result<PayloadType, BuiltinTemplateError> {
-    review_repair_input_type()
+    task_type()
 }
 
 pub(super) fn review_input_type() -> Result<PayloadType, BuiltinTemplateError> {


### PR DESCRIPTION
## Summary
- allow root group state to add deterministic empty string, null, and recursively empty record fields
- prove the materialized effective state during graph verification and apply the same defaults during reduction
- keep caller-authored initial input strict and stop mutating built-in template input in the CLI
- make the software-change template accept task-only input
- cover optional-to-required nested record widening so verifier guarantees match runtime materialization

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps`
- `npm run lint`
- `npm test`
- `npm run distribution:check`
- `npm run protocol:check`
- Opcore Zero staged Verify clean; Sense reported no issues, cycles, or duplicates
- two independent subagent audits; final verdict APPROVE