### PR TITLE
fix: allow deferred PyPI publication

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -24,6 +24,11 @@ on:
         description: Exact full lowercase SDK source commit from main.
         required: true
         type: string
+      publish_pypi:
+        description: Publish to PyPI; disable only when trusted publishing is unavailable.
+        required: true
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       action:
@@ -38,6 +43,10 @@ on:
       release_commit:
         required: true
         type: string
+      publish_pypi:
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -330,11 +339,13 @@ jobs:
           path: sdk-release
 
       - name: Setup Python 3.12
+        if: inputs.publish_pypi
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: '3.12'
 
       - name: Verify existing PyPI version before recovery
+        if: inputs.publish_pypi
         id: pypi
         env:
           PACKAGE_VERSION: ${{ needs.plan.outputs.package-version }}
@@ -385,6 +396,21 @@ jobs:
           with Path(os.environ['GITHUB_OUTPUT']).open('a', encoding='utf-8') as output:
               output.write('exists=true\n')
           PY
+
+      - name: Record intentionally deferred PyPI publication
+        if: inputs.publish_pypi == false
+        env:
+          PACKAGE_VERSION: ${{ needs.plan.outputs.package-version }}
+        run: |
+          message="PyPI publication for $PACKAGE_VERSION was explicitly disabled"
+          message="$message because trusted publishing is unavailable."
+          echo "::warning::$message"
+          {
+            echo "### PyPI publication deferred"
+            echo
+            echo "$message"
+            echo "Rerun this workflow with the same immutable inputs and publish_pypi enabled to recover."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or complete independent SDK GitHub Release
         shell: bash
@@ -446,7 +472,7 @@ jobs:
           }
 
       - name: Publish Python SDK with trusted publishing
-        if: steps.pypi.outputs.exists == 'false'
+        if: inputs.publish_pypi && steps.pypi.outputs.exists == 'false'
         uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0
         with:
           packages-dir: sdk-release/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
         description: Exact full lowercase commit SHA from main.
         required: true
         type: string
+      publish_pypi:
+        description: Publish Python revision 1 to PyPI; disable only when trusted publishing is unavailable.
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -750,4 +755,5 @@ jobs:
       zeroshot_version: ${{ needs.plan.outputs.version }}
       sdk_revision: 1
       release_commit: ${{ needs.plan.outputs.commit }}
+      publish_pypi: ${{ inputs.publish_pypi }}
     secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,9 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 - Python SDK tags are `zeroshot-python-vZEROSHOT_SDK` and package versions are
   `ZEROSHOT.postSDK`. Canonical releases publish SDK revision `1`; later SDK revisions may release
   independently from an exact `main` commit descended from the canonical tag.
+- Canonical releases always publish revision `1` wheels to an immutable GitHub Release.
+  `publish_pypi` defaults to `true`; operators may set it to `false` only when PyPI trusted
+  publishing is known to be unavailable, then recover the same revision from the same source later.
 - Checked-in Cargo/npm versions are development placeholders. Tags, registry metadata, and GitHub
   Releases are authoritative. Never commit a staged release version to `main`.
 - Release recovery may complete missing outputs only when existing immutable artifacts match the
@@ -160,6 +163,8 @@ python -m pytest
 - `.github/workflows/release.yml` is the only canonical product release workflow.
 - It publishes native archives/checksums, `ghcr.io/the-open-engine/zeroshot-target`, and
   `@the-open-engine-company/zeroshot`, then invokes Python revision `1`.
+- Python revision `1` always produces its GitHub wheel release. PyPI publication is fail-closed by
+  default and may be explicitly deferred with `publish_pypi: false`.
 - `.github/workflows/release-python.yml` may publish later SDK-only revisions.
 - There is no automatic semantic release, release-promotion branch, `dev -> main` flow, or second
   runtime release train.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -13,7 +13,8 @@ One successful release produces the same version across:
 - npm package: `@the-open-engine-company/zeroshot@X.Y.Z`
 - target image: `ghcr.io/the-open-engine/zeroshot-target:X.Y.Z`
 - target image source tag: `sha-<full-commit>`
-- Python revision 1: `the-open-engine-zeroshot==X.Y.Z.post1`
+- Python revision 1 GitHub wheel release: `zeroshot-python-vX.Y.Z_1`
+- Python package when PyPI publication is enabled: `the-open-engine-zeroshot==X.Y.Z.post1`
 
 The checked-in Cargo and npm versions are development placeholders. The release workspace stages the
 explicit version and never commits it back to `main`.
@@ -26,8 +27,8 @@ explicit version and never commits it back to `main`.
 4. The `release` GitHub environment permits the publishing jobs.
 5. npm trusted publishing is configured for `@the-open-engine-company/zeroshot` and
    `.github/workflows/release.yml`.
-6. PyPI trusted publishing is configured for `the-open-engine-zeroshot` and
-   `.github/workflows/release-python.yml`.
+6. When `publish_pypi` is enabled, PyPI trusted publishing is configured for
+   `the-open-engine-zeroshot` and `.github/workflows/release-python.yml`.
 7. GitHub Packages permits publishing `ghcr.io/the-open-engine/zeroshot-target`; make the package
    public after its first publication when anonymous pulls are required.
 
@@ -47,7 +48,9 @@ create tags or publish registries.
 
 ## Publish
 
-Dispatch the same workflow with `action: release`. The workflow:
+Dispatch the same workflow with `action: release`. `publish_pypi` defaults to `true`. Set it to
+`false` only when PyPI trusted publishing is known to be unavailable; this is an explicit deferral,
+not a blanket ignored failure. The workflow:
 
 1. verifies the exact source and canonical version ordering;
 2. builds the five declared native targets;
@@ -56,10 +59,21 @@ Dispatch the same workflow with `action: release`. The workflow:
 5. creates or verifies the GitHub Release and uploads exact artifacts;
 6. publishes immutable image tags and `latest` when this is the newest release;
 7. packs, installs, smokes, and publishes `@the-open-engine-company/zeroshot`;
-8. invokes the Python SDK workflow for revision `1`.
+8. invokes the Python SDK workflow for revision `1`, always creating or verifying its immutable
+   GitHub wheel release and publishing the same wheels to PyPI when `publish_pypi` is enabled.
 
 Later Python-only revisions may dispatch `Release Python SDK` with the same Zeroshot version, a
 higher positive SDK revision, and an exact `main` commit containing the SDK changes.
+
+## Deferred PyPI publication
+
+When the PyPI organization or trusted publisher is not yet available, dispatch either release
+workflow with `publish_pypi: false`. The Python wheels are still built, verified, and attached to the
+revision's GitHub Release, and the workflow records a warning and successful intentional deferral.
+
+After PyPI becomes available, dispatch `Release Python SDK` with `action: release`,
+`publish_pypi: true`, and the same Zeroshot version, SDK revision, and release commit. Recovery
+verifies every existing immutable wheel before publishing the exact set to PyPI.
 
 ## One-time npm bootstrap
 
@@ -72,4 +86,4 @@ interactive publish; do not create a second package name or temporary compatibil
 
 Release jobs are designed to verify already-published immutable artifacts before completing missing
 steps. Recovery must use the same version, tag, and source commit. Never overwrite a different npm
-tarball, GitHub asset, image source label, or tag target.
+tarball, GitHub asset, Python wheel, image source label, or tag target.

--- a/docs/zeroshot-distribution.md
+++ b/docs/zeroshot-distribution.md
@@ -11,6 +11,8 @@ Zeroshot uses one explicit release workflow: `.github/workflows/release.yml`. An
 - target manifest: `distribution/zeroshot-targets.json`
 - npm package: `@the-open-engine-company/zeroshot`
 - target image: `ghcr.io/the-open-engine/zeroshot-target`
+- Python wheel release: `zeroshot-python-vX.Y.Z_1`
+- Python package: `the-open-engine-zeroshot==X.Y.Z.post1` when PyPI publication is enabled
 
 No alternate tag prefix, package, image, executable alias, source-build fallback, or compatibility
 artifact is published.
@@ -37,6 +39,8 @@ verifies the exact coupling before compilation. Release automation never commits
 4. Create or verify the canonical GitHub Release and exact assets.
 5. Publish the image version, source-commit, and eligible `latest` tags.
 6. Pack, install, smoke, and publish `@the-open-engine-company/zeroshot`.
-7. Publish Python SDK revision `1` from the same canonical release.
+7. Build and publish Python SDK revision `1` as an immutable GitHub wheel release.
+8. Publish that exact wheel set to PyPI unless the operator explicitly defers unavailable trusted
+   publishing with `publish_pypi: false`.
 
 See `PUBLISHING.md` for operator setup and recovery rules.

--- a/scripts/distribution/repository.js
+++ b/scripts/distribution/repository.js
@@ -82,6 +82,47 @@ function checkReleaseJobs(document) {
   }
 }
 
+function checkOptionalPyPiInputs(releaseDocument, pythonDocument) {
+  const releaseInput = releaseDocument.on?.workflow_dispatch?.inputs?.publish_pypi;
+  if (releaseInput?.type !== 'boolean' || releaseInput.default !== true) {
+    failIntegrity('release workflow must default publish_pypi to true');
+  }
+  const delegatedInput = releaseDocument.jobs?.['python-sdk-release']?.with?.publish_pypi;
+  if (delegatedInput !== '${{ inputs.publish_pypi }}') {
+    failIntegrity('release workflow must pass publish_pypi to the Python SDK workflow');
+  }
+
+  for (const trigger of ['workflow_dispatch', 'workflow_call']) {
+    const input = pythonDocument.on?.[trigger]?.inputs?.publish_pypi;
+    if (input?.type !== 'boolean' || input.default !== true) {
+      failIntegrity(`release-python ${trigger} must default publish_pypi to true`);
+    }
+  }
+}
+
+function checkOptionalPyPiSteps(pythonDocument) {
+  const publishSteps = new Map(
+    pythonDocument.jobs?.publish?.steps?.map((step) => [step.name, step]) ?? []
+  );
+  const expectedConditions = new Map([
+    ['Setup Python 3.12', 'inputs.publish_pypi'],
+    ['Verify existing PyPI version before recovery', 'inputs.publish_pypi'],
+    ['Record intentionally deferred PyPI publication', 'inputs.publish_pypi == false'],
+    [
+      'Publish Python SDK with trusted publishing',
+      "inputs.publish_pypi && steps.pypi.outputs.exists == 'false'",
+    ],
+  ]);
+  for (const [name, condition] of expectedConditions) {
+    if (publishSteps.get(name)?.if !== condition) {
+      failIntegrity(`release-python ${name} must use condition: ${condition}`);
+    }
+  }
+  if (publishSteps.get('Create or complete independent SDK GitHub Release')?.if !== undefined) {
+    failIntegrity('release-python GitHub wheel publication must not depend on publish_pypi');
+  }
+}
+
 function checkObsoleteWorkflowIdentities(workflow) {
   const forbidden = [
     'zeroshot-rust',
@@ -116,6 +157,7 @@ function checkReleaseFragments(workflow) {
     'node scripts/distribution.js publish-assets --tag "$RELEASE_TAG" --dir release-assets',
     'npm publish --provenance --access public ./shim-release/*.tgz',
     'uses: ./.github/workflows/release-python.yml',
+    'publish_pypi: ${{ inputs.publish_pypi }}',
   ]);
 }
 
@@ -128,10 +170,15 @@ function checkPythonReleaseFragments(workflow) {
     'gh release download "$SDK_TAG" --pattern "$name" --dir "$existing_dir"',
     '[[ "$local_sha" == "$remote_sha" ]]',
     'gh release edit "$SDK_TAG" --latest=false',
-    "if: steps.pypi.outputs.exists == 'false'",
+    'if: inputs.publish_pypi == false',
+    "if: inputs.publish_pypi && steps.pypi.outputs.exists == 'false'",
+    'Rerun this workflow with the same immutable inputs and publish_pypi enabled to recover.',
   ]);
   if (workflow.includes('skip-existing: true')) {
     failIntegrity('release-python workflow must verify existing files instead of skipping them');
+  }
+  if (workflow.includes('continue-on-error')) {
+    failIntegrity('release-python workflow must not hide publication failures');
   }
 }
 
@@ -174,8 +221,10 @@ function checkToolingManifest(packageManifest, packageLock) {
 function checkRepository(options = {}) {
   const contract = repositoryContract(options);
   const document = parseReleaseWorkflow(contract.workflow);
-  parsePythonReleaseWorkflow(contract.pythonWorkflow);
+  const pythonDocument = parsePythonReleaseWorkflow(contract.pythonWorkflow);
   checkReleaseJobs(document);
+  checkOptionalPyPiInputs(document, pythonDocument);
+  checkOptionalPyPiSteps(pythonDocument);
   checkObsoleteWorkflowIdentities(contract.workflow);
   checkReleaseFragments(contract.workflow);
   checkPythonReleaseFragments(contract.pythonWorkflow);

--- a/tests/tooling/release-contract.test.js
+++ b/tests/tooling/release-contract.test.js
@@ -51,6 +51,47 @@ describe('v8 hard cutover contract', () => {
     assert.match(versionModule, /version\("the-open-engine-zeroshot"\)/);
     assert.match(pyproject, /"PyYAML==6\.0\.3"/);
   });
+});
+
+describe('Python release publication contract', () => {
+  it('requires an explicit opt-out to defer PyPI publication', () => {
+    const release = yaml.load(read('.github/workflows/release.yml'));
+    const pythonRelease = yaml.load(read('.github/workflows/release-python.yml'));
+    const releaseInput = release.on.workflow_dispatch.inputs.publish_pypi;
+
+    assert.equal(releaseInput.type, 'boolean');
+    assert.equal(releaseInput.default, true);
+    assert.equal(releaseInput.required, true);
+    assert.equal(
+      release.jobs['python-sdk-release'].with.publish_pypi,
+      '${{ inputs.publish_pypi }}'
+    );
+
+    for (const trigger of ['workflow_dispatch', 'workflow_call']) {
+      const input = pythonRelease.on[trigger].inputs.publish_pypi;
+      assert.equal(input.type, 'boolean', trigger);
+      assert.equal(input.default, true, trigger);
+    }
+
+    const publishSteps = new Map(pythonRelease.jobs.publish.steps.map((step) => [step.name, step]));
+    assert.equal(publishSteps.get('Setup Python 3.12').if, 'inputs.publish_pypi');
+    assert.equal(
+      publishSteps.get('Verify existing PyPI version before recovery').if,
+      'inputs.publish_pypi'
+    );
+    assert.equal(
+      publishSteps.get('Record intentionally deferred PyPI publication').if,
+      'inputs.publish_pypi == false'
+    );
+    assert.equal(
+      publishSteps.get('Publish Python SDK with trusted publishing').if,
+      "inputs.publish_pypi && steps.pypi.outputs.exists == 'false'"
+    );
+    assert.equal(
+      publishSteps.get('Create or complete independent SDK GitHub Release').if,
+      undefined
+    );
+  });
 
   it('keeps release recovery exact and fail-closed', () => {
     const pythonRelease = read('.github/workflows/release-python.yml');
@@ -64,10 +105,18 @@ describe('v8 hard cutover contract', () => {
     assert.match(pythonRelease, /GH_REPO: \$\{\{ github\.repository \}\}/);
     assert.match(pythonRelease, /gh release download "\$SDK_TAG"/);
     assert.match(pythonRelease, /"\$local_sha" == "\$remote_sha"/);
-    assert.match(pythonRelease, /if: steps\.pypi\.outputs\.exists == 'false'/);
+    assert.match(pythonRelease, /if: inputs\.publish_pypi == false/);
+    assert.match(
+      pythonRelease,
+      /if: inputs\.publish_pypi && steps\.pypi\.outputs\.exists == 'false'/
+    );
+    assert.match(pythonRelease, /same immutable inputs and publish_pypi enabled to recover/);
     assert.doesNotMatch(pythonRelease, /skip-existing:\s*true/);
+    assert.doesNotMatch(pythonRelease, /continue-on-error/);
   });
+});
 
+describe('v8 hard cutover contract', () => {
   it('keeps every workflow syntactically valid YAML', () => {
     const workflows = fs.readdirSync(path.join(root, '.github', 'workflows'));
     for (const filename of workflows.filter((name) => name.endsWith('.yml'))) {


### PR DESCRIPTION
## Summary
- add an explicit `publish_pypi` release input that defaults to `true`
- allow operators to defer only the PyPI step when trusted publishing is known to be unavailable
- keep Python wheel builds, immutable GitHub SDK release verification, and recovery checks mandatory
- document the exact recovery procedure and enforce the workflow contract in tooling tests

## Safety
- default releases remain fail-closed for PyPI
- no `continue-on-error` or blanket publication failure suppression
- deferred runs emit an explicit warning and can be replayed later with the same immutable release inputs

## Validation
- `node --test tests/tooling/release-contract.test.js`
- `npm run distribution:check`
- `npm run lint`
- `npm test`
- `npm run protocol:check`
- `actionlint .github/workflows/release.yml .github/workflows/release-python.yml`
- targeted Prettier and `git diff --check`
- full Python 3.12 SDK lane, deterministic wheel builds, and `twine check`
- full Rust/native lane
- target Docker image build and CLI version checks
- `opcore-zero check --repo . --staged --json`
- `opcore-zero sense --repo . --staged --json` (partial coverage for two unsupported files; no findings)
