### PR TITLE
feat: generate pull request metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,11 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 - GitHub delivery treats aggregate merge policy and required contexts as authority, waits through
   merge queues/deferrals, and succeeds only after observing the exact merged result. Outside merge
   queues, branch freshness advances only through an authorized compare-and-swap response.
+- Delivery-enabled software-change templates make the acceptance verifier the sole author of the
+  current change title and description after every review pass. Git delivery uses that manifest for
+  commits and reviews, refreshes only its marker-delimited body section while preserving surrounding
+  text. Verifier guidance reserves closing references for delivery, which appends them only from
+  caller-owned issue input.
 - GitHub review creation and rediscovery are shared by pull-request and merge delivery. They verify
   the exact pushed ref and head, retry bounded transient visibility or API failures, refresh a
   dynamic credential once on HTTP 401/403 within the synchronization deadline and cancellation

--- a/zeroshot/src/native_v2_cli/execution.rs
+++ b/zeroshot/src/native_v2_cli/execution.rs
@@ -1,4 +1,6 @@
+use std::future::Future;
 use std::io::Write;
+use std::pin::Pin;
 use std::time::Duration;
 
 use openengine_cluster_protocol::{
@@ -372,6 +374,31 @@ enum DurableItem {
     Closed(SubscriptionCloseReason),
 }
 
+enum SubscriptionStep<E> {
+    Detached,
+    Reconnect,
+    Item(Option<E>),
+}
+
+async fn next_or_detach<E, N, D>(
+    next: N,
+    mut detach: Pin<&mut D>,
+) -> Result<SubscriptionStep<E>, NativeV2CliError>
+where
+    N: Future<Output = Result<Option<E>, NativeV2CliError>>,
+    D: Future<Output = ()> + ?Sized,
+{
+    tokio::select! {
+        biased;
+        () = detach.as_mut() => Ok(SubscriptionStep::Detached),
+        item = next => match item {
+            Ok(item) => Ok(SubscriptionStep::Item(item)),
+            Err(NativeV2CliError::Disconnected) => Ok(SubscriptionStep::Reconnect),
+            Err(error) => Err(error),
+        },
+    }
+}
+
 impl DurableItem {
     fn cursor(&self) -> Option<&Cursor> {
         match self {
@@ -394,9 +421,12 @@ where
 {
     let mut from_cursor = follow.initial_cursor.clone();
     let mut opened = false;
+    let detach = signal.wait();
+    tokio::pin!(detach);
     loop {
         let subscription = tokio::select! {
-            () = signal.wait() => return Ok(CliOutcome::Detached),
+            biased;
+            () = &mut detach => return Ok(CliOutcome::Detached),
             result = follow.open(from_cursor.clone()) => match result {
                 Ok(subscription) => {
                     opened = true;
@@ -412,23 +442,23 @@ where
         };
         let mut subscription = subscription;
         loop {
-            let item = tokio::select! {
-                () = signal.wait() => return Ok(CliOutcome::Detached),
-                item = subscription.next() => item,
-            };
-            match item {
-                Ok(Some(DurableItem::Closed(SubscriptionCloseReason::Done))) => {
+            match next_or_detach(subscription.next(), detach.as_mut()).await? {
+                SubscriptionStep::Detached => return Ok(CliOutcome::Detached),
+                SubscriptionStep::Item(Some(DurableItem::Closed(
+                    SubscriptionCloseReason::Done,
+                ))) => {
                     return Ok(follow.kind.done_outcome());
                 }
-                Ok(Some(DurableItem::Closed(SubscriptionCloseReason::SlowConsumer)))
-                | Ok(None)
-                | Err(NativeV2CliError::Disconnected) => break,
-                Ok(Some(event)) => {
+                SubscriptionStep::Item(Some(DurableItem::Closed(
+                    SubscriptionCloseReason::SlowConsumer,
+                )))
+                | SubscriptionStep::Item(None)
+                | SubscriptionStep::Reconnect => break,
+                SubscriptionStep::Item(Some(event)) => {
                     if let Some(outcome) = write_durable_event(event, &mut from_cursor, output)? {
                         return Ok(outcome);
                     }
                 }
-                Err(error) => return Err(error),
             }
         }
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/zeroshot/src/native_v2_cli/execution/attach.rs
+++ b/zeroshot/src/native_v2_cli/execution/attach.rs
@@ -8,7 +8,7 @@ use super::super::{
     NativeV2CliError,
 };
 
-use super::write_json;
+use super::{SubscriptionStep, next_or_detach, write_json};
 
 pub(super) struct RoutedAttach<'a> {
     pub(super) target: Option<&'a str>,
@@ -27,9 +27,12 @@ where
     W: Write,
 {
     let RoutedAttach { target, params } = route;
+    let detach = signal.wait();
+    tokio::pin!(detach);
     loop {
         let mut subscription = tokio::select! {
-            () = signal.wait() => return Ok(CliOutcome::Detached),
+            biased;
+            () = &mut detach => return Ok(CliOutcome::Detached),
             result = backend.run_attach(target, params.clone()) => match result {
                 Ok(subscription) => subscription,
                 Err(NativeV2CliError::Disconnected) => {
@@ -40,25 +43,25 @@ where
             },
         };
         loop {
-            let item = tokio::select! {
-                () = signal.wait() => return Ok(CliOutcome::Detached),
-                item = subscription.next() => item,
-            };
-            match item {
-                Ok(Some(CliSubscriptionItem::Event(event))) => write_json(output, &event)?,
-                Ok(Some(CliSubscriptionItem::Closed {
+            let step = next_or_detach(subscription.next(), detach.as_mut()).await?;
+            match step {
+                SubscriptionStep::Detached => return Ok(CliOutcome::Detached),
+                SubscriptionStep::Item(Some(CliSubscriptionItem::Event(event))) => {
+                    write_json(output, &event)?;
+                }
+                SubscriptionStep::Item(Some(CliSubscriptionItem::Closed {
                     reason: SubscriptionCloseReason::Done,
                 })) => return Ok(CliOutcome::Completed),
-                Ok(Some(CliSubscriptionItem::Closed {
+                SubscriptionStep::Item(Some(CliSubscriptionItem::Closed {
                     reason: SubscriptionCloseReason::SlowConsumer,
                 }))
-                | Ok(None)
-                | Err(NativeV2CliError::Disconnected) => break,
-                Err(error) => return Err(error),
+                | SubscriptionStep::Item(None)
+                | SubscriptionStep::Reconnect => break,
             }
         }
         tokio::select! {
-            () = signal.wait() => return Ok(CliOutcome::Detached),
+            biased;
+            () = &mut detach => return Ok(CliOutcome::Detached),
             () = tokio::time::sleep(Duration::from_millis(100)) => {}
         }
     }

--- a/zeroshot/src/native_v2_cli/tests.rs
+++ b/zeroshot/src/native_v2_cli/tests.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::ffi::OsString;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use openengine_cluster_protocol::{RunTitle, RuntimePlan};
@@ -28,6 +29,37 @@ use support::*;
 
 fn args(values: &[&str]) -> Vec<OsString> {
     values.iter().map(OsString::from).collect()
+}
+
+struct EdgeDetachSignal {
+    notification: tokio::sync::watch::Sender<()>,
+}
+
+#[async_trait::async_trait]
+impl DetachSignal for EdgeDetachSignal {
+    async fn wait(&mut self) {
+        let mut receiver = self.notification.subscribe();
+        let _ = receiver.changed().await;
+    }
+}
+
+struct NotifyingOutput {
+    notification: Option<tokio::sync::watch::Sender<()>>,
+    bytes: Vec<u8>,
+}
+
+impl Write for NotifyingOutput {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.bytes.extend_from_slice(bytes);
+        if let Some(notification) = self.notification.take() {
+            let _ = notification.send(());
+        }
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 fn assert_cursor_calls(calls: &[Call], kind: CursorCallKind, expected: &[Option<&str>]) {
@@ -336,6 +368,37 @@ async fn ctrl_c_detaches_observation_without_force_stop() {
             .iter()
             .any(|call| matches!(call, Call::Force { .. }))
     );
+}
+
+#[tokio::test]
+async fn detach_notification_survives_a_completed_subscription_branch() {
+    let backend = FakeBackend::with_reconnecting_watch();
+    let (notification, _receiver) = tokio::sync::watch::channel(());
+    let mut signal = EdgeDetachSignal {
+        notification: notification.clone(),
+    };
+    let mut output = NotifyingOutput {
+        notification: Some(notification),
+        bytes: Vec::new(),
+    };
+    let command =
+        parse_native_v2_args(args(&["watch", "run-public", "--target", "prod"])).assert_value();
+
+    let outcome = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        execute_native_v2_cli(command, &backend, &mut signal, &mut output),
+    )
+    .await
+    .expect("detach notification remains observable")
+    .assert_value();
+
+    assert_eq!(outcome, CliOutcome::Detached);
+    assert!(
+        String::from_utf8(output.bytes)
+            .assert_value()
+            .contains("\"cursor\":\"v2:1\"")
+    );
+    assert_cursor_calls(&backend.calls(), CursorCallKind::Watch, &[None]);
 }
 
 #[tokio::test]

--- a/zeroshot/src/native_v2_cli/tests.rs
+++ b/zeroshot/src/native_v2_cli/tests.rs
@@ -226,6 +226,10 @@ fn template_list_and_show_are_static_and_emit_ordinary_json() {
         shown.pointer("/initialInput/fields/task/required"),
         Some(&json!(true))
     );
+    assert_eq!(
+        shown.pointer("/initialInput/fields/issueNumber/required"),
+        Some(&json!(false))
+    );
     assert!(
         shown
             .pointer("/initialInput/fields/acceptanceFeedback")
@@ -243,6 +247,12 @@ fn template_list_and_show_are_static_and_emit_ordinary_json() {
         shown.pointer("/root/state/fields/deliveryFeedback/required"),
         Some(&json!(true))
     );
+    for field in ["title", "description", "issueNumber"] {
+        assert_eq!(
+            shown.pointer(&format!("/root/state/fields/{field}/required")),
+            Some(&json!(true))
+        );
+    }
     assert!(shown.to_string().contains("builtin.git-delivery.pr@1"));
     assert!(backend.calls().is_empty());
 }

--- a/zeroshot/src/native_v2_cli/tests/environment.rs
+++ b/zeroshot/src/native_v2_cli/tests/environment.rs
@@ -80,7 +80,7 @@ async fn assert_declared_environment_rejected(
 async fn template_run_preserves_authored_input_and_owned_delivery_binding() {
     let files = FixtureFiles::with_runtime(
         graph(),
-        json!({"task":"ship it"}),
+        json!({"task":"ship it","issueNumber":"208"}),
         software_change_runtime(),
     );
     let command = parse_native_v2_args(args(&[
@@ -120,13 +120,14 @@ async fn template_run_preserves_authored_input_and_owned_delivery_binding() {
     }
     .assert_value();
     assert_eq!(submitted.1.pointer("/task"), Some(&json!("ship it")));
+    assert_eq!(submitted.1.pointer("/issueNumber"), Some(&json!("208")));
     assert!(submitted.1.pointer("/acceptanceFeedback").is_none());
     assert!(submitted.1.pointer("/codeFeedback").is_none());
     assert!(submitted.1.pointer("/deliveryFeedback").is_none());
     let authored_input = std::fs::read(&files.input).assert_value();
     assert_eq!(
         serde_json::from_slice::<serde_json::Value>(&authored_input).assert_value(),
-        json!({"task":"ship it"})
+        json!({"task":"ship it","issueNumber":"208"})
     );
 
     let runtime = serde_json::to_value(submitted.0).assert_value();

--- a/zeroshot/src/native_v2_delivery.rs
+++ b/zeroshot/src/native_v2_delivery.rs
@@ -234,6 +234,8 @@ pub struct GitHubReviewRequest {
     pub target: DeliveryTarget,
     pub head_branch: String,
     pub head_revision: String,
+    pub title: String,
+    pub description: String,
     pub source_issue: Option<GitHubSourceIssue>,
 }
 

--- a/zeroshot/src/native_v2_delivery/adapter.rs
+++ b/zeroshot/src/native_v2_delivery/adapter.rs
@@ -4,7 +4,7 @@ mod head;
 mod input;
 mod review;
 mod sync;
-use input::source_issue;
+use input::delivery_input;
 use review::{crash_outcome, review_completion, ReviewProgress, ReviewStep};
 
 #[derive(Clone)]
@@ -214,15 +214,17 @@ impl NativeV2DeliveryAdapter {
         &self,
         preparation: DeliveryPreparation<'_, '_>,
     ) -> Result<GitHubReviewReceipt, DeliveryStop> {
-        let source_issue = source_issue(&preparation.invocation.node.input)?;
+        let input = delivery_input(&preparation.invocation.node.input)?;
         let head_revision = self
-            .prepare_head(preparation.session, preparation.control)
+            .prepare_head(preparation.session, preparation.control, &input.title)
             .await?;
         let review_request = GitHubReviewRequest {
             target: self.config.target.clone(),
             head_branch: delivery_branch(preparation.invocation.node.reference.run_id.as_str()),
             head_revision,
-            source_issue,
+            title: input.title,
+            description: input.description,
+            source_issue: input.source_issue,
         };
         self.push_review_head(&preparation, &review_request).await?;
         let review = self
@@ -247,11 +249,16 @@ impl NativeV2DeliveryAdapter {
         &self,
         session: &DeliverySession,
         control: &DriverControl,
+        commit_message: &str,
     ) -> Result<String, DeliveryStop> {
         emit(control, "delivery: preparing workspace revision").await?;
         match self
             .git
-            .prepare_revision(&session.workspace, &self.config.target.base_revision)
+            .prepare_revision(
+                &session.workspace,
+                &self.config.target.base_revision,
+                commit_message,
+            )
             .await
         {
             Ok(revision) => Ok(revision),

--- a/zeroshot/src/native_v2_delivery/adapter/input.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/input.rs
@@ -1,49 +1,157 @@
 use serde::Deserialize;
 
 use super::*;
+use crate::native_v2_delivery::github::valid_generated_description;
+
+const LEGACY_TITLE: &str = "feat: complete Zeroshot task";
+const LEGACY_DESCRIPTION: &str = "Created by Zeroshot v2.";
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-struct DeliveryInput {
+struct ManifestInput {
+    title: String,
+    description: String,
+    issue_number: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct LegacyIssueInput {
     issue_number: String,
 }
 
-pub(super) fn source_issue(input: &Value) -> Result<Option<GitHubSourceIssue>, DeliveryStop> {
+pub(super) struct PreparedDeliveryInput {
+    pub(super) title: String,
+    pub(super) description: String,
+    pub(super) source_issue: Option<GitHubSourceIssue>,
+}
+
+pub(super) fn delivery_input(input: &Value) -> Result<PreparedDeliveryInput, DeliveryStop> {
     if input.is_null() {
-        return Ok(None);
+        return Ok(legacy_input(None));
     }
-    let input: DeliveryInput = serde_json::from_value(input.clone())
-        .map_err(|_| DeliveryStop::Outcome(WorkerOutcome::malformed()))?;
-    let number = input
-        .issue_number
+    if let Ok(input) = serde_json::from_value::<ManifestInput>(input.clone()) {
+        if !valid_generated_description(&input.description) {
+            return Err(DeliveryStop::Outcome(WorkerOutcome::malformed()));
+        }
+        return Ok(PreparedDeliveryInput {
+            title: input.title,
+            description: input.description,
+            source_issue: optional_source_issue(input.issue_number.as_deref())?,
+        });
+    }
+    let input: LegacyIssueInput = malformed(serde_json::from_value(input.clone()))?;
+    Ok(legacy_input(Some(parse_source_issue(&input.issue_number)?)))
+}
+
+fn legacy_input(source_issue: Option<GitHubSourceIssue>) -> PreparedDeliveryInput {
+    PreparedDeliveryInput {
+        title: LEGACY_TITLE.to_owned(),
+        description: LEGACY_DESCRIPTION.to_owned(),
+        source_issue,
+    }
+}
+
+fn optional_source_issue(value: Option<&str>) -> Result<Option<GitHubSourceIssue>, DeliveryStop> {
+    let Some(value) = value.filter(|value| !value.is_empty()) else {
+        return Ok(None);
+    };
+    parse_source_issue(value).map(Some)
+}
+
+fn parse_source_issue(value: &str) -> Result<GitHubSourceIssue, DeliveryStop> {
+    let number = value
         .parse::<u64>()
         .ok()
-        .filter(|number| *number > 0 && number.to_string() == input.issue_number)
+        .filter(|number| *number > 0 && number.to_string() == value)
         .ok_or_else(|| DeliveryStop::Outcome(WorkerOutcome::malformed()))?;
-    Ok(Some(GitHubSourceIssue { number }))
+    Ok(GitHubSourceIssue { number })
+}
+
+fn malformed<T>(result: Result<T, serde_json::Error>) -> Result<T, DeliveryStop> {
+    result.map_err(|_| DeliveryStop::Outcome(WorkerOutcome::malformed()))
 }
 
 #[cfg(test)]
 mod tests {
+    use openengine_cluster_testkit::assertions::AssertValue;
     use serde_json::json;
 
     use super::*;
 
     #[test]
-    fn accepts_null_or_one_canonical_positive_issue_number() {
-        assert_eq!(source_issue(&Value::Null).ok(), Some(None));
+    fn accepts_manifest_with_optional_canonical_issue_number() {
+        let without_issue = delivery_input(&json!({
+            "title": "fix: repair checkout",
+            "description": "Repair the checkout flow."
+        }))
+        .assert_value();
+        assert_eq!(without_issue.title, "fix: repair checkout");
+        assert_eq!(without_issue.description, "Repair the checkout flow.");
+        assert_eq!(without_issue.source_issue, None);
+
+        let with_issue = delivery_input(&json!({
+            "title": "fix: repair checkout",
+            "description": "Repair the checkout flow.",
+            "issueNumber": "208"
+        }))
+        .assert_value();
         assert_eq!(
-            source_issue(&json!({"issueNumber":"208"})).ok(),
-            Some(Some(GitHubSourceIssue { number: 208 }))
+            with_issue.source_issue,
+            Some(GitHubSourceIssue { number: 208 })
         );
+        assert_eq!(
+            delivery_input(&json!({
+                "title": "fix: repair checkout",
+                "description": "Repair the checkout flow.",
+                "issueNumber": ""
+            }))
+            .assert_value()
+            .source_issue,
+            None
+        );
+    }
+
+    #[test]
+    fn accepts_legacy_null_and_issue_only_inputs() {
+        let null = delivery_input(&Value::Null).assert_value();
+        assert_eq!(null.title, LEGACY_TITLE);
+        assert_eq!(null.description, LEGACY_DESCRIPTION);
+        assert_eq!(null.source_issue, None);
+        assert_eq!(
+            delivery_input(&json!({"issueNumber":"208"}))
+                .assert_value()
+                .source_issue,
+            Some(GitHubSourceIssue { number: 208 })
+        );
+    }
+
+    #[test]
+    fn rejects_partial_manifests_noncanonical_issues_and_unknown_fields() {
         for malformed in [
             json!({}),
+            json!({"title":"fix: repair checkout"}),
+            json!({"description":"Repair the checkout flow."}),
             json!({"issueNumber":208}),
             json!({"issueNumber":"0"}),
+            json!({"issueNumber":""}),
             json!({"issueNumber":"0208"}),
             json!({"issueNumber":"208","extra":true}),
+            json!({
+                "title":"fix: repair checkout",
+                "description":"Repair the checkout flow.",
+                "extra":true
+            }),
+            json!({
+                "title":"fix: repair checkout",
+                "description":"<!-- zeroshot-delivery:generated:v1:start -->"
+            }),
+            json!({
+                "title":"fix: repair checkout",
+                "description":"<!-- zeroshot-delivery:generated:v1:end -->"
+            }),
         ] {
-            assert!(source_issue(&malformed).is_err());
+            assert!(delivery_input(&malformed).is_err());
         }
     }
 }

--- a/zeroshot/src/native_v2_delivery/git.rs
+++ b/zeroshot/src/native_v2_delivery/git.rs
@@ -5,8 +5,6 @@ use tokio::process::Command;
 
 use super::valid_revision;
 
-const COMMIT_MESSAGE: &str = "feat: complete Zeroshot task";
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum GitError {
     NoMutation,
@@ -27,6 +25,7 @@ impl SystemGit {
         &self,
         workspace: &Path,
         base_revision: &str,
+        commit_message: &str,
     ) -> Result<String, GitError> {
         self.require_success(workspace, &["add", "--all"]).await?;
         let staged = self
@@ -45,7 +44,7 @@ impl SystemGit {
                         "commit",
                         "--no-verify",
                         "--message",
-                        COMMIT_MESSAGE,
+                        commit_message,
                     ],
                 )
                 .await?;
@@ -122,5 +121,36 @@ impl SystemGit {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
         command
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_testkit::assertions::AssertValue;
+
+    use super::*;
+    use crate::native_v2_candidate::test_support::{TestGitRepository, git_output};
+
+    #[tokio::test]
+    async fn uses_manifest_title_as_the_commit_message() {
+        let repository = TestGitRepository::delivery();
+        let git = SystemGit::new(PathBuf::from("/usr/bin/git"));
+
+        let revision = git
+            .prepare_revision(
+                &repository.workspace,
+                &repository.base,
+                "fix: repair checkout",
+            )
+            .await
+            .assert_value();
+
+        assert_eq!(
+            git_output(
+                &repository.workspace,
+                &["show", "--no-patch", "--format=%s", &revision]
+            ),
+            "fix: repair checkout"
+        );
     }
 }

--- a/zeroshot/src/native_v2_delivery/github.rs
+++ b/zeroshot/src/native_v2_delivery/github.rs
@@ -16,11 +16,10 @@ use super::{
 };
 
 mod api;
+mod metadata;
 
 const DEFAULT_API_DEADLINE: Duration = Duration::from_secs(2 * 60);
 const DEFAULT_PUSH_DEADLINE: Duration = Duration::from_secs(10 * 60);
-const PULL_REQUEST_TITLE: &str = "feat: complete Zeroshot task";
-const PULL_REQUEST_BODY: &str = "Created by Zeroshot v2.";
 
 #[derive(Clone, Debug)]
 pub struct GhCliAuthorityConfig {
@@ -99,6 +98,7 @@ impl GhCliDeliveryAuthority {
         request: &GitHubReviewRequest,
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubReviewReceipt, GitHubAuthorityError> {
+        let body = pull_request_body(request)?;
         let value = self
             .api(
                 &[
@@ -106,9 +106,9 @@ impl GhCliDeliveryAuthority {
                     "--method".to_owned(),
                     "POST".to_owned(),
                     "-f".to_owned(),
-                    format!("title={PULL_REQUEST_TITLE}"),
+                    format!("title={}", request.title),
                     "-f".to_owned(),
-                    format!("body={}", pull_request_body(request)),
+                    format!("body={body}"),
                     "-f".to_owned(),
                     format!("head={}", request.head_branch),
                     "-f".to_owned(),
@@ -117,8 +117,63 @@ impl GhCliDeliveryAuthority {
                 credential,
             )
             .await?;
-        let review = serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
+        let review: PullRequestWire =
+            serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
+        if review.title.as_deref() != Some(request.title.as_str())
+            || review.body.as_deref() != Some(body.as_str())
+        {
+            return Err(GitHubAuthorityError::Rejected);
+        }
         review_receipt(review, request)
+    }
+
+    async fn refresh_review_metadata(
+        &self,
+        request: &GitHubReviewRequest,
+        review: &GitHubReviewReceipt,
+        credential: GitHubCredential<'_>,
+    ) -> Result<(), GitHubAuthorityError> {
+        let mut wire = self.pull_request(review, credential).await?;
+        require_review_identity(&wire, review)?;
+        let body = refresh_generated_body(wire.body.as_deref(), &request.description)?;
+        if wire.title.as_deref() == Some(request.title.as_str())
+            && wire.body.as_deref() == Some(body.as_str())
+        {
+            return Ok(());
+        }
+        wire = self
+            .patch_review(
+                review,
+                &[format!("title={}", request.title), format!("body={body}")],
+                credential,
+            )
+            .await?;
+        if wire.title.as_deref() != Some(request.title.as_str())
+            || wire.body.as_deref() != Some(body.as_str())
+        {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        Ok(())
+    }
+
+    async fn patch_review(
+        &self,
+        review: &GitHubReviewReceipt,
+        fields: &[String],
+        credential: GitHubCredential<'_>,
+    ) -> Result<PullRequestWire, GitHubAuthorityError> {
+        let mut arguments = vec![
+            format!("repos/{}/pulls/{}", review.repository, review.review_id),
+            "--method".to_owned(),
+            "PATCH".to_owned(),
+        ];
+        for field in fields {
+            arguments.extend(["-f".to_owned(), field.clone()]);
+        }
+        let value = self.api(&arguments, credential).await?;
+        let wire = serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
+        require_review_identity(&wire, review)?;
+        Ok(wire)
     }
 
     async fn policy_snapshot(
@@ -218,7 +273,11 @@ impl GitHubDeliveryAuthority for GhCliDeliveryAuthority {
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubReviewReceipt, GitHubAuthorityError> {
         let review = match self.find_review(request, credential).await? {
-            Some(review) => Ok(review),
+            Some(review) => {
+                self.refresh_review_metadata(request, &review, credential)
+                    .await?;
+                Ok(review)
+            }
             None => {
                 self.confirm_review_head(request, credential).await?;
                 self.create_review(request, credential).await
@@ -347,10 +406,29 @@ mod head;
 mod policy;
 mod source_issue;
 mod wire;
+use metadata::refresh_generated_body;
+pub(super) use metadata::valid_generated_description;
 use policy::{PolicySnapshot, classify_policy, include_check_logs, query_arguments};
 use source_issue::{connect_source_issue, pull_request_body};
 use api::check_log_tail;
-use wire::{PullRequestWire, review_receipt};
+use wire::{PullRequestWire, require_review_identity, review_receipt};
+
+#[cfg(test)]
+pub(super) fn test_review_request() -> GitHubReviewRequest {
+    GitHubReviewRequest {
+        target: super::DeliveryTarget::new(
+            "acme/project",
+            "main",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .expect("valid test delivery target"),
+        head_branch: "zeroshot/v2-run".to_owned(),
+        head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+        title: "fix: repair checkout".to_owned(),
+        description: "Repair the checkout flow.".to_owned(),
+        source_issue: None,
+    }
+}
 
 fn clean_command(
     config: &GhCliAuthorityConfig,

--- a/zeroshot/src/native_v2_delivery/github/metadata.rs
+++ b/zeroshot/src/native_v2_delivery/github/metadata.rs
@@ -1,0 +1,114 @@
+use std::ops::Range;
+
+use super::GitHubAuthorityError;
+
+const GENERATED_BODY_START: &str = "<!-- zeroshot-delivery:generated:v1:start -->";
+const GENERATED_BODY_END: &str = "<!-- zeroshot-delivery:generated:v1:end -->";
+
+pub(in crate::native_v2_delivery) fn valid_generated_description(description: &str) -> bool {
+    !description.contains(GENERATED_BODY_START) && !description.contains(GENERATED_BODY_END)
+}
+
+pub(super) fn generated_body(description: &str) -> Result<String, GitHubAuthorityError> {
+    valid_generated_description(description)
+        .then(|| format!("{GENERATED_BODY_START}\n{description}\n{GENERATED_BODY_END}"))
+        .ok_or(GitHubAuthorityError::Rejected)
+}
+
+pub(super) fn refresh_generated_body(
+    current: Option<&str>,
+    description: &str,
+) -> Result<String, GitHubAuthorityError> {
+    let generated = generated_body(description)?;
+    let Some(current) = current.filter(|body| !body.is_empty()) else {
+        return Ok(generated);
+    };
+    let Some(range) = generated_body_range(current)? else {
+        return Ok(format!("{current}\n\n{generated}"));
+    };
+    let mut refreshed = String::with_capacity(current.len() - range.len() + generated.len());
+    refreshed.push_str(&current[..range.start]);
+    refreshed.push_str(&generated);
+    refreshed.push_str(&current[range.end..]);
+    Ok(refreshed)
+}
+
+fn generated_body_range(body: &str) -> Result<Option<Range<usize>>, GitHubAuthorityError> {
+    let starts = body.match_indices(GENERATED_BODY_START).collect::<Vec<_>>();
+    let ends = body.match_indices(GENERATED_BODY_END).collect::<Vec<_>>();
+    match (starts.as_slice(), ends.as_slice()) {
+        ([], []) => Ok(None),
+        ([(start, _)], [(end, _)]) if start < end => {
+            Ok(Some(*start..end + GENERATED_BODY_END.len()))
+        }
+        _ => Err(GitHubAuthorityError::Rejected),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creates_and_replaces_generated_section() {
+        let original = generated_body("Original description.").unwrap();
+        assert_eq!(
+            refresh_generated_body(Some(&original), "Updated description.").unwrap(),
+            generated_body("Updated description.").unwrap()
+        );
+        assert_eq!(
+            refresh_generated_body(None, "New description.").unwrap(),
+            generated_body("New description.").unwrap()
+        );
+    }
+
+    #[test]
+    fn preserves_human_text_outside_generated_section() {
+        let current = format!(
+            "Human preface.\n\n{}\n\nHuman notes.",
+            generated_body("Old description.").unwrap()
+        );
+        assert_eq!(
+            refresh_generated_body(Some(&current), "New description.").unwrap(),
+            format!(
+                "Human preface.\n\n{}\n\nHuman notes.",
+                generated_body("New description.").unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn appends_section_to_unmanaged_body() {
+        assert_eq!(
+            refresh_generated_body(Some("Human-authored body."), "Generated description.").unwrap(),
+            format!(
+                "Human-authored body.\n\n{}",
+                generated_body("Generated description.").unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_missing_duplicate_or_misordered_markers() {
+        for body in [
+            GENERATED_BODY_START.to_owned(),
+            GENERATED_BODY_END.to_owned(),
+            format!("{GENERATED_BODY_START}\n{GENERATED_BODY_START}\n{GENERATED_BODY_END}"),
+            format!("{GENERATED_BODY_START}\n{GENERATED_BODY_END}\n{GENERATED_BODY_END}"),
+            format!("{GENERATED_BODY_END}\n{GENERATED_BODY_START}"),
+        ] {
+            assert!(refresh_generated_body(Some(&body), "Description.").is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_reserved_markers_in_generated_descriptions() {
+        for description in [
+            format!("Text before {GENERATED_BODY_START}"),
+            format!("{GENERATED_BODY_END} text after"),
+        ] {
+            assert!(generated_body(&description).is_err());
+            assert!(refresh_generated_body(None, &description).is_err());
+        }
+    }
+}

--- a/zeroshot/src/native_v2_delivery/github/source_issue.rs
+++ b/zeroshot/src/native_v2_delivery/github/source_issue.rs
@@ -1,5 +1,6 @@
 use super::wire::{IssueCommentWire, IssueWire, require_review_identity};
 use super::*;
+use super::metadata::generated_body;
 
 pub(super) async fn connect_source_issue(
     authority: &GhCliDeliveryAuthority,
@@ -10,25 +11,17 @@ pub(super) async fn connect_source_issue(
     let Some(issue) = request.source_issue.as_ref() else {
         return Ok(());
     };
-    let mut wire = authority.pull_request(review, credential).await?;
+    let wire = authority.pull_request(review, credential).await?;
     require_review_identity(&wire, review)?;
     let closing_reference = closing_reference(issue.number);
     if !body_has_closing_reference(wire.body.as_deref(), &closing_reference) {
         let body = append_closing_reference(wire.body.as_deref(), &closing_reference);
-        let value = authority
-            .api(
-                &[
-                    format!("repos/{}/pulls/{}", review.repository, review.review_id),
-                    "--method".to_owned(),
-                    "PATCH".to_owned(),
-                    "-f".to_owned(),
-                    format!("body={body}"),
-                ],
-                credential,
-            )
+        let updated = authority
+            .patch_review(review, &[format!("body={body}")], credential)
             .await?;
-        wire = serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
-        require_review_identity(&wire, review)?;
+        if updated.body.as_deref() != Some(body.as_str()) {
+            return Err(GitHubAuthorityError::Rejected);
+        }
     }
     comment_on_source_issue(authority, request, review, credential).await
 }
@@ -106,11 +99,13 @@ fn closing_reference(issue_number: u64) -> String {
     format!("Closes #{issue_number}")
 }
 
-pub(super) fn pull_request_body(request: &GitHubReviewRequest) -> String {
-    request.source_issue.as_ref().map_or_else(
-        || PULL_REQUEST_BODY.to_owned(),
-        |issue| format!("{PULL_REQUEST_BODY}\n\n{}", closing_reference(issue.number)),
-    )
+pub(super) fn pull_request_body(
+    request: &GitHubReviewRequest,
+) -> Result<String, GitHubAuthorityError> {
+    let body = generated_body(&request.description)?;
+    Ok(request.source_issue.as_ref().map_or(body.clone(), |issue| {
+        format!("{body}\n\n{}", closing_reference(issue.number))
+    }))
 }
 
 fn body_has_closing_reference(body: Option<&str>, closing_reference: &str) -> bool {
@@ -123,7 +118,7 @@ fn body_has_closing_reference(body: Option<&str>, closing_reference: &str) -> bo
 fn append_closing_reference(body: Option<&str>, closing_reference: &str) -> String {
     let body = body.unwrap_or_default().trim_end();
     if body.is_empty() {
-        format!("{PULL_REQUEST_BODY}\n\n{closing_reference}")
+        closing_reference.to_owned()
     } else {
         format!("{body}\n\n{closing_reference}")
     }
@@ -144,32 +139,29 @@ fn comments_have_marker(comments: &[IssueCommentWire], marker: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use openengine_cluster_testkit::assertions::AssertValue;
-
     use super::*;
-    use crate::native_v2_delivery::{DeliveryTarget, GitHubSourceIssue};
+    use crate::native_v2_delivery::GitHubSourceIssue;
 
     #[test]
     fn reference_is_created_and_repaired_without_replacing_body() {
         let request = GitHubReviewRequest {
-            target: DeliveryTarget::new(
-                "acme/project",
-                "main",
-                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            )
-            .assert_value(),
-            head_branch: "zeroshot/v2-run".to_owned(),
-            head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
             source_issue: Some(GitHubSourceIssue { number: 208 }),
+            ..test_review_request()
         };
         assert_eq!(
-            pull_request_body(&request),
-            "Created by Zeroshot v2.\n\nCloses #208"
+            pull_request_body(&request).unwrap(),
+            concat!(
+                "<!-- zeroshot-delivery:generated:v1:start -->\n",
+                "Repair the checkout flow.\n",
+                "<!-- zeroshot-delivery:generated:v1:end -->\n\n",
+                "Closes #208"
+            )
         );
         assert_eq!(
             append_closing_reference(Some("Human context"), "Closes #208"),
             "Human context\n\nCloses #208"
         );
+        assert_eq!(append_closing_reference(None, "Closes #208"), "Closes #208");
         assert!(body_has_closing_reference(
             Some("Human context\n\ncloses #208"),
             "Closes #208"

--- a/zeroshot/src/native_v2_delivery/github/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/tests.rs
@@ -3,7 +3,7 @@ use serde_json::{Value, json};
 
 use super::*;
 use super::policy::MergeMethod;
-use crate::native_v2_delivery::{DeliveryTarget, GitHubChecks};
+use crate::native_v2_delivery::GitHubChecks;
 
 fn review() -> GitHubReviewReceipt {
     GitHubReviewReceipt {
@@ -444,17 +444,7 @@ fn terminal_state_and_exact_identity_are_authoritative() {
 
 #[test]
 fn receipt_rejects_changed_authority() {
-    let request = GitHubReviewRequest {
-        target: DeliveryTarget::new(
-            "acme/project",
-            "main",
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
-        .assert_value(),
-        head_branch: "zeroshot/v2-run".to_owned(),
-        head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
-        source_issue: None,
-    };
+    let request = test_review_request();
     let wire = serde_json::from_value(json!({
         "number": 17,
         "body": null,

--- a/zeroshot/src/native_v2_delivery/github/wire.rs
+++ b/zeroshot/src/native_v2_delivery/github/wire.rs
@@ -5,6 +5,7 @@ use super::*;
 #[derive(Deserialize)]
 pub(super) struct PullRequestWire {
     number: u64,
+    pub(super) title: Option<String>,
     pub(super) body: Option<String>,
     base: ReviewBranchWire,
     head: ReviewBranchWire,

--- a/zeroshot/src/native_v2_delivery/github/wire/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/wire/tests.rs
@@ -2,20 +2,9 @@ use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
 use serde_json::json;
 
 use super::*;
-use crate::native_v2_delivery::DeliveryTarget;
 
 fn request() -> GitHubReviewRequest {
-    GitHubReviewRequest {
-        target: DeliveryTarget::new(
-            "acme/project",
-            "main",
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        )
-        .assert_value(),
-        head_branch: "zeroshot/v2-run".to_owned(),
-        head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
-        source_issue: None,
-    }
+    super::super::test_review_request()
 }
 
 #[test]

--- a/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
@@ -25,6 +25,8 @@ fn review_request(source_issue: Option<u64>) -> GitHubReviewRequest {
         .assert_value(),
         head_branch: "zeroshot/v2-test".to_owned(),
         head_revision: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+        title: "fix: repair checkout".to_owned(),
+        description: "Repair the checkout flow.".to_owned(),
         source_issue: source_issue.map(|number| GitHubSourceIssue { number }),
     }
 }
@@ -93,7 +95,13 @@ fn assert_production_github_capture(gh_capture: &str, home: &Path) {
     assert!(gh_capture.contains("arg=repos/acme/project/git/ref/heads/zeroshot/v2-test"));
     assert!(gh_capture.contains("arg=state=all"));
     assert!(gh_capture.contains("arg=head=acme:zeroshot/v2-test"));
-    assert!(gh_capture.contains("arg=body=Created by Zeroshot v2.\n\nCloses #208"));
+    assert!(gh_capture.contains("arg=title=fix: repair checkout"));
+    assert!(gh_capture.contains(concat!(
+        "arg=body=<!-- zeroshot-delivery:generated:v1:start -->\n",
+        "Repair the checkout flow.\n",
+        "<!-- zeroshot-delivery:generated:v1:end -->\n\n",
+        "Closes #208"
+    )));
     assert!(gh_capture.contains("arg=repos/acme/project/issues/208"));
     assert!(gh_capture.contains("arg=repos/acme/project/issues/208/comments"));
     assert!(gh_capture.contains("arg=page=1"));

--- a/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
@@ -410,6 +410,17 @@ for argument in "$@"; do
   if [ "$previous" = "--method" ]; then method=$argument; fi
   previous=$argument
 done
+print_review() {
+  /usr/bin/printf '%s%s%s%s%s%s%s%s\n' \
+    '{"number":17,"title":"fix: repair checkout",' \
+    '"body":"<!-- zeroshot-delivery:generated:v1:start -->\n' \
+    'Repair the checkout flow.\n' \
+    '<!-- zeroshot-delivery:generated:v1:end -->\n\nCloses #208",' \
+    '"state":"open","merged":false,"merge_commit_sha":null,"base":' \
+    '{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"full_name":"acme/project"}},' \
+    '"head":{"ref":"zeroshot/v2-test","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",' \
+    '"repo":{"full_name":"acme/project"}}}'
+}
 case "$endpoint:$method" in
   repos/acme/project/git/ref/heads/zeroshot/v2-test:GET)
     /usr/bin/printf '%s%s\n' \
@@ -420,26 +431,13 @@ case "$endpoint:$method" in
     /usr/bin/printf '%s\n' '[]'
     ;;
   repos/acme/project/pulls:POST)
-    /usr/bin/printf '%s%s%s%s\n' \
-      '{"number":17,"state":"open","merged":false,"merge_commit_sha":null,"base":' \
-      '{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"full_name":"acme/project"}},' \
-      '"head":{"ref":"zeroshot/v2-test","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",' \
-      '"repo":{"full_name":"acme/project"}}}'
+    print_review
     ;;
   repos/acme/project/pulls/17:GET)
-    /usr/bin/printf '%s%s%s%s\n' \
-      '{"number":17,"state":"open","merged":false,"merge_commit_sha":null,"base":' \
-      '{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"full_name":"acme/project"}},' \
-      '"head":{"ref":"zeroshot/v2-test","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",' \
-      '"repo":{"full_name":"acme/project"}}}'
+    print_review
     ;;
   repos/acme/project/pulls/17:PATCH)
-    /usr/bin/printf '%s%s%s%s%s\n' \
-      '{"number":17,"body":"Created by Zeroshot v2.\\n\\nCloses #208","state":"open",' \
-      '"merged":false,"merge_commit_sha":null,"base":' \
-      '{"ref":"main","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"full_name":"acme/project"}},' \
-      '"head":{"ref":"zeroshot/v2-test","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",' \
-      '"repo":{"full_name":"acme/project"}}}'
+    print_review
     ;;
   repos/acme/project/issues/208:GET)
     /usr/bin/printf '%s\n' '{"comments":0}'

--- a/zeroshot/src/native_v2_templates.rs
+++ b/zeroshot/src/native_v2_templates.rs
@@ -35,6 +35,9 @@ const TASK_FIELD: &str = "task";
 const ACCEPTANCE_FEEDBACK_FIELD: &str = "acceptanceFeedback";
 const CODE_FEEDBACK_FIELD: &str = "codeFeedback";
 const DELIVERY_FEEDBACK_FIELD: &str = "deliveryFeedback";
+const TITLE_FIELD: &str = "title";
+const DESCRIPTION_FIELD: &str = "description";
+const ISSUE_NUMBER_FIELD: &str = "issueNumber";
 const DIAGNOSTIC_MESSAGE_FIELD: &str = "message";
 const VERDICT_FIELD: &str = "verdict";
 const ACCEPTED_LABEL: &str = "accepted";
@@ -72,7 +75,7 @@ fn software_change_graph(delivery: TemplateDelivery) -> Result<GraphSpec, Builti
     )?;
     let worker_route = initial_worker_route(state.clone(), delivery)?;
     graph(
-        software_input_type()?,
+        software_input_type(delivery)?,
         sequence("run", state, vec![worker, worker_route], Vec::new())?,
     )
 }
@@ -113,7 +116,7 @@ fn change_loop(
     state: PayloadType,
     delivery: TemplateDelivery,
 ) -> Result<GraphNode, BuiltinTemplateError> {
-    let parallel = parallel_reviewers(state.clone())?;
+    let parallel = parallel_reviewers(state.clone(), delivery)?;
     let route = review_route(state.clone(), delivery)?;
     let feedback_paths = feedback_paths()?;
     let body = sequence(
@@ -141,55 +144,92 @@ fn change_loop(
     )
 }
 
-fn parallel_reviewers(state: PayloadType) -> Result<GraphNode, BuiltinTemplateError> {
-    let acceptance = review_verifier(
-        "acceptance",
-        "builtin.agent.acceptance-verifier@1",
-        "Verify the change independently against the user's request and observable behavior. Do \
-         not edit files. When delivery feedback is present, verify that the repair addresses it. \
-         Accept only with concrete evidence; otherwise return actionable feedback.",
-        ACCEPTANCE_FEEDBACK_FIELD,
-    )?;
-    let code = review_verifier(
-        "code",
-        "builtin.agent.code-verifier@1",
-        "Review the change independently for correctness, safety, integration, and substantive \
-         maintainability. Do not edit files or reject for style-only preferences. When delivery \
-         feedback is present, verify that the repair addresses it. Return actionable feedback \
-         when rejecting.",
-        CODE_FEEDBACK_FIELD,
-    )?;
+fn parallel_reviewers(
+    state: PayloadType,
+    delivery: TemplateDelivery,
+) -> Result<GraphNode, BuiltinTemplateError> {
+    let delivery_metadata = delivery_mode(delivery).is_some();
+    let acceptance = review_verifier(ReviewVerifierSpec {
+        name: "acceptance",
+        worker: "builtin.agent.acceptance-verifier@1",
+        authored_instructions: if delivery_metadata {
+            "Verify the change independently against the user's request and observable behavior. \
+             Do not edit files. When delivery feedback is present, verify that the repair addresses \
+             it. Accept only with concrete evidence; otherwise return actionable feedback. Provide \
+             an accurate, informative prospective pull request title and description for the \
+             complete change under review regardless of the verdict. Follow the repository's pull \
+             request conventions, keep the title concise, and keep the description focused on \
+             information useful to reviewers. If mentioning validation, use only results stated \
+             directly by command output and do not infer counts. Do not add issue-closing \
+             references because delivery owns them."
+        } else {
+            "Verify the change independently against the user's request and observable behavior. Do \
+             not edit files. When delivery feedback is present, verify that the repair addresses it. \
+             Accept only with concrete evidence; otherwise return actionable feedback."
+        },
+        feedback_target: ACCEPTANCE_FEEDBACK_FIELD,
+        output: if delivery_metadata {
+            change_manifest_type()?
+        } else {
+            PayloadType::Null
+        },
+        write_bindings: if delivery_metadata {
+            vec![
+                output_write("acceptance", TITLE_FIELD, TITLE_FIELD)?,
+                output_write("acceptance", DESCRIPTION_FIELD, DESCRIPTION_FIELD)?,
+            ]
+        } else {
+            Vec::new()
+        },
+    })?;
+    let code = review_verifier(ReviewVerifierSpec {
+        name: "code",
+        worker: "builtin.agent.code-verifier@1",
+        authored_instructions: "Review the change independently for correctness, safety, \
+             integration, and substantive maintainability. Do not edit files or reject for \
+             style-only preferences. When delivery feedback is present, verify that the repair \
+             addresses it. Return actionable feedback when rejecting.",
+        feedback_target: CODE_FEEDBACK_FIELD,
+        output: PayloadType::Null,
+        write_bindings: Vec::new(),
+    })?;
     Ok(GraphNode::Par(ParNode {
         name: node_name("parallel_reviews")?,
         state,
         branches: non_empty(vec![acceptance, code])?,
-        promoted_state_paths: review_feedback_paths()?,
+        promoted_state_paths: review_promoted_paths(delivery)?,
         join: Join::All {},
     }))
 }
 
-fn review_verifier(
-    name: &str,
-    worker: &str,
-    authored_instructions: &str,
-    feedback_target: &str,
-) -> Result<GraphNode, BuiltinTemplateError> {
-    let signals = BTreeMap::from([(field_name(VERDICT_FIELD)?, verdict_labels()?)]);
+struct ReviewVerifierSpec<'a> {
+    name: &'a str,
+    worker: &'a str,
+    authored_instructions: &'a str,
+    feedback_target: &'a str,
+    output: PayloadType,
+    write_bindings: Vec<WriteBinding>,
+}
+
+fn review_verifier(spec: ReviewVerifierSpec<'_>) -> Result<GraphNode, BuiltinTemplateError> {
+    let signals = review_signals()?;
+    let mut write_bindings = spec.write_bindings;
+    write_bindings.push(diagnostic_write(spec.name, spec.feedback_target)?);
     Ok(GraphNode::Verifier(VerifierNode {
-        name: node_name(name)?,
-        worker: worker_ref(worker)?,
+        name: node_name(spec.name)?,
+        worker: worker_ref(spec.worker)?,
         input: review_input_type()?,
-        output: PayloadType::Null,
+        output: spec.output,
         input_bindings: vec![
             state_input(TASK_FIELD, TASK_FIELD)?,
             state_input(DELIVERY_FEEDBACK_FIELD, DELIVERY_FEEDBACK_FIELD)?,
         ],
-        write_bindings: vec![diagnostic_write(name, feedback_target)?],
+        write_bindings,
         timeout_ms: positive(NODE_TIMEOUT_MS)?,
         attempts: positive(1)?,
         signals,
         diagnostic: diagnostic_type()?,
-        instructions: Some(instructions(authored_instructions)?),
+        instructions: Some(instructions(spec.authored_instructions)?),
     }))
 }
 
@@ -322,9 +362,13 @@ fn delivery_node(mode: DeliveryMode) -> Result<GraphNode, BuiltinTemplateError> 
     Ok(GraphNode::Verifier(VerifierNode {
         name: node_name(DELIVERY_NODE)?,
         worker: worker_ref(delivery_worker(mode))?,
-        input: PayloadType::Null,
+        input: delivery_input_type()?,
         output,
-        input_bindings: Vec::new(),
+        input_bindings: vec![
+            state_input(TITLE_FIELD, TITLE_FIELD)?,
+            state_input(DESCRIPTION_FIELD, DESCRIPTION_FIELD)?,
+            state_input(ISSUE_NUMBER_FIELD, ISSUE_NUMBER_FIELD)?,
+        ],
         write_bindings,
         timeout_ms: positive(NODE_TIMEOUT_MS)?,
         attempts: positive(1)?,
@@ -430,6 +474,24 @@ fn review_feedback_paths() -> Result<Vec<FieldPath>, BuiltinTemplateError> {
         field_path(ACCEPTANCE_FEEDBACK_FIELD)?,
         field_path(CODE_FEEDBACK_FIELD)?,
     ])
+}
+
+fn review_promoted_paths(
+    delivery: TemplateDelivery,
+) -> Result<Vec<FieldPath>, BuiltinTemplateError> {
+    let mut paths = review_feedback_paths()?;
+    if delivery_mode(delivery).is_some() {
+        paths.push(field_path(TITLE_FIELD)?);
+        paths.push(field_path(DESCRIPTION_FIELD)?);
+    }
+    Ok(paths)
+}
+
+fn review_signals() -> Result<BTreeMap<FieldName, NonEmptyEnumSet>, BuiltinTemplateError> {
+    Ok(BTreeMap::from([(
+        field_name(VERDICT_FIELD)?,
+        verdict_labels()?,
+    )]))
 }
 
 fn verdict_labels() -> Result<NonEmptyEnumSet, BuiltinTemplateError> {

--- a/zeroshot/src/native_v2_templates/tests.rs
+++ b/zeroshot/src/native_v2_templates/tests.rs
@@ -58,6 +58,23 @@ fn catalog_and_template_inputs_are_closed() {
             .validate_value(&json!({"task":"repair checkout","acceptanceFeedback":""}))
             .is_err()
     );
+    assert!(
+        software
+            .initial_input
+            .validate_value(&json!({"task":"repair checkout","issueNumber":"208"}))
+            .is_err()
+    );
+    let delivered = BuiltinGraphTemplate::SoftwareChange
+        .materialize(TemplateDelivery::PullRequest)
+        .assert_value();
+    delivered
+        .initial_input
+        .validate_value(&authored)
+        .assert_value();
+    delivered
+        .initial_input
+        .validate_value(&json!({"task":"repair checkout","issueNumber":"208"}))
+        .assert_value();
 }
 
 #[tokio::test]
@@ -213,7 +230,7 @@ async fn accepted_second_review_round_ignores_stale_sibling_verdicts() {
 async fn accepted_reviews_complete_or_dispatch_pull_request_delivery() {
     for delivery in [TemplateDelivery::None, TemplateDelivery::PullRequest] {
         let (verified, initial_input) = verified_software_template(delivery).await;
-        let reviews = accepted_review_history();
+        let reviews = accepted_review_history(delivery);
         let worker_history = [settled_worker()];
         let after_worker = reduce(&verified, &initial_input, &worker_history);
         assert_dispatched_together(&after_worker, &["acceptance", "code"]);
@@ -237,7 +254,7 @@ async fn accepted_reviews_complete_or_dispatch_pull_request_delivery() {
                 node_instance: 4,
                 node: DELIVERY_NODE,
                 settled_at: 4,
-                input: serde_json::Value::Null,
+                input: delivery_input(),
             },
             DeliveryMode::PullRequest,
             DELIVERY_OPENED_LABEL,
@@ -259,7 +276,7 @@ async fn merge_delivery_repairs_recoverable_outcomes_then_returns_the_receipt() 
 async fn assert_recoverable_delivery(recoverable: &str) {
     let delivery_feedback = format!("trusted delivery reported {recoverable}");
     let (verified, initial_input) = verified_software_template(TemplateDelivery::Merge).await;
-    let mut history = accepted_review_history();
+    let mut history = accepted_review_history(TemplateDelivery::Merge);
     let repair_input = json!({
         "task":"repair checkout",
         "outcome":recoverable,
@@ -271,7 +288,7 @@ async fn assert_recoverable_delivery(recoverable: &str) {
             node_instance: 4,
             node: DELIVERY_NODE,
             settled_at: 4,
-            input: Value::Null,
+            input: delivery_input(),
         },
         DeliveryMode::Merge,
         recoverable,
@@ -306,26 +323,33 @@ fn assert_repaired_reviews_then_merge(
     });
     assert_dispatch(&repaired, "acceptance", &review_input);
     assert_dispatch(&repaired, "code", &review_input);
-    for (execution, node, diagnostic) in [
-        (6, "acceptance", "CI repair meets the request"),
-        (7, "code", "CI repair is sound"),
-    ] {
-        history.push(settled_review_execution(
-            SettledExecutionSpec {
-                execution,
-                node_instance: execution - 4,
-                node,
-                settled_at: execution,
-                input: review_input.clone(),
-            },
-            ACCEPTED_LABEL,
-            diagnostic,
-        ));
-    }
+    history.push(settled_review_execution_with_output(
+        SettledExecutionSpec {
+            execution: 6,
+            node_instance: 2,
+            node: "acceptance",
+            settled_at: 6,
+            input: review_input.clone(),
+        },
+        ACCEPTED_LABEL,
+        "CI repair meets the request",
+        repaired_change_manifest(),
+    ));
+    history.push(settled_review_execution(
+        SettledExecutionSpec {
+            execution: 7,
+            node_instance: 3,
+            node: "code",
+            settled_at: 7,
+            input: review_input,
+        },
+        ACCEPTED_LABEL,
+        "CI repair is sound",
+    ));
     assert_dispatch(
         &reduce(verified, initial_input, history),
         DELIVERY_NODE,
-        &Value::Null,
+        &repaired_delivery_input(),
     );
     history.push(settled_delivery(
         SettledExecutionSpec {
@@ -333,7 +357,7 @@ fn assert_repaired_reviews_then_merge(
             node_instance: 4,
             node: DELIVERY_NODE,
             settled_at: 8,
-            input: Value::Null,
+            input: repaired_delivery_input(),
         },
         DeliveryMode::Merge,
         DELIVERY_MERGED_LABEL,
@@ -396,7 +420,11 @@ async fn verified_software_template(
     let template = BuiltinGraphTemplate::SoftwareChange;
     let graph = template.materialize(delivery).assert_value();
     let runtime = runtime_for(template, delivery, &executable_leaves(&graph.root));
-    let initial_input = json!({"task":"repair checkout"});
+    let initial_input = if delivery == TemplateDelivery::None {
+        json!({"task":"repair checkout"})
+    } else {
+        json!({"task":"repair checkout","issueNumber":"208"})
+    };
     let admitted = NativeV2Admission
         .admit(RunSubmission {
             title: RunTitle::new("Template behavior").assert_value(),

--- a/zeroshot/src/native_v2_templates/tests/support.rs
+++ b/zeroshot/src/native_v2_templates/tests/support.rs
@@ -17,6 +17,12 @@ use crate::native_v2_contract::{CodexProvider, DeclaredConnections, ModelId};
 
 use super::super::*;
 
+pub(super) const CHANGE_TITLE: &str = "fix: repair checkout";
+pub(super) const CHANGE_DESCRIPTION: &str = "Repair the checkout flow.";
+pub(super) const REPAIRED_CHANGE_TITLE: &str = "fix: stabilize checkout";
+pub(super) const REPAIRED_CHANGE_DESCRIPTION: &str =
+    "Repair the checkout flow and stabilize its delivery checks.";
+
 pub(super) fn executable_leaves(root: &GraphNode) -> Vec<&GraphNode> {
     let mut leaves = Vec::new();
     let mut pending = vec![root];
@@ -83,12 +89,58 @@ pub(super) fn resolved_source() -> ResolvedSource {
     }
 }
 
-pub(super) fn accepted_review_history() -> Vec<DurableExecution> {
+pub(super) fn accepted_review_history(delivery: TemplateDelivery) -> Vec<DurableExecution> {
+    let acceptance_output = if delivery == TemplateDelivery::None {
+        serde_json::Value::Null
+    } else {
+        change_manifest()
+    };
     vec![
         settled_worker(),
-        settled_review(2, "acceptance", ACCEPTED_LABEL, "requirements met"),
+        settled_review_execution_with_output(
+            SettledExecutionSpec {
+                execution: 2,
+                node_instance: 2,
+                node: "acceptance",
+                settled_at: 2,
+                input: json!({"task":"repair checkout","deliveryFeedback":""}),
+            },
+            ACCEPTED_LABEL,
+            "requirements met",
+            acceptance_output,
+        ),
         settled_review(3, "code", ACCEPTED_LABEL, "implementation sound"),
     ]
+}
+
+pub(super) fn change_manifest() -> serde_json::Value {
+    json!({
+        "title": CHANGE_TITLE,
+        "description": CHANGE_DESCRIPTION
+    })
+}
+
+pub(super) fn repaired_change_manifest() -> serde_json::Value {
+    json!({
+        "title": REPAIRED_CHANGE_TITLE,
+        "description": REPAIRED_CHANGE_DESCRIPTION
+    })
+}
+
+pub(super) fn delivery_input() -> serde_json::Value {
+    json!({
+        "title": CHANGE_TITLE,
+        "description": CHANGE_DESCRIPTION,
+        "issueNumber": "208"
+    })
+}
+
+pub(super) fn repaired_delivery_input() -> serde_json::Value {
+    json!({
+        "title": REPAIRED_CHANGE_TITLE,
+        "description": REPAIRED_CHANGE_DESCRIPTION,
+        "issueNumber": "208"
+    })
 }
 
 pub(super) fn settled_worker() -> DurableExecution {
@@ -135,10 +187,19 @@ pub(super) fn settled_review_execution(
     verdict: &str,
     diagnostic: &str,
 ) -> DurableExecution {
+    settled_review_execution_with_output(spec, verdict, diagnostic, serde_json::Value::Null)
+}
+
+pub(super) fn settled_review_execution_with_output(
+    spec: SettledExecutionSpec<'_>,
+    verdict: &str,
+    diagnostic: &str,
+    output: serde_json::Value,
+) -> DurableExecution {
     settled_execution(
         spec,
         WorkerOutcome::Verifier {
-            output: serde_json::Value::Null,
+            output,
             signals: BTreeMap::from([(
                 FieldName::new(VERDICT_FIELD).assert_value(),
                 EnumLabel::new(verdict).assert_value(),

--- a/zeroshot/src/native_v2_templates/values.rs
+++ b/zeroshot/src/native_v2_templates/values.rs
@@ -14,7 +14,8 @@ use crate::native_v2_delivery::DeliveryMode;
 use super::{
     delivery_mode, enum_label, field_name, field_path, node_name, non_empty, static_value,
     BuiltinTemplateError, TemplateDelivery, ACCEPTANCE_FEEDBACK_FIELD, CODE_FEEDBACK_FIELD,
-    DELIVERY_FEEDBACK_FIELD, DIAGNOSTIC_MESSAGE_FIELD, TASK_FIELD,
+    DELIVERY_FEEDBACK_FIELD, DESCRIPTION_FIELD, DIAGNOSTIC_MESSAGE_FIELD, ISSUE_NUMBER_FIELD,
+    TASK_FIELD, TITLE_FIELD,
 };
 
 pub(super) fn graph(
@@ -94,8 +95,29 @@ pub(super) fn review_repair_input_type() -> Result<PayloadType, BuiltinTemplateE
     ])
 }
 
-pub(super) fn software_input_type() -> Result<PayloadType, BuiltinTemplateError> {
-    task_type()
+pub(super) fn software_input_type(
+    delivery: TemplateDelivery,
+) -> Result<PayloadType, BuiltinTemplateError> {
+    let mut fields = vec![(TASK_FIELD, PayloadType::String, true)];
+    if delivery_mode(delivery).is_some() {
+        fields.push((ISSUE_NUMBER_FIELD, PayloadType::String, false));
+    }
+    record_type(fields)
+}
+
+pub(super) fn change_manifest_type() -> Result<PayloadType, BuiltinTemplateError> {
+    record_type(vec![
+        (TITLE_FIELD, PayloadType::String, true),
+        (DESCRIPTION_FIELD, PayloadType::String, true),
+    ])
+}
+
+pub(super) fn delivery_input_type() -> Result<PayloadType, BuiltinTemplateError> {
+    record_type(vec![
+        (TITLE_FIELD, PayloadType::String, true),
+        (DESCRIPTION_FIELD, PayloadType::String, true),
+        (ISSUE_NUMBER_FIELD, PayloadType::String, false),
+    ])
 }
 
 pub(super) fn review_input_type() -> Result<PayloadType, BuiltinTemplateError> {
@@ -138,12 +160,29 @@ pub(super) fn software_state(
         ),
     ]);
     if let Some(mode) = delivery_mode(delivery) {
-        let output = static_value(delivery_result_schema(mode))?;
-        for (name, field) in record_fields(output)? {
-            fields.insert(name, optional(field.value_type));
-        }
+        add_delivery_state_fields(&mut fields, mode)?;
     }
     Ok(PayloadType::Record { fields })
+}
+
+fn add_delivery_state_fields(
+    fields: &mut BTreeMap<FieldName, RecordField>,
+    mode: DeliveryMode,
+) -> Result<(), BuiltinTemplateError> {
+    fields.insert(field_name(TITLE_FIELD)?, required(PayloadType::String));
+    fields.insert(
+        field_name(DESCRIPTION_FIELD)?,
+        required(PayloadType::String),
+    );
+    fields.insert(
+        field_name(ISSUE_NUMBER_FIELD)?,
+        required(PayloadType::String),
+    );
+    let output = static_value(delivery_result_schema(mode))?;
+    for (name, field) in record_fields(output)? {
+        fields.insert(name, optional(field.value_type));
+    }
+    Ok(())
 }
 
 fn record_type(

--- a/zeroshot/tests/native_v2_cli_local.rs
+++ b/zeroshot/tests/native_v2_cli_local.rs
@@ -142,7 +142,9 @@ async fn detached_local_run_reconnects_without_observer_ownership_and_force_stop
         run_id.as_str()
     );
 
-    let watch = fixture.interrupted(&["watch", &run_id], "block").await;
+    let watch = fixture
+        .interrupted(&["watch", &run_id], "block", &run_id)
+        .await;
     assert_success(&watch, "interrupted local watch");
     assert!(String::from_utf8_lossy(&watch.stdout).contains(&run_id));
     assert_eq!(
@@ -159,12 +161,18 @@ async fn detached_local_run_reconnects_without_observer_ownership_and_force_stop
         "active controller retired early"
     );
 
-    let logs = fixture.interrupted(&["logs", &run_id], "block").await;
+    let logs = fixture
+        .interrupted(&["logs", &run_id], "block", "Codex turn started")
+        .await;
     assert_success(&logs, "interrupted local logs");
     assert!(String::from_utf8_lossy(&logs.stdout).contains("Codex turn started"));
 
     let attach = fixture
-        .interrupted(&["attach", &run_id, &execution], "block")
+        .interrupted(
+            &["attach", &run_id, &execution],
+            "block",
+            "Codex turn started",
+        )
         .await;
     assert_success(&attach, "interrupted read-only local attach");
     let attached = String::from_utf8_lossy(&attach.stdout);

--- a/zeroshot/tests/native_v2_cli_local/fixture.rs
+++ b/zeroshot/tests/native_v2_cli_local/fixture.rs
@@ -8,7 +8,7 @@ use openengine_cluster_testkit::TemporaryDirectory;
 use openengine_cluster_testkit::assertions::{AssertValue, JsonAt};
 use serde_json::{Value, json};
 use tokio::process::{Child, Command};
-use tokio::io::AsyncWriteExt as _;
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
 use tokio::time::{Instant, sleep, timeout};
 
 const CLI_TIMEOUT: Duration = Duration::from_secs(20);
@@ -191,12 +191,12 @@ impl LocalFixture {
         serde_json::from_slice(&output.stdout).assert_value_with("local CLI JSON output")
     }
 
-    pub(super) async fn interrupted(&self, args: &[&str], mode: &str) -> Output {
+    pub(super) async fn interrupted(&self, args: &[&str], mode: &str, expected: &str) -> Output {
         let mut command = self.command(args, mode);
         command.stdout(std::process::Stdio::piped());
         command.stderr(std::process::Stdio::piped());
         let child = command.spawn().assert_value_with("spawn observer CLI");
-        interrupt_after_observation(child).await
+        interrupt_after_observation(child, expected).await
     }
 
     pub(super) async fn assert_replay(&self, command: &str, run_id: &str, expected: &str) {
@@ -316,14 +316,65 @@ impl Drop for LocalFixture {
     }
 }
 
-async fn interrupt_after_observation(child: Child) -> Output {
+async fn interrupt_after_observation(mut child: Child, expected: &str) -> Output {
     let pid = child.id().assert_value_with("observer CLI PID");
-    sleep(Duration::from_millis(350)).await;
+    let stdout = child.stdout.take().assert_value_with("observer stdout");
+    let mut stdout = BufReader::new(stdout);
+    let mut stderr = child.stderr.take().assert_value_with("observer stderr");
+    let stderr = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        stderr
+            .read_to_end(&mut bytes)
+            .await
+            .assert_value_with("read observer stderr");
+        bytes
+    });
+    let mut bytes = Vec::new();
+    let observed = timeout(CLI_TIMEOUT, async {
+        loop {
+            let read = stdout
+                .read_until(b'\n', &mut bytes)
+                .await
+                .assert_value_with("read observer stdout");
+            if read == 0 {
+                return false;
+            }
+            if bytes
+                .windows(expected.len())
+                .any(|window| window == expected.as_bytes())
+            {
+                return true;
+            }
+        }
+    })
+    .await
+    .unwrap_or(false);
     signal(pid, libc::SIGINT).assert_value_with("interrupt observer CLI");
-    timeout(CLI_TIMEOUT, child.wait_with_output())
-        .await
-        .assert_value_with("observer CLI exit deadline")
-        .assert_value_with("wait for observer CLI")
+    let (status, stderr) = timeout(CLI_TIMEOUT, async {
+        stdout
+            .read_to_end(&mut bytes)
+            .await
+            .assert_value_with("finish observer stdout");
+        let status = child
+            .wait()
+            .await
+            .assert_value_with("wait for observer CLI");
+        let stderr = stderr.await.assert_value_with("join observer stderr");
+        (status, stderr)
+    })
+    .await
+    .assert_value_with("observer CLI shutdown deadline");
+    assert!(
+        observed,
+        "observer CLI exited before emitting {expected:?}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&bytes),
+        String::from_utf8_lossy(&stderr)
+    );
+    Output {
+        status,
+        stdout: bytes,
+        stderr,
+    }
 }
 
 pub(super) async fn wait_for_exit(pid: u32) {

--- a/zeroshot/tests/native_v2_cli_local/fixture.rs
+++ b/zeroshot/tests/native_v2_cli_local/fixture.rs
@@ -9,7 +9,7 @@ use openengine_cluster_testkit::assertions::{AssertValue, JsonAt};
 use serde_json::{Value, json};
 use tokio::process::{Child, Command};
 use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
-use tokio::time::{Instant, sleep, timeout};
+use tokio::time::{Instant, sleep, timeout, timeout_at};
 
 const CLI_TIMEOUT: Duration = Duration::from_secs(20);
 const DECLARED_KEY: &str = "local-declared-key";
@@ -349,21 +349,26 @@ async fn interrupt_after_observation(mut child: Child, expected: &str) -> Output
     })
     .await
     .unwrap_or(false);
-    signal(pid, libc::SIGINT).assert_value_with("interrupt observer CLI");
-    let (status, stderr) = timeout(CLI_TIMEOUT, async {
+    let stdout = tokio::spawn(async move {
         stdout
             .read_to_end(&mut bytes)
             .await
             .assert_value_with("finish observer stdout");
-        let status = child
-            .wait()
-            .await
-            .assert_value_with("wait for observer CLI");
+        bytes
+    });
+    let deadline = Instant::now() + CLI_TIMEOUT;
+    signal(pid, libc::SIGINT).assert_value_with("interrupt observer CLI");
+    let status = timeout_at(deadline, child.wait())
+        .await
+        .assert_value_with("observer CLI exit deadline")
+        .assert_value_with("wait for observer CLI");
+    let (bytes, stderr) = timeout_at(deadline, async {
+        let stdout = stdout.await.assert_value_with("join observer stdout");
         let stderr = stderr.await.assert_value_with("join observer stderr");
-        (status, stderr)
+        (stdout, stderr)
     })
     .await
-    .assert_value_with("observer CLI shutdown deadline");
+    .assert_value_with("observer CLI output drain deadline");
     assert!(
         observed,
         "observer CLI exited before emitting {expected:?}\nstdout:\n{}\nstderr:\n{}",


### PR DESCRIPTION
## Summary

- Let the acceptance verifier author a current PR title and description for delivery-enabled software-change runs without threading verbose manifests through every worker.
- Use that manifest for delivery commits and PR creation or refresh, preserving human-authored body text and deriving optional issue linkage from caller input.
- Keep CLI detach signals registered across reconnect boundaries and make the process regression output-driven and fully bounded.

## Validation

Passed Rust workspace formatting, Clippy, and tests; repository tooling; Python SDK checks; strict docs build; staged post-edit analysis; and 100 consecutive runs of the former detach flake. A realistic local software-change --ship run created and merged [matrix PR #152](https://github.com/the-open-engine/zeroshot-matrix-demo-20260812-3ebd/pull/152) and closed its caller-supplied issue.