### PR TITLE
fix: install pinned Rust components for docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -123,6 +123,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.0
+          components: clippy,rustfmt
 
       - name: Install documentation tools
         run: python -m pip install --disable-pip-version-check -r docs/requirements.lock

--- a/tests/tooling/release-contract.test.js
+++ b/tests/tooling/release-contract.test.js
@@ -139,6 +139,13 @@ describe('Versioned documentation publication contract', () => {
     assertPagesPublisherPermissions(docs.permissions);
     assert.equal(docs.concurrency['cancel-in-progress'], false);
     assert.equal(docs.concurrency.queue, 'max');
+    const rustSetup = docs.jobs.publish.steps.find(
+      (step) => step.name === 'Setup Rust 1.97.0'
+    );
+    assert.deepEqual(rustSetup.with, {
+      toolchain: '1.97.0',
+      components: 'clippy,rustfmt',
+    });
   });
 
   it('runs from the release chain after Python revision 1', () => {


### PR DESCRIPTION
## Summary

Install the Rust components declared by the repository toolchain during the docs setup step. This prevents the clean Pages runner from trying to install `rustfmt` during the generated CLI check and colliding with the runner's existing shim.

Add a workflow contract assertion so the setup cannot regress.

## Verification

- `npm run lint`
- `npm test`
- `git diff --check`
- Opcore staged Verify
