### PR TITLE
fix(native-v2): retry crashed verifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   milliseconds and remain unchanged across durable replay.
 - Run close reserves and tombstones execution activity atomically. No late start, handle, or stream
   may surface after close returns.
+- Native-v2 retries only a settled `crash` outcome when the executable has another authored
+  attempt. A provider session invalidated by that active execution becomes replaceable for the
+  authorized retry; passive session loss and run closure remain permanent, fail-closed loss.
 - Contained provider sessions bound post-exit I/O draining by the command deadline and a ten-minute
   ceiling while still observing cancellation and cleanup.
 - GitHub delivery treats aggregate merge policy and required contexts as authority, waits through

--- a/zeroshot/src/full_v1_reducer.rs
+++ b/zeroshot/src/full_v1_reducer.rs
@@ -25,6 +25,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
 
+const INITIAL_ATTEMPT: u64 = 1;
+
 #[derive(Clone, Debug)]
 pub struct ReductionInput<'a> {
     pub initial_input: &'a Value,
@@ -105,7 +107,7 @@ pub struct FullV1Reducer<'a> {
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum ExecutionMode {
     LegacyAttempts,
-    NativeV2NoRetry,
+    NativeV2,
 }
 
 impl<'a> FullV1Reducer<'a> {
@@ -117,12 +119,12 @@ impl<'a> FullV1Reducer<'a> {
         }
     }
 
-    /// Native-v2 execution: every structural revisit is a fresh execution with attempt one.
+    /// Native-v2 execution: retries stay within a structural visit, while a revisit starts at one.
     #[must_use]
     pub const fn native_v2(graph: &'a VerifiedGraph) -> Self {
         Self {
             graph,
-            execution_mode: ExecutionMode::NativeV2NoRetry,
+            execution_mode: ExecutionMode::NativeV2,
         }
     }
 

--- a/zeroshot/src/full_v1_reducer.rs
+++ b/zeroshot/src/full_v1_reducer.rs
@@ -18,7 +18,7 @@ pub use history::{
 use openengine_cluster_protocol::{
     ChoiceNode, ControlSelector, ControlSource, DataSelector, FieldPath, GraphNode, Guard, Join,
     EnumLabel, MapNode, NodeName, NodeOutputChannel, ParNode, PositiveInteger, TerminalResult,
-    WorkerOutcome, WorkerRef,
+    WorkerErrorCode, WorkerOutcome, WorkerRef,
 };
 use openengine_cluster_server::admission::VerifiedGraph;
 use serde::{Deserialize, Serialize};

--- a/zeroshot/src/full_v1_reducer/evaluation.rs
+++ b/zeroshot/src/full_v1_reducer/evaluation.rs
@@ -215,7 +215,10 @@ impl Engine<'_> {
         };
         let visit = *visit;
         let input = bind_payload(spec.input_bindings, &context.state, traversal.item)?;
-        if let Some(execution) = &visit.existing {
+        for execution in &visit.executions {
+            if execution.input != input {
+                return Err(ReducerError::InconsistentHistory);
+            }
             self.consumed_executions.insert(execution.execution);
         }
         mark_visit(
@@ -255,14 +258,22 @@ impl Engine<'_> {
         if execution.dispatch_position > traversal.cutoff {
             return Ok(Status::Pending);
         }
-        if execution.input != input {
-            return Err(ReducerError::InconsistentHistory);
-        }
         let DurableExecutionState::Settled { position, outcome } = &execution.state else {
             return Ok(Status::Pending);
         };
         if *position > traversal.cutoff {
             return Ok(Status::Pending);
+        }
+        if self.execution_mode == ExecutionMode::NativeV2
+            && matches!(outcome, WorkerOutcome::Error { .. })
+            && execution.attempt < spec.attempt_ceiling
+        {
+            return self.dispatch_retry(RetryDispatchRequest {
+                spec,
+                traversal,
+                execution,
+                input,
+            });
         }
         let writes_applied = self.apply_outcome(OutcomeApplication {
             spec: &spec,
@@ -294,7 +305,7 @@ impl Engine<'_> {
             .cloned()
             .collect::<Vec<_>>();
         let number = next_visit(spec.name, map_indices, &context.controls);
-        let (attempt, existing) = match self.execution_mode {
+        let (attempt, existing, executions) = match self.execution_mode {
             ExecutionMode::LegacyAttempts => {
                 matching.sort_by_key(|execution| execution.attempt);
                 let attempt =
@@ -306,20 +317,30 @@ impl Engine<'_> {
                     .iter()
                     .find(|execution| execution.attempt == attempt)
                     .cloned();
-                (attempt, existing)
+                let executions = existing.iter().cloned().collect();
+                (attempt, existing, executions)
             }
-            ExecutionMode::NativeV2NoRetry => {
+            ExecutionMode::NativeV2 => {
                 matching.sort_by_key(|execution| execution.dispatch_position);
-                let attempt =
-                    PositiveInteger::new(1).map_err(|_| ReducerError::InconsistentHistory)?;
-                let index =
-                    usize::try_from(number - 1).map_err(|_| ReducerError::IdentityOutOfRange)?;
-                (attempt, matching.get(index).cloned())
+                let executions = native_visit_executions(&matching, number);
+                let existing = executions.last().cloned();
+                let attempt = existing.as_ref().map_or_else(
+                    || {
+                        PositiveInteger::new(INITIAL_ATTEMPT)
+                            .expect("the initial attempt is positive")
+                    },
+                    |execution| execution.attempt,
+                );
+                if attempt > spec.attempt_ceiling {
+                    return Err(ReducerError::InconsistentHistory);
+                }
+                (attempt, existing, executions)
             }
         };
         Ok(VisitResolution::Ready(Box::new(ExecutableVisit {
             occurrence,
             matching,
+            executions,
             number,
             attempt,
             existing,
@@ -362,6 +383,44 @@ impl Engine<'_> {
             execution,
             occurrence: visit.occurrence,
             attempt: visit.attempt,
+            worker: spec.worker.clone(),
+            input,
+        });
+        Ok(Status::Pending)
+    }
+
+    fn dispatch_retry(
+        &mut self,
+        request: RetryDispatchRequest<'_, '_>,
+    ) -> Result<Status, ReducerError> {
+        let RetryDispatchRequest {
+            spec,
+            traversal,
+            execution: previous,
+            input,
+        } = request;
+        if traversal.mode == EvalMode::Probe || traversal.cutoff != HistoryPosition::MAX {
+            return Ok(Status::Pending);
+        }
+        let attempt = previous
+            .attempt
+            .get()
+            .checked_add(1)
+            .ok_or(ReducerError::IdentityOutOfRange)
+            .and_then(|value| {
+                PositiveInteger::new(value).map_err(|_| ReducerError::IdentityOutOfRange)
+            })?;
+        let execution =
+            ExecutionId::new(self.next_execution).map_err(|_| ReducerError::IdentityOutOfRange)?;
+        self.next_execution = self
+            .next_execution
+            .checked_add(1)
+            .ok_or(ReducerError::IdentityOutOfRange)?;
+        self.decisions.push(Decision::Dispatch {
+            node_instance: previous.node_instance,
+            execution,
+            occurrence: previous.occurrence,
+            attempt,
             worker: spec.worker.clone(),
             input,
         });
@@ -467,4 +526,20 @@ impl Engine<'_> {
         Ok(())
     }
     // Choice, parallel, and map evaluation live in the groups companion module.
+}
+
+fn native_visit_executions(
+    executions: &[DurableExecution],
+    requested_visit: u64,
+) -> Vec<DurableExecution> {
+    let mut visit = 0;
+    executions
+        .iter()
+        .filter_map(|execution| {
+            if execution.attempt.get() == 1 {
+                visit += 1;
+            }
+            (visit == requested_visit).then(|| execution.clone())
+        })
+        .collect()
 }

--- a/zeroshot/src/full_v1_reducer/evaluation.rs
+++ b/zeroshot/src/full_v1_reducer/evaluation.rs
@@ -265,7 +265,13 @@ impl Engine<'_> {
             return Ok(Status::Pending);
         }
         if self.execution_mode == ExecutionMode::NativeV2
-            && matches!(outcome, WorkerOutcome::Error { .. })
+            && matches!(
+                outcome,
+                WorkerOutcome::Error {
+                    code: WorkerErrorCode::Crash,
+                    ..
+                }
+            )
             && execution.attempt < spec.attempt_ceiling
         {
             return self.dispatch_retry(RetryDispatchRequest {

--- a/zeroshot/src/full_v1_reducer/evaluation/state.rs
+++ b/zeroshot/src/full_v1_reducer/evaluation/state.rs
@@ -43,6 +43,13 @@ pub(super) struct MissingDispatchRequest<'graph, 'traversal> {
     pub(super) traversal: Traversal<'traversal>,
 }
 
+pub(super) struct RetryDispatchRequest<'graph, 'traversal> {
+    pub(super) spec: ExecutableSpec<'graph>,
+    pub(super) traversal: Traversal<'traversal>,
+    pub(super) execution: DurableExecution,
+    pub(super) input: Value,
+}
+
 pub(super) struct OutcomeApplication<'request, 'graph> {
     pub(super) spec: &'request ExecutableSpec<'graph>,
     pub(super) context: &'request mut Context,
@@ -53,6 +60,7 @@ pub(super) struct OutcomeApplication<'request, 'graph> {
 pub(super) struct ExecutableVisit {
     pub(super) occurrence: StructuralOccurrence,
     pub(super) matching: Vec<DurableExecution>,
+    pub(super) executions: Vec<DurableExecution>,
     pub(super) number: u64,
     pub(super) attempt: PositiveInteger,
     pub(super) existing: Option<DurableExecution>,

--- a/zeroshot/src/full_v1_reducer/values.rs
+++ b/zeroshot/src/full_v1_reducer/values.rs
@@ -111,7 +111,10 @@ fn validate_native_attempt_lineage(executions: &[DurableExecution]) -> Result<()
                 &previous.state,
                 DurableExecutionState::Settled {
                     position,
-                    outcome: WorkerOutcome::Error { .. },
+                    outcome: WorkerOutcome::Error {
+                        code: WorkerErrorCode::Crash,
+                        ..
+                    },
                 } if *position < current.dispatch_position
             ) && previous
                 .attempt
@@ -461,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    fn native_history_still_accepts_retry_after_settled_error() {
+    fn native_history_accepts_retry_after_settled_crash() {
         let failed = execution(
             1,
             INITIAL_ATTEMPT,
@@ -473,5 +476,23 @@ mod tests {
         );
         let retry = execution(2, INITIAL_ATTEMPT + 1, 3, DurableExecutionState::Active);
         assert_eq!(validate_native_attempt_lineage(&[failed, retry]), Ok(()));
+    }
+
+    #[test]
+    fn native_history_rejects_retry_after_non_crash_error() {
+        let timed_out = execution(
+            1,
+            INITIAL_ATTEMPT,
+            1,
+            DurableExecutionState::Settled {
+                position: HistoryPosition::new(2).expect("valid position"),
+                outcome: WorkerOutcome::declared_failure(WorkerErrorCode::Timeout),
+            },
+        );
+        let retry = execution(2, INITIAL_ATTEMPT + 1, 3, DurableExecutionState::Active);
+        assert_eq!(
+            validate_native_attempt_lineage(&[timed_out, retry]),
+            Err(ReducerError::InconsistentHistory)
+        );
     }
 }

--- a/zeroshot/src/full_v1_reducer/values.rs
+++ b/zeroshot/src/full_v1_reducer/values.rs
@@ -49,6 +49,8 @@ pub(super) fn validate_history_for_mode(
                 return Err(ReducerError::InconsistentHistory);
             }
         }
+    } else {
+        validate_native_attempt_lineage(executions)?;
     }
     Ok(())
 }
@@ -70,12 +72,9 @@ impl HistoryVisitIdentities {
             ExecutionMode::LegacyAttempts => self
                 .attempts
                 .insert((execution.occurrence.clone(), execution.attempt)),
-            ExecutionMode::NativeV2NoRetry => {
-                execution.attempt.get() == 1
-                    && self
-                        .visits
-                        .insert((execution.occurrence.clone(), execution.dispatch_position))
-            }
+            ExecutionMode::NativeV2 => self
+                .visits
+                .insert((execution.occurrence.clone(), execution.dispatch_position)),
         };
         if self.ids.insert(execution.execution) && valid_visit {
             Ok(())
@@ -83,6 +82,50 @@ impl HistoryVisitIdentities {
             Err(ReducerError::InconsistentHistory)
         }
     }
+}
+
+fn validate_native_attempt_lineage(executions: &[DurableExecution]) -> Result<(), ReducerError> {
+    let mut occurrences = BTreeMap::<StructuralOccurrence, Vec<&DurableExecution>>::new();
+    for execution in executions {
+        occurrences
+            .entry(execution.occurrence.clone())
+            .or_default()
+            .push(execution);
+    }
+    for occurrence_executions in occurrences.values_mut() {
+        occurrence_executions.sort_by_key(|execution| execution.dispatch_position);
+        let first = occurrence_executions[0];
+        if first.attempt.get() != INITIAL_ATTEMPT {
+            return Err(ReducerError::InconsistentHistory);
+        }
+        for pair in occurrence_executions.windows(2) {
+            let previous = pair[0];
+            let current = pair[1];
+            let follows_finalized_visit = matches!(
+                &previous.state,
+                DurableExecutionState::Settled { position, .. }
+                    | DurableExecutionState::Voided { position, .. }
+                    if *position < current.dispatch_position
+            );
+            let follows_failed_attempt = matches!(
+                &previous.state,
+                DurableExecutionState::Settled {
+                    position,
+                    outcome: WorkerOutcome::Error { .. },
+                } if *position < current.dispatch_position
+            ) && previous
+                .attempt
+                .get()
+                .checked_add(1)
+                .is_some_and(|attempt| attempt == current.attempt.get());
+            if (current.attempt.get() == 1 && !follows_finalized_visit)
+                || (current.attempt.get() != 1 && !follows_failed_attempt)
+            {
+                return Err(ReducerError::InconsistentHistory);
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn validate_instance_lineage(
@@ -363,4 +406,72 @@ pub(super) fn descendant_names(node: &GraphNode) -> BTreeSet<NodeName> {
     let mut depths = BTreeMap::new();
     collect_map_depths(node, 0, &mut depths);
     depths.into_keys().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_protocol::WorkerErrorCode;
+
+    use super::*;
+
+    const NODE_INSTANCE: u64 = 1;
+
+    fn execution(
+        execution: u64,
+        attempt: u64,
+        dispatch_position: u64,
+        state: DurableExecutionState,
+    ) -> DurableExecution {
+        DurableExecution {
+            dispatch_position: HistoryPosition::new(dispatch_position).expect("valid position"),
+            node_instance: NodeInstanceId::new(NODE_INSTANCE).expect("valid node instance"),
+            execution: ExecutionId::new(execution).expect("valid execution"),
+            occurrence: StructuralOccurrence {
+                node: "loop_work".parse().expect("valid node name"),
+                map_indices: Vec::new(),
+            },
+            attempt: PositiveInteger::new(attempt).expect("positive attempt"),
+            input: Value::Null,
+            state,
+        }
+    }
+
+    #[test]
+    fn native_history_accepts_fresh_visit_after_void_but_rejects_retry() {
+        let voided = execution(
+            1,
+            INITIAL_ATTEMPT,
+            1,
+            DurableExecutionState::Voided {
+                position: HistoryPosition::new(2).expect("valid position"),
+                reason: ExecutionVoidReason::ParallelJoin,
+            },
+        );
+        let fresh_visit = execution(2, INITIAL_ATTEMPT, 3, DurableExecutionState::Active);
+        assert_eq!(
+            validate_native_attempt_lineage(&[voided.clone(), fresh_visit]),
+            Ok(())
+        );
+
+        let invalid_retry = execution(2, INITIAL_ATTEMPT + 1, 3, DurableExecutionState::Active);
+        assert_eq!(
+            validate_native_attempt_lineage(&[voided, invalid_retry]),
+            Err(ReducerError::InconsistentHistory)
+        );
+    }
+
+    #[test]
+    fn native_history_still_accepts_retry_after_settled_error() {
+        let failed = execution(
+            1,
+            INITIAL_ATTEMPT,
+            1,
+            DurableExecutionState::Settled {
+                position: HistoryPosition::new(2).expect("valid position"),
+                outcome: WorkerOutcome::declared_failure(WorkerErrorCode::Crash),
+            },
+        );
+        let retry = execution(2, INITIAL_ATTEMPT + 1, 3, DurableExecutionState::Active);
+        assert_eq!(validate_native_attempt_lineage(&[failed, retry]), Ok(()));
+    }
 }

--- a/zeroshot/src/native_v2_admission.rs
+++ b/zeroshot/src/native_v2_admission.rs
@@ -25,6 +25,8 @@ use crate::native_v2_contract::{
 };
 use openengine_cluster_protocol::MAX_DECLARED_ENVIRONMENT_NAMES;
 
+pub(crate) const MAX_AGENT_VERIFIER_ATTEMPTS: u64 = 2;
+
 /// Host policy for graph-visible Git delivery.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -42,7 +44,7 @@ pub enum NativeV2AdmissionError {
     UnsupportedGraphProfile,
     #[error("initial input does not match GraphSpec.initialInput: {0}")]
     InitialInput(#[from] PayloadValueError),
-    #[error("executable node {node} must use exactly one attempt, found {attempts}")]
+    #[error("executable node {node} uses unsupported native-v2 attempt count {attempts}")]
     Attempts { node: NodeName, attempts: u64 },
     #[error("runtime plan has no binding for executable node {node}")]
     MissingRuntimeBinding { node: NodeName },

--- a/zeroshot/src/native_v2_admission/tests.rs
+++ b/zeroshot/src/native_v2_admission/tests.rs
@@ -207,14 +207,34 @@ async fn rejects_non_full_profile_and_invalid_actual_input() {
 }
 
 #[tokio::test]
-async fn rejects_non_single_attempts_and_runtime_coverage_errors() {
+async fn bounds_attempts_and_rejects_runtime_coverage_errors() {
+    let mut verifier = null_verifier("verify", "verify.work@1");
+    *verifier.get_mut("attempts").assert_value() = json!(MAX_AGENT_VERIFIER_ATTEMPTS);
+    let verifier_graph = graph(vec![verifier, succeed("done")]);
+    let verifier_nodes = BTreeMap::from([(named("verify"), binding("claude-sonnet-5", None))]);
+    NativeV2Admission
+        .admit(submission(verifier_graph, verifier_nodes))
+        .await
+        .assert_value();
+
     let mut value = null_step("work", "agent.work@1");
-    *value.get_mut("attempts").assert_value() = json!(2);
+    *value.get_mut("attempts").assert_value() = json!(MAX_AGENT_VERIFIER_ATTEMPTS);
     let attempts_graph = graph(vec![value, succeed("done")]);
     let nodes = BTreeMap::from([(named("work"), binding("claude-sonnet-5", None))]);
     assert!(matches!(
         NativeV2Admission
             .admit(submission(attempts_graph, nodes))
+            .await,
+        Err(NativeV2AdmissionError::Attempts { .. })
+    ));
+
+    let mut delivery = delivery_verifier("deliver", DeliveryMode::PullRequest);
+    *delivery.get_mut("attempts").assert_value() = json!(MAX_AGENT_VERIFIER_ATTEMPTS);
+    let delivery_graph = graph(vec![delivery, succeed("done")]);
+    let delivery_nodes = BTreeMap::from([(named("deliver"), delivery_binding())]);
+    assert!(matches!(
+        NativeV2Admission
+            .admit(submission(delivery_graph, delivery_nodes))
             .await,
         Err(NativeV2AdmissionError::Attempts { .. })
     ));

--- a/zeroshot/src/native_v2_admission/validation.rs
+++ b/zeroshot/src/native_v2_admission/validation.rs
@@ -5,7 +5,7 @@ use openengine_cluster_protocol::{
     WorkerContract, WorkerRef, MAX_DECLARED_ENVIRONMENT_NAMES, RUNTIME_WORKER_ERRORS,
 };
 
-use super::{DeliveryPolicy, NativeV2AdmissionError};
+use super::{DeliveryPolicy, NativeV2AdmissionError, MAX_AGENT_VERIFIER_ATTEMPTS};
 use crate::native_v2_contract::{
     AdmittedRun, NodeRuntimeBinding, GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF,
 };
@@ -125,7 +125,12 @@ fn collect_declarations(node: &GraphNode, declarations: &mut Vec<ExecutableDecla
 }
 
 fn validate_attempts(declarations: &[ExecutableDeclaration]) -> Result<(), NativeV2AdmissionError> {
-    if let Some(declaration) = declarations.iter().find(|item| item.attempts != 1) {
+    if let Some(declaration) = declarations.iter().find(|item| {
+        item.attempts != 1
+            && !(item.kind == LeafKind::Verifier
+                && !is_git_delivery_worker(&item.worker)
+                && item.attempts <= MAX_AGENT_VERIFIER_ATTEMPTS)
+    }) {
         return Err(NativeV2AdmissionError::Attempts {
             node: declaration.name.clone(),
             attempts: declaration.attempts,

--- a/zeroshot/src/native_v2_runner/state.rs
+++ b/zeroshot/src/native_v2_runner/state.rs
@@ -206,6 +206,12 @@ impl SessionPool {
         let mut entries = self.entries.lock().await;
         match entries.get(key) {
             Some(SessionEntry::Lost) => Err(NodeRunnerError::SessionLost),
+            Some(SessionEntry::Replaceable) => {
+                let (ready, _) = watch::channel(false);
+                let ready = Arc::new(ready);
+                entries.insert(key.clone(), SessionEntry::Opening(ready.clone()));
+                Ok(CheckoutAction::Open(ready))
+            }
             Some(SessionEntry::Live(session)) => Ok(CheckoutAction::Reuse(session.clone())),
             Some(SessionEntry::Opening(ready)) => Ok(CheckoutAction::Wait(ready.subscribe())),
             None => {
@@ -327,6 +333,16 @@ impl SessionPool {
         session.close().await;
     }
 
+    async fn replace_after_failure(&self, key: SessionKey, session: ManagedSession) {
+        let mut entries = self.entries.lock().await;
+        if matches!(entries.get(&key), Some(SessionEntry::Live(current)) if current.same(&session))
+        {
+            entries.insert(key, SessionEntry::Replaceable);
+        }
+        drop(entries);
+        session.close().await;
+    }
+
     pub(super) async fn close_run(&self, run_id: &RunId) {
         let mut entries = self.entries.lock().await;
         let keys = entries
@@ -339,7 +355,7 @@ impl SessionPool {
             .filter_map(|key| match entries.insert(key, SessionEntry::Lost) {
                 Some(SessionEntry::Live(session)) => Some(EntryToClose::Session(session)),
                 Some(SessionEntry::Opening(ready)) => Some(EntryToClose::Opening(ready)),
-                Some(SessionEntry::Lost) | None => None,
+                Some(SessionEntry::Replaceable | SessionEntry::Lost) | None => None,
             })
             .collect::<Vec<_>>();
         drop(entries);
@@ -393,6 +409,9 @@ struct SessionKey {
 enum SessionEntry {
     Opening(Arc<watch::Sender<bool>>),
     Live(ManagedSession),
+    /// The previous execution invalidated its session, so a reducer-authorized dispatch may
+    /// establish a replacement. Passive session loss remains permanently fail-closed.
+    Replaceable,
     Lost,
 }
 
@@ -407,7 +426,9 @@ impl SessionLease {
         match self.kind {
             SessionLeaseKind::Execution => self.session.close().await,
             SessionLeaseKind::NodeInstance(_) if clean => {}
-            SessionLeaseKind::NodeInstance(key) => self.pool.invalidate(key, self.session).await,
+            SessionLeaseKind::NodeInstance(key) => {
+                self.pool.replace_after_failure(key, self.session).await;
+            }
         }
     }
 }

--- a/zeroshot/src/native_v2_runner/tests.rs
+++ b/zeroshot/src/native_v2_runner/tests.rs
@@ -117,6 +117,30 @@ async fn a_lost_reused_session_fails_without_replacement() {
 }
 
 #[tokio::test]
+async fn closing_a_run_permanently_loses_a_replaceable_session() {
+    const RUN_NAME: &str = "run";
+
+    let factory = Arc::new(FakeFactory::default());
+    let pool = SessionPool::new(factory.clone());
+    let (_cancel, mut cancellation) = watch::channel(false);
+    let first = request(RUN_NAME, "looped", (1, 1));
+    pool.checkout(&first.invocation, &first.environment, &mut cancellation)
+        .await
+        .assert_value()
+        .finish(false)
+        .await;
+
+    pool.close_run(&RunId::new(RUN_NAME)).await;
+    let retry = request(RUN_NAME, "looped", (1, 2));
+    assert!(matches!(
+        pool.checkout(&retry.invocation, &retry.environment, &mut cancellation,)
+            .await,
+        Err(NodeRunnerError::SessionLost)
+    ));
+    assert_eq!(factory.opened.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn closing_a_run_closes_and_permanently_loses_its_reused_sessions() {
     let (runner, _, factory) = runner();
     runner

--- a/zeroshot/src/native_v2_supervisor/tests.rs
+++ b/zeroshot/src/native_v2_supervisor/tests.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 use std::time::Duration;
 
@@ -13,6 +14,7 @@ use serde_json::{Value, json};
 use super::*;
 use crate::native_v2_admission::NativeV2Admission;
 use crate::native_v2_contract::RunSubmission;
+use crate::execution::SessionScope;
 use crate::native_v2_runner::{
     DriverControl, DriverInvocation, LiveOutput, LiveOutputStream, NativeNodeRunner, NodeDriver,
     NodeRole, NodeSession, SessionFactory,
@@ -35,8 +37,10 @@ impl NodeSession for FakeSession {
     async fn close(&self) {}
 }
 
-#[derive(Clone, Default)]
-struct FakeSessionFactory;
+#[derive(Default)]
+struct FakeSessionFactory {
+    opened: AtomicUsize,
+}
 
 #[async_trait]
 impl SessionFactory for FakeSessionFactory {
@@ -45,6 +49,7 @@ impl SessionFactory for FakeSessionFactory {
         _invocation: &NodeInvocation,
         _environment: &ResolvedEnvironment,
     ) -> Result<Arc<dyn NodeSession>, NodeRunnerError> {
+        self.opened.fetch_add(1, Ordering::SeqCst);
         Ok(Arc::new(FakeSession))
     }
 }
@@ -55,6 +60,7 @@ enum Behavior {
         delay: Duration,
         outcome: WorkerOutcome,
     },
+    Fail(NodeRunnerError),
     Hang,
 }
 
@@ -163,6 +169,7 @@ impl NodeDriver for FakeDriver {
                 self.state().cancellations.push(node.clone());
                 Err(NodeRunnerError::Cancelled)
             }
+            Behavior::Fail(error) => Err(error),
         };
         self.state().active -= 1;
         result
@@ -195,6 +202,7 @@ struct Harness {
     supervisor: NativeV2Supervisor,
     ledger: Arc<FakeRunLedger>,
     driver: Arc<FakeDriver>,
+    sessions: Arc<FakeSessionFactory>,
 }
 
 #[derive(Clone, Default)]
@@ -254,6 +262,15 @@ impl LiveOutputRegistrar for RejectLiveRegistrar {
 }
 
 async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> Harness {
+    harness_with_session_scope(graph, initial_input, driver, SessionScope::Execution).await
+}
+
+async fn harness_with_session_scope(
+    graph: GraphSpec,
+    initial_input: Value,
+    driver: FakeDriver,
+    session_scope: SessionScope,
+) -> Harness {
     let runtime_nodes = executable_names(&graph.root)
         .into_iter()
         .map(|name| {
@@ -263,6 +280,7 @@ async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> 
                     "kind": "agent",
                     "model": "gpt-5.6",
                     "effort": "max",
+                    "sessionScope": session_scope,
                     "connections": {}
                 }),
             )
@@ -303,8 +321,9 @@ async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> 
         .await
         .assert_value_with("create run");
     let driver = Arc::new(driver);
+    let sessions = Arc::new(FakeSessionFactory::default());
     let runner = Arc::new(
-        NativeNodeRunner::new(&admitted, driver.clone(), Arc::new(FakeSessionFactory))
+        NativeNodeRunner::new(&admitted, driver.clone(), sessions.clone())
             .assert_value_with("runner"),
     );
     let environment = RunEnvironment::exact(&admitted.runtime, BTreeMap::new())
@@ -313,6 +332,7 @@ async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> 
         supervisor: NativeV2Supervisor::new(run_id, ledger.clone(), runner, Arc::new(environment)),
         ledger,
         driver,
+        sessions,
     }
 }
 

--- a/zeroshot/src/native_v2_supervisor/tests/cases_3.rs
+++ b/zeroshot/src/native_v2_supervisor/tests/cases_3.rs
@@ -1,5 +1,45 @@
 use super::*;
 
+#[tokio::test]
+async fn crashed_node_instance_verifier_retries_with_a_fresh_provider_session() {
+    const VERIFIER_ATTEMPTS: u64 = 2;
+
+    let mut verifier = verifier("review", 1_000);
+    verifier["attempts"] = json!(VERIFIER_ATTEMPTS);
+    let graph = graph(
+        sequence(vec![verifier, succeed("done")], null_type()),
+        null_type(),
+    );
+    let harness = harness_with_session_scope(
+        graph,
+        Value::Null,
+        FakeDriver::scripted([(
+            "review",
+            vec![
+                Behavior::Fail(NodeRunnerError::Driver),
+                Behavior::Complete {
+                    delay: Duration::ZERO,
+                    outcome: verifier_outcome("accepted"),
+                },
+            ],
+        )]),
+        SessionScope::NodeInstance,
+    )
+    .await;
+
+    assert_eq!(
+        harness.supervisor.drive().await.assert_value_with("drive"),
+        TerminalResult::Succeeded {
+            output: Value::Null
+        }
+    );
+    assert_eq!(harness.driver.starts("review"), VERIFIER_ATTEMPTS as usize);
+    assert_eq!(
+        harness.sessions.opened.load(Ordering::SeqCst),
+        VERIFIER_ATTEMPTS as usize
+    );
+}
+
 async fn seed_active_execution(ledger: &FakeRunLedger, run_id: &RunId) -> ExecutionRef {
     let reference = ExecutionRef {
         run_id: run_id.clone(),

--- a/zeroshot/src/native_v2_templates.rs
+++ b/zeroshot/src/native_v2_templates.rs
@@ -10,6 +10,7 @@ use openengine_cluster_protocol::{
 };
 
 use crate::native_v2_contract::{GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF};
+use crate::native_v2_admission::MAX_AGENT_VERIFIER_ATTEMPTS;
 use crate::native_v2_delivery::contract::{
     delivery_diagnostic_schema, delivery_result_schema, delivery_signal_labels,
 };
@@ -186,7 +187,7 @@ fn review_verifier(
         ],
         write_bindings: vec![diagnostic_write(name, feedback_target)?],
         timeout_ms: positive(NODE_TIMEOUT_MS)?,
-        attempts: positive(1)?,
+        attempts: positive(MAX_AGENT_VERIFIER_ATTEMPTS)?,
         signals,
         diagnostic: diagnostic_type()?,
         instructions: Some(instructions(authored_instructions)?),

--- a/zeroshot/src/native_v2_templates/tests.rs
+++ b/zeroshot/src/native_v2_templates/tests.rs
@@ -151,6 +151,92 @@ async fn rejected_parallel_reviews_dispatch_repair_with_both_diagnostics() {
 }
 
 #[tokio::test]
+async fn crashed_parallel_review_retries_only_the_failed_verifier() {
+    let (verified, initial_input) = verified_software_template(TemplateDelivery::None).await;
+    let review_input = json!({"task":"repair checkout","deliveryFeedback":""});
+    let history = [
+        settled_worker(),
+        settled_review(
+            2,
+            "acceptance",
+            REJECTED_LABEL,
+            "missing requested behavior",
+        ),
+        settled_failure(
+            SettledExecutionSpec {
+                execution: 3,
+                node_instance: 3,
+                node: "code",
+                settled_at: 3,
+                input: review_input,
+            },
+            WorkerErrorCode::Crash,
+        ),
+    ];
+    let reduction = reduce(&verified, &initial_input, &history);
+
+    assert_eq!(
+        reduction
+            .decisions
+            .iter()
+            .filter(|decision| matches!(decision, Decision::Dispatch { .. }))
+            .count(),
+        1
+    );
+    assert!(reduction.decisions.iter().any(|decision| matches!(
+        decision,
+        Decision::Dispatch { occurrence, attempt, input, .. }
+            if occurrence.node.as_str() == "code"
+                && attempt.get() == MAX_AGENT_VERIFIER_ATTEMPTS
+                && input == &json!({"task":"repair checkout","deliveryFeedback":""})
+    )));
+    assert!(reduction.terminal.is_none());
+}
+
+#[tokio::test]
+async fn repeatedly_crashed_parallel_review_fails_after_the_retry_limit() {
+    let (verified, initial_input) = verified_software_template(TemplateDelivery::None).await;
+    let review_input = json!({"task":"repair checkout","deliveryFeedback":""});
+    let history = [
+        settled_worker(),
+        settled_review(
+            2,
+            "acceptance",
+            REJECTED_LABEL,
+            "missing requested behavior",
+        ),
+        settled_failure(
+            SettledExecutionSpec {
+                execution: 3,
+                node_instance: 3,
+                node: "code",
+                settled_at: 3,
+                input: review_input.clone(),
+            },
+            WorkerErrorCode::Crash,
+        ),
+        settled_failure_attempt(
+            SettledExecutionSpec {
+                execution: 4,
+                node_instance: 3,
+                node: "code",
+                settled_at: 5,
+                input: review_input,
+            },
+            WorkerErrorCode::Crash,
+            MAX_AGENT_VERIFIER_ATTEMPTS,
+        ),
+    ];
+
+    assert_eq!(
+        reduce(&verified, &initial_input, &history).terminal,
+        Some(TerminalProjection::Failed {
+            reason: "review_failed".parse().assert_value()
+        })
+    );
+}
+
+#[tokio::test]
 async fn accepted_second_review_round_ignores_stale_sibling_verdicts() {
     let (verified, initial_input) = verified_software_template(TemplateDelivery::None).await;
     let review_input = json!({"task":"repair checkout","deliveryFeedback":""});

--- a/zeroshot/src/native_v2_templates/tests/support.rs
+++ b/zeroshot/src/native_v2_templates/tests/support.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use openengine_cluster_protocol::{
     EnumLabel, FieldName, NodeName, NodeRuntimeBinding, PositiveInteger, ReasoningEffort, RunSize,
     RuntimePlan, SessionScope, SourceBranchId, SourceRepositoryId, SourceRevisionId,
-    ResolvedSource, WorkerOutcome,
+    ResolvedSource, WorkerErrorCode, WorkerOutcome,
 };
 use openengine_cluster_server::graph_verifier::graph_node_children;
 use openengine_cluster_testkit::assertions::AssertValue;
@@ -109,6 +109,23 @@ pub(super) fn settled_agent(spec: SettledExecutionSpec<'_>) -> DurableExecution 
             artifacts: Vec::new(),
         },
     )
+}
+
+pub(super) fn settled_failure(
+    spec: SettledExecutionSpec<'_>,
+    code: WorkerErrorCode,
+) -> DurableExecution {
+    settled_execution(spec, WorkerOutcome::declared_failure(code))
+}
+
+pub(super) fn settled_failure_attempt(
+    spec: SettledExecutionSpec<'_>,
+    code: WorkerErrorCode,
+    attempt: u64,
+) -> DurableExecution {
+    let mut execution = settled_failure(spec, code);
+    execution.attempt = PositiveInteger::new(attempt).assert_value();
+    execution
 }
 
 pub(super) fn settled_review(

--- a/zeroshot/tests/full_v1_reducer/cases_2.rs
+++ b/zeroshot/tests/full_v1_reducer/cases_2.rs
@@ -99,6 +99,175 @@ async fn native_v2_loop_reuses_node_instance_with_fresh_attempt_one_executions()
 }
 
 #[tokio::test]
+async fn native_v2_retries_a_failed_execution_before_continuing() {
+    let graph = verified(
+        sequence("root", vec![verifier("check", 2), succeed("done")]),
+        json!({"check":2}),
+    )
+    .await;
+    let failed = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    let retry = FullV1Reducer::native_v2(&graph)
+        .reduce(ReductionInput {
+            initial_input: &json!({}),
+            executions: std::slice::from_ref(&failed),
+            next_node_instance: 2,
+            next_execution: 2,
+        })
+        .assert_value();
+    assert!(retry.decisions.iter().any(|decision| matches!(
+        decision,
+        Decision::Dispatch { node_instance, execution, attempt, .. }
+            if node_instance.get() == 1 && execution.get() == 2 && attempt.get() == 2
+    )));
+    assert!(retry.terminal.is_none());
+
+    let succeeded = settled(
+        SettledSpec::new(2, 1, "check").attempt(2).position(6),
+        verdict("accepted"),
+    );
+    assert!(matches!(
+        FullV1Reducer::native_v2(&graph)
+            .reduce(ReductionInput {
+                initial_input: &json!({}),
+                executions: &[failed, succeeded],
+                next_node_instance: 2,
+                next_execution: 3,
+            })
+            .assert_value()
+            .terminal,
+        Some(TerminalProjection::Succeeded { .. })
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_a_retry_that_does_not_follow_an_error() {
+    let graph = verified(
+        sequence("root", vec![verifier("check", 2), succeed("done")]),
+        json!({"check":2}),
+    )
+    .await;
+    let history = [
+        settled(
+            SettledSpec::new(1, 1, "check").position(3),
+            verdict("accepted"),
+        ),
+        settled(
+            SettledSpec::new(2, 1, "check").attempt(2).position(6),
+            verdict("accepted"),
+        ),
+    ];
+
+    assert!(matches!(
+        FullV1Reducer::native_v2(&graph).reduce(ReductionInput {
+            initial_input: &json!({}),
+            executions: &history,
+            next_node_instance: 2,
+            next_execution: 3,
+        }),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_a_retry_visit_with_mismatched_prior_input() {
+    let graph = verified(
+        sequence("root", vec![verifier("check", 2), succeed("done")]),
+        json!({"check":2}),
+    )
+    .await;
+    let mut failed = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    failed.input = json!({"unexpected":true});
+    let succeeded = settled(
+        SettledSpec::new(2, 1, "check").attempt(2).position(6),
+        verdict("accepted"),
+    );
+
+    assert!(matches!(
+        FullV1Reducer::native_v2(&graph).reduce(ReductionInput {
+            initial_input: &json!({}),
+            executions: &[failed, succeeded],
+            next_node_instance: 2,
+            next_execution: 3,
+        }),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_a_retry_dispatched_before_the_failure_settled() {
+    let graph = verified(
+        sequence("root", vec![verifier("check", 2), succeed("done")]),
+        json!({"check":2}),
+    )
+    .await;
+    let mut failed = settled(
+        SettledSpec::new(1, 1, "check").position(5),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    failed.dispatch_position = HistoryPosition::new(1).assert_value();
+    let retry = settled(
+        SettledSpec::new(2, 1, "check").attempt(2).position(4),
+        verdict("accepted"),
+    );
+
+    assert!(matches!(
+        FullV1Reducer::native_v2(&graph).reduce(ReductionInput {
+            initial_input: &json!({}),
+            executions: &[failed, retry],
+            next_node_instance: 2,
+            next_execution: 3,
+        }),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_invalid_initial_and_excess_attempts() {
+    let graph = verified(
+        sequence("root", vec![verifier("check", 1), succeed("done")]),
+        json!({"check":1}),
+    )
+    .await;
+    let invalid_initial = settled(
+        SettledSpec::new(1, 1, "check").attempt(2).position(3),
+        verdict("accepted"),
+    );
+    assert!(matches!(
+        FullV1Reducer::native_v2(&graph).reduce(ReductionInput {
+            initial_input: &json!({}),
+            executions: &[invalid_initial],
+            next_node_instance: 2,
+            next_execution: 2,
+        }),
+        Err(ReducerError::InconsistentHistory)
+    ));
+
+    let failed = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    let excess_attempt = settled(
+        SettledSpec::new(2, 1, "check").attempt(2).position(6),
+        verdict("accepted"),
+    );
+    assert!(matches!(
+        FullV1Reducer::native_v2(&graph).reduce(ReductionInput {
+            initial_input: &json!({}),
+            executions: &[failed, excess_attempt],
+            next_node_instance: 2,
+            next_execution: 3,
+        }),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+#[tokio::test]
 async fn map_is_input_ordered_total_and_assigns_stable_nested_indices() {
     let state = required_array_record(&[("outerItems", "null"), ("innerItems", "null")]);
     let nested = json!({

--- a/zeroshot/tests/full_v1_reducer/cases_2.rs
+++ b/zeroshot/tests/full_v1_reducer/cases_2.rs
@@ -172,6 +172,32 @@ async fn native_v2_rejects_a_retry_that_does_not_follow_an_error() {
 }
 
 #[tokio::test]
+async fn native_v2_does_not_retry_a_non_crash_error() {
+    let graph = verified(
+        sequence("root", vec![verifier("check", 2), succeed("done")]),
+        json!({"check":2}),
+    )
+    .await;
+    let timed_out = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Timeout),
+    );
+    let reduction = FullV1Reducer::native_v2(&graph)
+        .reduce(ReductionInput {
+            initial_input: &json!({}),
+            executions: std::slice::from_ref(&timed_out),
+            next_node_instance: 2,
+            next_execution: 2,
+        })
+        .assert_value();
+
+    assert!(!reduction.decisions.iter().any(|decision| matches!(
+        decision,
+        Decision::Dispatch { occurrence, .. } if occurrence.node.as_str() == "check"
+    )));
+}
+
+#[tokio::test]
 async fn native_v2_rejects_a_retry_visit_with_mismatched_prior_input() {
     let graph = verified(
         sequence("root", vec![verifier("check", 2), succeed("done")]),


### PR DESCRIPTION
## Summary

- retry a crashed software-change verifier execution once without redispatching settled sibling verifiers, while leaving non-crash errors terminal
- replace provider sessions invalidated by an active execution failure while keeping passive session loss and run closure fail-closed
- validate retry lineage and causality, while preserving `review_failed` after retry exhaustion

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- instrumented focused reducer, admission, template, runner, and supervisor suites (77 tests)
- real supervisor-to-runner RED -> GREEN -> reverted RED proof with two provider starts and two sessions
- workspace replay: 433 passing, with only the same three environment-dependent container-hosting failures observed at baseline
- strict rustdoc, optimized locked binary build/version smoke, and generated-protocol consistency check
- 100% changed-line coverage (197/197 executable lines)
- independent Codex acceptance and code-quality reviews: approved with no findings

Fixes #1067
