### PR TITLE
fix: wait for hosted Git maintenance before launching workers

### DIFF
--- a/docker/zeroshot-target/Dockerfile
+++ b/docker/zeroshot-target/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97.0-bookworm AS builder
+FROM rust:1.97.0-trixie AS builder
 
 WORKDIR /src
 
@@ -8,7 +8,7 @@ COPY zeroshot ./zeroshot
 
 RUN cargo build --locked --release --package zeroshot --bin zeroshot
 
-FROM node:22-bookworm-slim AS runtime
+FROM node:22-trixie-slim AS runtime
 
 ARG CODEX_VERSION=0.148.0
 ARG CLAUDE_CODE_VERSION=2.1.237
@@ -27,6 +27,8 @@ RUN apt-get update \
         gh \
         git \
         ripgrep \
+    && git_version="$(git --version)" \
+    && dpkg --compare-versions "${git_version#git version }" ge 2.47 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN npm install --global --no-audit --no-fund \

--- a/zeroshot/src/native_v2_hosting/repository.rs
+++ b/zeroshot/src/native_v2_hosting/repository.rs
@@ -11,6 +11,9 @@ use crate::native_v2_delivery::DeliveryTarget;
 use crate::native_v2_delivery::git_auth::encode_basic_credential;
 use crate::native_v2_contract::ResolvedSource;
 
+#[cfg(all(test, unix))]
+mod tests;
+
 const GIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 const MAX_GIT_OUTPUT_BYTES: usize = 4_096;
 
@@ -157,6 +160,10 @@ impl GitProcess<'_> {
             .env("GIT_CONFIG_NOSYSTEM", "1")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_TERMINAL_PROMPT", "0")
+            // Checkout and the agent share a UID. Detached maintenance can leave an orphan
+            // under that UID after Git exits, preventing the agent's containment registration.
+            .arg("-c")
+            .arg("maintenance.autoDetach=false")
             .arg("-c")
             .arg("core.hooksPath=/dev/null");
         if let Some(token) = self.token {

--- a/zeroshot/src/native_v2_hosting/repository/tests.rs
+++ b/zeroshot/src/native_v2_hosting/repository/tests.rs
@@ -1,0 +1,88 @@
+use openengine_cluster_testkit::assertions::AssertValue;
+use serde_json::Value;
+
+use super::*;
+use crate::native_v2_candidate::test_support::TestDirectory;
+
+#[tokio::test]
+async fn fetch_waits_for_automatic_maintenance() {
+    let root = TestDirectory::new("git-maintenance");
+    let program = root.write_executable(
+        "git-trace",
+        "#!/bin/sh\nexport GIT_TRACE2_EVENT=\"$0.trace\"\nexec /usr/bin/git \"$@\"\n",
+    );
+    let git = GitProcess {
+        program: &program,
+        token: None,
+        uid: unsafe { libc::geteuid() },
+        gid: unsafe { libc::getegid() },
+    };
+    let seed = root.child("seed");
+    let workspace = root.child("workspace");
+    git.run(None, &["init".into(), seed.as_os_str().to_owned()])
+        .await
+        .assert_value_with("initialize source");
+    git.run(
+        Some(&seed),
+        &[
+            "-c".into(),
+            "user.name=Fixture".into(),
+            "-c".into(),
+            "user.email=fixture@example.invalid".into(),
+            "commit".into(),
+            "--allow-empty".into(),
+            "-m".into(),
+            "fixture".into(),
+        ],
+    )
+    .await
+    .assert_value_with("commit source");
+    let revision = git
+        .capture(&seed, &["rev-parse".into(), "HEAD".into()])
+        .await
+        .assert_value_with("resolve revision");
+    git.run(
+        None,
+        &[
+            "clone".into(),
+            "--no-tags".into(),
+            "--no-checkout".into(),
+            seed.as_os_str().to_owned(),
+            workspace.as_os_str().to_owned(),
+        ],
+    )
+    .await
+    .assert_value_with("clone source");
+    checkout_revision(&git, &workspace, revision.trim())
+        .await
+        .assert_value_with("fetch and checkout revision");
+    assert_eq!(
+        git.capture(&workspace, &["rev-parse".into(), "HEAD".into()])
+            .await
+            .assert_value_with("checkout revision"),
+        revision
+    );
+
+    let trace = root.read("git-trace.trace");
+    let maintenance: Vec<Value> = trace
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).assert_value_with("Git trace event"))
+        .filter(|event| {
+            event["event"] == "child_start"
+                && event["argv"]
+                    .as_array()
+                    .is_some_and(|args| args.iter().any(|arg| arg == "maintenance"))
+        })
+        .collect();
+    assert!(
+        !maintenance.is_empty(),
+        "fetch must exercise automatic maintenance"
+    );
+    for event in maintenance {
+        let args = event["argv"]
+            .as_array()
+            .assert_value_with("maintenance arguments");
+        assert!(args.iter().any(|arg| arg == "--no-detach"), "{event}");
+        assert!(!args.iter().any(|arg| arg == "--detach"), "{event}");
+    }
+}


### PR DESCRIPTION
Before Zeroshot starts a hosted coding agent, it downloads the repository with Git. Git can also start a background housekeeping process. In the Cloud container, that process can leave behind an entry in the operating system’s process table even after it has exited—a “zombie.”

Repository setup and the coding agent use the same operating-system user account. Zeroshot checks that this account has no existing processes before launching the agent, so different jobs cannot interfere with each other. The leftover Git entry makes that safety check fail, and the agent never starts.

We discovered this while testing Claude, but the problem is in shared repository setup and can also block Codex or any other hosted worker.

This PR tells Git to finish its automatic housekeeping before returning, using `maintenance.autoDetach=false`. That prevents the detached background process that caused the failure. The production fix is four lines, and the worker’s isolation check stays intact.

Validation:

- Added a test that uses real Git to download and check out a repository. It checks that automatic housekeeping runs in the foreground and that checkout still selects the requested revision. The test fails before the fix and passes afterward.
- Reproduced the original failure in the local runtime container. With foreground housekeeping, no processes were left under the worker’s account in three repeated tests.
- Formatting, repository lint/tests, and Opcore Verify passed. Opcore Sense reported no findings, but has incomplete Rust/interface coverage.
- The broader runtime library suite on macOS had 393 passing and 35 failing tests, including failures involving Linux-specific assumptions. Those results do not establish a passing full suite; see the PR’s Linux CI checks for that validation.

This is a focused fix for Git’s detached housekeeping. It does not establish that all timeout and cancellation cleanup paths are correct. Authenticated Cloud execution is now verified: read-only run 01a08670-e34f-7100-b486-36e1a225f4dc succeeded, followed by full coding run 01a08673-8273-7412-94f9-8a1e559242b7, which modified code, passed tests and both reviews, built the npm package, and opened PR #1089. That test PR was later closed unmerged at the user's request. All Linux CI checks on this runtime PR passed. Cloud consumes the fix in the separate the-open-engine/zero-cloud#251.

