### PR TITLE
fix: retain private Git push diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,8 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   records.
 - Target HTTP failures use the shared bounded `{code,message,details?}` protocol problem; message-only
   bodies are invalid, and details contain only user-safe structured metadata.
+- Operator diagnostics are private-capability-only, run-scoped, bounded, sanitized, and excluded
+  from public run status and logs.
 - Read-only safe commands include `zeroshot list`, `zeroshot status`, and `zeroshot logs`.
 - Destructive commands such as `zeroshot force-stop` require explicit user intent.
 

--- a/crates/openengine-cluster-protocol/src/native_v2_target.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_target.rs
@@ -25,6 +25,7 @@ pub const TARGET_RUN_PATH: &str = "/native-v2/run";
 pub const TARGET_SESSION_PATH: &str = "/native-v2/oecp-session";
 pub const TARGET_OECP_PATH: &str = "/native-v2/oecp";
 pub const TARGET_PRIVATE_BOOTSTRAP_PATH: &str = "/native-v2/private-bootstrap";
+pub const TARGET_OPERATOR_DIAGNOSTICS_PATH_PREFIX: &str = "/native-v2/operator-diagnostics/";
 pub const TARGET_DISCOVERY_KIND: &str = "zeroshot.native-v2-target/v2";
 pub const TARGET_CONTROLLER_AUDIENCE: &str = "controller";
 pub const HOSTED_RUNS_KIND: &str = "zeroshot.hosted-runs/v1";
@@ -252,6 +253,29 @@ fn redacted(secret: &Option<String>) -> Option<&'static str> {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct TargetRunReceipt {
     pub run_id: RunId,
+}
+
+/// One bounded, sanitized platform diagnostic retained outside public run observation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct TargetOperatorDiagnostic {
+    pub id: String,
+    pub run_id: RunId,
+    pub code: String,
+    pub operation: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
+/// Private target snapshot of the small retained operator-diagnostic buffer.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct TargetOperatorDiagnostics {
+    pub diagnostics: Vec<TargetOperatorDiagnostic>,
 }
 
 /// A hosted authority requires a run so it can route to one exact task attempt. Direct targets

--- a/zeroshot/src/native_v2_delivery/adapter.rs
+++ b/zeroshot/src/native_v2_delivery/adapter.rs
@@ -287,10 +287,15 @@ impl NativeV2DeliveryAdapter {
             head_revision: review.head_revision.clone(),
         };
         emit(preparation.control, "delivery: pushing run branch").await?;
-        self.authority
+        if self
+            .authority
             .push_branch(&push, preparation.credentials.current())
             .await
-            .map_err(|_| crash_outcome())?;
+            .is_err()
+        {
+            emit(preparation.control, "delivery: Git push failed").await?;
+            return Err(crash_outcome());
+        }
         Ok(())
     }
 

--- a/zeroshot/src/native_v2_delivery/github.rs
+++ b/zeroshot/src/native_v2_delivery/github.rs
@@ -1,12 +1,15 @@
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use openengine_cluster_protocol::RunId;
 use tokio::process::Command;
 use tokio::time::timeout;
 
 use crate::native_v2_delivery::git_auth::encode_basic_credential;
+use crate::native_v2_target_authority::OperatorDiagnosticStore;
 
 use super::{
     GitHubAuthorityError, GitHubChecks, GitHubCredential, GitHubDeliveryAuthority,
@@ -17,6 +20,7 @@ use super::{
 
 mod api;
 mod metadata;
+mod push;
 
 const DEFAULT_API_DEADLINE: Duration = Duration::from_secs(2 * 60);
 const DEFAULT_PUSH_DEADLINE: Duration = Duration::from_secs(10 * 60);
@@ -46,12 +50,31 @@ impl GhCliAuthorityConfig {
 #[derive(Clone, Debug)]
 pub struct GhCliDeliveryAuthority {
     config: GhCliAuthorityConfig,
+    operator_diagnostics: Option<OperatorDiagnosticReporter>,
+}
+
+#[derive(Clone, Debug)]
+struct OperatorDiagnosticReporter {
+    run_id: RunId,
+    store: Arc<OperatorDiagnosticStore>,
 }
 
 impl GhCliDeliveryAuthority {
     #[must_use]
     pub fn new(config: GhCliAuthorityConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            operator_diagnostics: None,
+        }
+    }
+
+    pub(crate) fn with_operator_diagnostics(
+        mut self,
+        run_id: RunId,
+        store: Arc<OperatorDiagnosticStore>,
+    ) -> Self {
+        self.operator_diagnostics = Some(OperatorDiagnosticReporter { run_id, store });
+        self
     }
 
     async fn find_review(
@@ -254,17 +277,7 @@ impl GitHubDeliveryAuthority for GhCliDeliveryAuthority {
         request: &GitHubPushRequest,
         credential: GitHubCredential<'_>,
     ) -> Result<(), GitHubAuthorityError> {
-        let mut command = authenticated_git_command(&self.config, &request.workspace, credential);
-        command
-            .arg("push")
-            .arg("--porcelain")
-            .arg("--no-verify")
-            .arg(format!(
-                "https://github.com/{}.git",
-                request.target.repository
-            ))
-            .arg(format!("HEAD:refs/heads/{}", request.head_branch));
-        bounded_status(command, self.config.push_deadline).await
+        push::push_branch(self, request, credential).await
     }
 
     async fn open_or_update_review(

--- a/zeroshot/src/native_v2_delivery/github/push.rs
+++ b/zeroshot/src/native_v2_delivery/github/push.rs
@@ -1,0 +1,489 @@
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::{Child, ChildStderr, ChildStdout, Command};
+use tokio::time::timeout;
+
+use crate::native_v2_delivery::git_auth::encode_basic_credential;
+use crate::native_v2_target_authority::{MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES, NewOperatorDiagnostic};
+
+use super::{
+    GhCliDeliveryAuthority, GitHubAuthorityError, GitHubCredential, GitHubPushRequest,
+    authenticated_git_command,
+};
+
+const REDACTED: &str = "[REDACTED]";
+const READ_BUFFER_BYTES: usize = 8 * 1024;
+
+pub(super) async fn push_branch(
+    authority: &GhCliDeliveryAuthority,
+    request: &GitHubPushRequest,
+    credential: GitHubCredential<'_>,
+) -> Result<(), GitHubAuthorityError> {
+    let basic_credential = encode_basic_credential(credential.expose());
+    let secrets = [credential.expose().as_bytes(), basic_credential.as_bytes()];
+    let mut command = authenticated_git_command(&authority.config, &request.workspace, credential);
+    command
+        .arg("push")
+        .arg("--porcelain")
+        .arg("--no-verify")
+        .arg(format!(
+            "https://github.com/{}.git",
+            request.target.repository
+        ))
+        .arg(format!("HEAD:refs/heads/{}", request.head_branch))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    match capture(command, authority.config.push_deadline, &secrets).await {
+        Ok(()) => Ok(()),
+        Err(failure) => {
+            authority.record_push_failure(failure.diagnostic);
+            Err(failure.error)
+        }
+    }
+}
+
+struct PushFailure {
+    error: GitHubAuthorityError,
+    diagnostic: CommandDiagnostic,
+}
+
+impl PushFailure {
+    fn unavailable(message: &str) -> Self {
+        Self {
+            error: GitHubAuthorityError::Unavailable,
+            diagnostic: CommandDiagnostic::message(message),
+        }
+    }
+}
+
+struct CommandDiagnostic {
+    exit_status: Option<i32>,
+    stdout: CapturedText,
+    stderr: CapturedText,
+}
+
+impl CommandDiagnostic {
+    fn message(message: &str) -> Self {
+        Self {
+            exit_status: None,
+            stdout: CapturedText::default(),
+            stderr: CapturedText {
+                text: message.to_owned(),
+                truncated: false,
+            },
+        }
+    }
+}
+
+#[derive(Default)]
+struct CapturedText {
+    text: String,
+    truncated: bool,
+}
+
+struct CapturedBytes {
+    bytes: Vec<u8>,
+    retain_bytes: usize,
+    truncated: bool,
+    read_failed: bool,
+}
+
+impl CapturedBytes {
+    fn new(retain_bytes: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(retain_bytes),
+            retain_bytes,
+            truncated: false,
+            read_failed: false,
+        }
+    }
+}
+
+struct ChildOutputs {
+    stdout: ChildStdout,
+    stderr: ChildStderr,
+}
+
+struct CapturedStreams {
+    stdout: CapturedBytes,
+    stderr: CapturedBytes,
+}
+
+enum Termination {
+    Exited(ExitStatus),
+    TimedOut,
+    Unavailable,
+}
+
+async fn capture(
+    mut command: Command,
+    deadline: Duration,
+    secrets: &[&[u8]],
+) -> Result<(), PushFailure> {
+    let retain_bytes = MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES
+        .saturating_add(secrets.iter().map(|secret| secret.len()).max().unwrap_or(0));
+    let mut child = command
+        .spawn()
+        .map_err(|_| PushFailure::unavailable("git push could not be started"))?;
+    let outputs = match (child.stdout.take(), child.stderr.take()) {
+        (Some(stdout), Some(stderr)) => ChildOutputs { stdout, stderr },
+        _ => {
+            stop_child(&mut child);
+            return Err(PushFailure::unavailable(
+                "git push output capture was unavailable",
+            ));
+        }
+    };
+    let mut captured = CapturedStreams {
+        stdout: CapturedBytes::new(retain_bytes),
+        stderr: CapturedBytes::new(retain_bytes),
+    };
+    let termination = wait_for_capture(&mut child, outputs, &mut captured, deadline).await;
+    capture_result(termination, captured, secrets)
+}
+
+fn capture_result(
+    termination: Termination,
+    captured: CapturedStreams,
+    secrets: &[&[u8]],
+) -> Result<(), PushFailure> {
+    let diagnostic = CommandDiagnostic {
+        exit_status: match &termination {
+            Termination::Exited(status) => status.code(),
+            Termination::TimedOut | Termination::Unavailable => None,
+        },
+        stdout: sanitize_output(captured.stdout, secrets),
+        stderr: sanitize_output(captured.stderr, secrets),
+    };
+    match termination {
+        Termination::Exited(status) if status.success() => Ok(()),
+        Termination::Exited(_) => Err(PushFailure {
+            error: GitHubAuthorityError::Rejected,
+            diagnostic,
+        }),
+        Termination::TimedOut => Err(PushFailure {
+            error: GitHubAuthorityError::Unavailable,
+            diagnostic: with_context(diagnostic, "git push timed out"),
+        }),
+        Termination::Unavailable => Err(PushFailure {
+            error: GitHubAuthorityError::Unavailable,
+            diagnostic: with_context(diagnostic, "git push status was unavailable"),
+        }),
+    }
+}
+
+async fn wait_for_capture(
+    child: &mut Child,
+    mut outputs: ChildOutputs,
+    captured: &mut CapturedStreams,
+    deadline: Duration,
+) -> Termination {
+    let operation = async {
+        let (status, (), ()) = tokio::join!(
+            child.wait(),
+            drain_bounded(&mut outputs.stdout, &mut captured.stdout),
+            drain_bounded(&mut outputs.stderr, &mut captured.stderr),
+        );
+        status
+    };
+    match timeout(deadline, operation).await {
+        Ok(Ok(status)) => Termination::Exited(status),
+        Ok(Err(_)) => {
+            stop_child(child);
+            Termination::Unavailable
+        }
+        Err(_) => {
+            captured.stdout.truncated = true;
+            captured.stderr.truncated = true;
+            stop_child(child);
+            Termination::TimedOut
+        }
+    }
+}
+
+fn stop_child(child: &mut Child) {
+    let _ = child.start_kill();
+}
+
+async fn drain_bounded(reader: &mut (impl AsyncRead + Unpin), captured: &mut CapturedBytes) {
+    let mut buffer = [0_u8; READ_BUFFER_BYTES];
+    loop {
+        let read = match reader.read(&mut buffer).await {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => {
+                captured.read_failed = true;
+                break;
+            }
+        };
+        let retained = captured
+            .retain_bytes
+            .saturating_sub(captured.bytes.len())
+            .min(read);
+        captured.bytes.extend_from_slice(&buffer[..retained]);
+        captured.truncated |= retained < read;
+    }
+}
+
+fn sanitize_output(mut captured: CapturedBytes, secrets: &[&[u8]]) -> CapturedText {
+    if captured.truncated || captured.read_failed {
+        trim_trailing_secret_prefix(&mut captured.bytes, secrets);
+    }
+    let mut text = String::from_utf8_lossy(&captured.bytes).into_owned();
+    for secret in secrets.iter().filter(|secret| !secret.is_empty()) {
+        if let Ok(secret) = std::str::from_utf8(secret) {
+            text = text.replace(secret, REDACTED);
+        }
+    }
+    let truncated = captured.truncated || captured.read_failed;
+    let (text, text_truncated) = truncate_text(text);
+    CapturedText {
+        text,
+        truncated: truncated || text_truncated,
+    }
+}
+
+fn trim_trailing_secret_prefix(bytes: &mut Vec<u8>, secrets: &[&[u8]]) {
+    let trim = secrets
+        .iter()
+        .filter(|secret| !secret.is_empty() && !bytes.ends_with(secret))
+        .flat_map(|secret| (1..secret.len()).map(move |length| &secret[..length]))
+        .filter(|prefix| bytes.ends_with(prefix))
+        .map(<[u8]>::len)
+        .max()
+        .unwrap_or(0);
+    bytes.truncate(bytes.len().saturating_sub(trim));
+}
+
+fn truncate_text(mut text: String) -> (String, bool) {
+    if text.len() <= MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES {
+        return (text, false);
+    }
+    let mut boundary = MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES;
+    while !text.is_char_boundary(boundary) {
+        boundary = boundary.saturating_sub(1);
+    }
+    text.truncate(boundary);
+    (text, true)
+}
+
+fn with_context(mut diagnostic: CommandDiagnostic, context: &str) -> CommandDiagnostic {
+    if diagnostic.stderr.text.is_empty() {
+        diagnostic.stderr.text = context.to_owned();
+    }
+    diagnostic
+}
+
+impl GhCliDeliveryAuthority {
+    fn record_push_failure(&self, diagnostic: CommandDiagnostic) {
+        let Some(reporter) = &self.operator_diagnostics else {
+            return;
+        };
+        reporter.store.record(NewOperatorDiagnostic {
+            run_id: reporter.run_id.clone(),
+            code: "git_push_failed",
+            operation: "delivery.git_push",
+            exit_status: diagnostic.exit_status,
+            stdout: diagnostic.stdout.text,
+            stderr: diagnostic.stderr.text,
+            stdout_truncated: diagnostic.stdout.truncated,
+            stderr_truncated: diagnostic.stderr.truncated,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::sync::Arc;
+    #[cfg(unix)]
+    use std::time::Instant;
+
+    #[cfg(unix)]
+    use openengine_cluster_protocol::RunId;
+    #[cfg(unix)]
+    use openengine_cluster_testkit::assertions::AssertValue;
+
+    #[cfg(unix)]
+    use crate::native_v2_candidate::test_support::TestGitRepository;
+    #[cfg(unix)]
+    use crate::native_v2_delivery::GhCliAuthorityConfig;
+    #[cfg(unix)]
+    use crate::native_v2_target_authority::OperatorDiagnosticStore;
+
+    #[test]
+    fn truncation_never_retains_a_partial_registered_secret() {
+        let secret = b"credential-value".as_slice();
+        let captured = CapturedBytes {
+            bytes: b"safe output\ncredential-val".to_vec(),
+            retain_bytes: MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES,
+            truncated: true,
+            read_failed: false,
+        };
+
+        let sanitized = sanitize_output(captured, &[secret]);
+
+        assert_eq!(sanitized.text, "safe output\n");
+        assert!(sanitized.truncated);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_push_records_bounded_redacted_stdout_and_stderr() {
+        let repository = TestGitRepository::delivery();
+        let git_program = executable(
+            repository.root.path(),
+            "failing-git",
+            r#"#!/bin/sh
+/usr/bin/printf 'stdout-safe-ref=refs/heads/rejected\n'
+/usr/bin/printf 'stdout-token=%s\n' "$GH_TOKEN"
+/usr/bin/printf 'stdout-auth=%s\n' "$GIT_CONFIG_VALUE_1"
+for argument in "$@"; do /usr/bin/printf 'arg=%s\n' "$argument"; done
+/usr/bin/head -c 131072 /dev/zero | /usr/bin/tr '\000' x
+/usr/bin/printf 'stderr-safe=remote rejected update\n' >&2
+/usr/bin/printf 'stderr-token=%s\n' "$GH_TOKEN" >&2
+/usr/bin/printf 'stderr-auth=%s\n' "$GIT_CONFIG_VALUE_1" >&2
+/usr/bin/head -c 131072 /dev/zero | /usr/bin/tr '\000' y >&2
+exit 17
+"#,
+        );
+        let store = Arc::new(OperatorDiagnosticStore::default());
+        let run_id = RunId::new("018f5e78-7f95-7c22-8d98-3f15af20c991");
+        let authority =
+            diagnostic_authority(&repository, git_program, run_id.clone(), store.clone());
+        let request = push_request(&repository);
+        let token = "raw-github-token";
+        let basic = encode_basic_credential(token);
+
+        assert_eq!(
+            push_branch(&authority, &request, GitHubCredential(token)).await,
+            Err(GitHubAuthorityError::Rejected)
+        );
+
+        let snapshot = store.snapshot(&run_id);
+        assert_eq!(snapshot.diagnostics.len(), 1);
+        let diagnostic = &snapshot.diagnostics[0];
+        assert_eq!(diagnostic.code, "git_push_failed");
+        assert_eq!(diagnostic.operation, "delivery.git_push");
+        assert_eq!(diagnostic.exit_status, Some(17));
+        assert!(diagnostic.stdout_truncated);
+        assert!(diagnostic.stderr_truncated);
+        assert!(diagnostic.stdout.len() <= MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES);
+        assert!(diagnostic.stderr.len() <= MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES);
+        assert!(
+            diagnostic
+                .stdout
+                .contains("stdout-safe-ref=refs/heads/rejected")
+        );
+        assert!(
+            diagnostic
+                .stderr
+                .contains("stderr-safe=remote rejected update")
+        );
+        assert!(
+            diagnostic
+                .stdout
+                .contains("arg=https://github.com/acme/project.git")
+        );
+        assert!(diagnostic.stdout.contains(REDACTED));
+        assert!(diagnostic.stderr.contains(REDACTED));
+        assert!(!diagnostic.stdout.contains(token));
+        assert!(!diagnostic.stderr.contains(token));
+        assert!(!diagnostic.stdout.contains(&basic));
+        assert!(!diagnostic.stderr.contains(&basic));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn successful_push_does_not_record_a_diagnostic() {
+        let repository = TestGitRepository::delivery();
+        let store = Arc::new(OperatorDiagnosticStore::default());
+        let run_id = RunId::new("018f5e78-7f95-7c22-8d98-3f15af20c991");
+        let authority = diagnostic_authority(
+            &repository,
+            "/usr/bin/true".into(),
+            run_id.clone(),
+            store.clone(),
+        );
+
+        push_branch(
+            &authority,
+            &push_request(&repository),
+            GitHubCredential("raw-github-token"),
+        )
+        .await
+        .assert_value();
+
+        assert!(store.snapshot(&run_id).diagnostics.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_deadline_includes_drain_completion() {
+        let repository = TestGitRepository::delivery();
+        let program = executable(
+            repository.root.path(),
+            "inherited-pipe-git",
+            "#!/bin/sh\n(/usr/bin/sleep 2) &\nexit 17\n",
+        );
+        let mut command = Command::new(program);
+        command
+            .kill_on_drop(true)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let started = Instant::now();
+
+        let failure = capture(command, Duration::from_millis(20), &[])
+            .await
+            .expect_err("inherited output pipes exceed the deadline");
+
+        assert_eq!(failure.error, GitHubAuthorityError::Unavailable);
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(failure.diagnostic.stdout.truncated);
+        assert!(failure.diagnostic.stderr.truncated);
+    }
+
+    #[cfg(unix)]
+    fn push_request(repository: &TestGitRepository) -> GitHubPushRequest {
+        let review = super::super::test_review_request();
+        GitHubPushRequest {
+            workspace: repository.workspace.clone(),
+            target: review.target,
+            head_branch: review.head_branch,
+            head_revision: review.head_revision,
+        }
+    }
+
+    #[cfg(unix)]
+    fn diagnostic_authority(
+        repository: &TestGitRepository,
+        git_program: std::path::PathBuf,
+        run_id: RunId,
+        store: Arc<OperatorDiagnosticStore>,
+    ) -> GhCliDeliveryAuthority {
+        GhCliDeliveryAuthority::new(GhCliAuthorityConfig {
+            git_program,
+            gh_program: "/usr/bin/false".into(),
+            home_directory: repository.root.path().to_owned(),
+            api_deadline: Duration::from_secs(10),
+            push_deadline: Duration::from_secs(10),
+        })
+        .with_operator_diagnostics(run_id, store)
+    }
+
+    #[cfg(unix)]
+    fn executable(directory: &std::path::Path, name: &str, contents: &str) -> std::path::PathBuf {
+        let path = directory.join(name);
+        fs::write(&path, contents).assert_value();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).assert_value();
+        path
+    }
+}

--- a/zeroshot/src/native_v2_delivery/tests.rs
+++ b/zeroshot/src/native_v2_delivery/tests.rs
@@ -301,6 +301,35 @@ async fn rewritten_history_is_rejected_before_push() {
     );
 }
 
+#[tokio::test]
+async fn push_rejection_emits_a_short_safe_public_failure_line() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), Script::PushRejected));
+
+    let execution = run_delivery_execution(
+        DeliveryRunRequest {
+            repo: &repo,
+            attempts: 2,
+            mode: DeliveryMode::Merge,
+            run_id: "push-rejected",
+            refresh: None,
+        },
+        authority,
+    )
+    .await;
+
+    assert_eq!(
+        execution.outcome,
+        WorkerOutcome::declared_failure(WorkerErrorCode::Crash)
+    );
+    assert!(
+        execution
+            .output
+            .iter()
+            .any(|output| output.text == "delivery: Git push failed")
+    );
+}
+
 #[test]
 fn delivery_contract_rejects_the_other_modes_schema() {
     let response = NodeResponseContract::Verifier {
@@ -349,6 +378,18 @@ async fn run_delivery_with_id(
     request: DeliveryRunRequest<'_>,
     authority: Arc<FakeGitHub>,
 ) -> WorkerOutcome {
+    run_delivery_execution(request, authority).await.outcome
+}
+
+struct DeliveryExecution {
+    outcome: WorkerOutcome,
+    output: Vec<LiveOutput>,
+}
+
+async fn run_delivery_execution(
+    request: DeliveryRunRequest<'_>,
+    authority: Arc<FakeGitHub>,
+) -> DeliveryExecution {
     let admitted = admitted(request.repo, request.mode).await;
     let config = NativeV2DeliveryConfig {
         workspace: request.repo.workspace.clone(),
@@ -393,7 +434,15 @@ async fn run_delivery_with_id(
         })
         .await
         .assert_value();
-    handle.completion().await.assert_value().outcome
+    let mut durable = handle.take_initial_output().assert_value();
+    let outcome = handle.completion().await.assert_value().outcome;
+    let mut output = Vec::new();
+    while let Ok(event) = durable.recv().await {
+        if let crate::native_v2_runner::DurableNodeEvent::Output { output: event, .. } = event {
+            output.push(event);
+        }
+    }
+    DeliveryExecution { outcome, output }
 }
 
 async fn admitted(repo: &TempRepo, mode: DeliveryMode) -> crate::native_v2_contract::AdmittedRun {

--- a/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
@@ -12,6 +12,7 @@ use super::*;
 #[derive(Clone, Copy)]
 pub(super) enum Script {
     NoCi,
+    PushRejected,
     CiFailed,
     Conflict,
     ConflictAtMerge,
@@ -177,16 +178,10 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         credential: GitHubCredential<'_>,
     ) -> Result<(), GitHubAuthorityError> {
         assert_eq!(credential.expose(), "test-token");
-        let status = tokio::process::Command::new("/usr/bin/git")
-            .arg("-C")
-            .arg(&request.workspace)
-            .arg("push")
-            .arg(&self.remote)
-            .arg(format!("HEAD:refs/heads/{}", request.head_branch))
-            .status()
-            .await
-            .assert_value();
-        if !status.success() {
+        if matches!(self.script, Script::PushRejected) {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        if !push_succeeded(request, &self.remote).await {
             return Err(GitHubAuthorityError::Rejected);
         }
         self.pushed.store(true, Ordering::SeqCst);
@@ -373,6 +368,17 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         }
         Ok(())
     }
+}
+
+async fn push_succeeded(request: &GitHubPushRequest, remote: &Path) -> bool {
+    let mut command = tokio::process::Command::new("/usr/bin/git");
+    command
+        .arg("-C")
+        .arg(&request.workspace)
+        .arg("push")
+        .arg(remote)
+        .arg(format!("HEAD:refs/heads/{}", request.head_branch));
+    command.status().await.assert_value().success()
 }
 
 pub(super) fn write_executable(directory: &Path, name: &str, contents: &str) -> PathBuf {

--- a/zeroshot/src/native_v2_hosting.rs
+++ b/zeroshot/src/native_v2_hosting.rs
@@ -27,8 +27,8 @@ use crate::native_v2_claude::ClaudeProcessEnvironment;
 use crate::native_v2_cloud::{NativeV2CloudController, NativeV2CloudError};
 use crate::native_v2_cloud::submission_digest;
 use crate::native_v2_target_authority::{
-    NativeV2TargetAuthority, TargetAuthorityError, TargetControllerFactory, TargetRunReceipt,
-    TargetRunRequest,
+    NativeV2TargetAuthority, OperatorDiagnosticStore, TargetAuthorityError,
+    TargetControllerFactory, TargetRunReceipt, TargetRunRequest,
 };
 use crate::v2_run_ledger::RunLedger;
 use crate::v2_run_ledger::RunLedgerError;
@@ -45,9 +45,11 @@ pub async fn build_production_target_authority(
     config: ProductionHostingConfig,
 ) -> Result<NativeV2TargetAuthority, ProductionHostingError> {
     prepare_storage_root(&config.storage_root)?;
-    Ok(NativeV2TargetAuthority::new(Arc::new(
-        ProductionTargetControllerFactory::new(config),
-    )))
+    let factory = Arc::new(ProductionTargetControllerFactory::new(config));
+    Ok(NativeV2TargetAuthority::new_with_operator_diagnostics(
+        factory.clone(),
+        factory.operator_diagnostics.clone(),
+    ))
 }
 
 /// Host-owned non-secret capabilities used to compose one installed target.
@@ -82,6 +84,7 @@ impl fmt::Debug for ProductionHostingConfig {
 #[derive(Clone, Debug)]
 pub struct ProductionTargetControllerFactory {
     config: Arc<ProductionHostingConfig>,
+    operator_diagnostics: Arc<OperatorDiagnosticStore>,
 }
 
 impl ProductionTargetControllerFactory {
@@ -89,6 +92,7 @@ impl ProductionTargetControllerFactory {
     pub fn new(config: ProductionHostingConfig) -> Self {
         Self {
             config: Arc::new(config),
+            operator_diagnostics: Arc::new(OperatorDiagnosticStore::default()),
         }
     }
 
@@ -111,6 +115,7 @@ impl ProductionTargetControllerFactory {
             gh_program: self.config.gh_program.clone(),
             process_pool: self.config.process_pool,
             claude_turn_timeout: self.config.claude_turn_timeout,
+            operator_diagnostics: self.operator_diagnostics.clone(),
         })?);
         let controller = NativeV2CloudController::new_with_delivery_policy(
             ledger,

--- a/zeroshot/src/native_v2_hosting/allocator.rs
+++ b/zeroshot/src/native_v2_hosting/allocator.rs
@@ -31,6 +31,7 @@ use crate::native_v2_contract::{AdmittedRun, RuntimePlan};
 use crate::native_v2_delivery::{GhCliAuthorityConfig, GhCliDeliveryAuthority, NativeV2DeliveryConfig};
 use crate::native_v2_portable_controller::WorkspaceIdentity;
 use crate::native_v2_supervisor::RunRuntimeExit;
+use crate::native_v2_target_authority::OperatorDiagnosticStore;
 
 use super::{ProductionHostingError, set_traversable_directory};
 use super::repository::{RepositoryInstall, install_repository, production_source};
@@ -47,6 +48,7 @@ pub(super) struct ProductionCapsuleConfig {
     pub gh_program: PathBuf,
     pub process_pool: HostedProcessPool,
     pub claude_turn_timeout: Duration,
+    pub operator_diagnostics: Arc<OperatorDiagnosticStore>,
 }
 
 type FilesystemPreparer =
@@ -142,7 +144,12 @@ impl ProductionCapsuleAllocator {
                     filesystem.workspace.clone(),
                     target,
                 ),
-                github: Arc::new(GhCliDeliveryAuthority::new(github_config)),
+                github: Arc::new(
+                    GhCliDeliveryAuthority::new(github_config).with_operator_diagnostics(
+                        run_id.clone(),
+                        self.config.operator_diagnostics.clone(),
+                    ),
+                ),
             },
         )
         .map_err(|_| CapsuleAllocationUnavailable)?;

--- a/zeroshot/src/native_v2_hosting/tests/fixtures.rs
+++ b/zeroshot/src/native_v2_hosting/tests/fixtures.rs
@@ -98,6 +98,9 @@ pub(super) fn capsule_config(storage_root: PathBuf) -> ProductionCapsuleConfig {
         gh_program: config.gh_program,
         process_pool: allocator_process_pool(),
         claude_turn_timeout: config.claude_turn_timeout,
+        operator_diagnostics: std::sync::Arc::new(
+            crate::native_v2_target_authority::OperatorDiagnosticStore::default(),
+        ),
     }
 }
 

--- a/zeroshot/src/native_v2_target_authority.rs
+++ b/zeroshot/src/native_v2_target_authority.rs
@@ -3,6 +3,7 @@
 //! Source selection is immutable before this boundary. HTTP submission is the only creation seam;
 //! OECP observes and controls runs already admitted to the target's ledger namespace.
 
+mod operator_diagnostics;
 mod private_access;
 mod transport;
 
@@ -10,12 +11,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 pub use openengine_cluster_protocol::{
-    TargetAuthentication, TargetDiscoveryDocument, TargetOecpSession, TargetOecpSessionRequest,
-    TARGET_RUN_REJECTED_CODE, TargetHttpProblem, TargetRunReceipt, TargetRunRequest,
+    TargetAuthentication, TargetDiscoveryDocument, TargetHttpProblem, TargetOecpSession,
+    TargetOecpSessionRequest, TargetOperatorDiagnostics, TargetRunReceipt, TargetRunRequest,
+    TARGET_RUN_REJECTED_CODE,
 };
 pub use openengine_cluster_protocol::{
     TARGET_CONTROLLER_AUDIENCE as CONTROLLER_AUDIENCE, TARGET_DISCOVERY_KIND as DISCOVERY_KIND,
     TARGET_DISCOVERY_PATH as DISCOVERY_PATH, TARGET_OECP_PATH as OECP_PATH,
+    TARGET_OPERATOR_DIAGNOSTICS_PATH_PREFIX as OPERATOR_DIAGNOSTICS_PATH_PREFIX,
     TARGET_PRIVATE_BOOTSTRAP_PATH, TARGET_RUN_PATH as RUN_PATH,
     TARGET_SESSION_PATH as SESSION_PATH,
 };
@@ -24,6 +27,9 @@ use thiserror::Error;
 use tokio::sync::Mutex;
 
 use crate::native_v2_cloud::NativeV2CloudController;
+pub(crate) use operator_diagnostics::{
+    MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES, NewOperatorDiagnostic, OperatorDiagnosticStore,
+};
 pub use transport::NativeV2TargetServer;
 pub use private_access::TargetBootstrapKey;
 
@@ -125,16 +131,32 @@ pub struct NativeV2TargetAuthority {
     factory: Arc<dyn TargetControllerFactory>,
     state: Mutex<AuthorityState>,
     submission_turn: Mutex<()>,
+    operator_diagnostics: Arc<OperatorDiagnosticStore>,
 }
 
 impl NativeV2TargetAuthority {
     #[must_use]
     pub fn new(factory: Arc<dyn TargetControllerFactory>) -> Self {
+        Self::new_with_operator_diagnostics(factory, Arc::new(OperatorDiagnosticStore::default()))
+    }
+
+    pub(crate) fn new_with_operator_diagnostics(
+        factory: Arc<dyn TargetControllerFactory>,
+        operator_diagnostics: Arc<OperatorDiagnosticStore>,
+    ) -> Self {
         Self {
             factory,
             state: Mutex::new(AuthorityState { controller: None }),
             submission_turn: Mutex::new(()),
+            operator_diagnostics,
         }
+    }
+
+    fn operator_diagnostics(
+        &self,
+        run_id: &openengine_cluster_protocol::RunId,
+    ) -> TargetOperatorDiagnostics {
+        self.operator_diagnostics.snapshot(run_id)
     }
 
     /// Activates exactly one controller and returns the same authority for every target session.

--- a/zeroshot/src/native_v2_target_authority/operator_diagnostics.rs
+++ b/zeroshot/src/native_v2_target_authority/operator_diagnostics.rs
@@ -1,0 +1,155 @@
+use std::collections::VecDeque;
+use std::fmt;
+use std::sync::Mutex;
+
+use openengine_cluster_protocol::{RunId, TargetOperatorDiagnostic, TargetOperatorDiagnostics};
+
+const MAX_BUFFERED_DIAGNOSTICS: usize = 2;
+pub(crate) const MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES: usize = 4 * 1024;
+
+pub(crate) struct NewOperatorDiagnostic {
+    pub run_id: RunId,
+    pub code: &'static str,
+    pub operation: &'static str,
+    pub exit_status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub stdout_truncated: bool,
+    pub stderr_truncated: bool,
+}
+
+#[derive(Default)]
+struct DiagnosticState {
+    next_id: u64,
+    diagnostics: VecDeque<TargetOperatorDiagnostic>,
+}
+
+#[derive(Default)]
+pub(crate) struct OperatorDiagnosticStore {
+    state: Mutex<DiagnosticState>,
+}
+
+impl fmt::Debug for OperatorDiagnosticStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("OperatorDiagnosticStore(..)")
+    }
+}
+
+impl OperatorDiagnosticStore {
+    pub(crate) fn record(&self, mut diagnostic: NewOperatorDiagnostic) {
+        let (stdout, stdout_truncated) = bounded_text(diagnostic.stdout);
+        let (stderr, stderr_truncated) = bounded_text(diagnostic.stderr);
+        diagnostic.stdout = stdout;
+        diagnostic.stderr = stderr;
+        diagnostic.stdout_truncated |= stdout_truncated;
+        diagnostic.stderr_truncated |= stderr_truncated;
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.next_id = state.next_id.saturating_add(1);
+        if state.diagnostics.len() == MAX_BUFFERED_DIAGNOSTICS {
+            state.diagnostics.pop_front();
+        }
+        let id = state.next_id.to_string();
+        state.diagnostics.push_back(TargetOperatorDiagnostic {
+            id,
+            run_id: diagnostic.run_id,
+            code: diagnostic.code.to_owned(),
+            operation: diagnostic.operation.to_owned(),
+            exit_status: diagnostic.exit_status,
+            stdout: diagnostic.stdout,
+            stderr: diagnostic.stderr,
+            stdout_truncated: diagnostic.stdout_truncated,
+            stderr_truncated: diagnostic.stderr_truncated,
+        });
+    }
+
+    pub(crate) fn snapshot(&self, run_id: &RunId) -> TargetOperatorDiagnostics {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        TargetOperatorDiagnostics {
+            diagnostics: state
+                .diagnostics
+                .iter()
+                .filter(|diagnostic| &diagnostic.run_id == run_id)
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+fn bounded_text(text: String) -> (String, bool) {
+    let mut normalized = text
+        .chars()
+        .map(|character| match character {
+            '\n' | '\r' | '\t' => character,
+            character if character.is_control() => '\u{fffd}',
+            character => character,
+        })
+        .collect::<String>();
+    if normalized.len() <= MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES {
+        return (normalized, false);
+    }
+    let mut boundary = MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES;
+    while !normalized.is_char_boundary(boundary) {
+        boundary = boundary.saturating_sub(1);
+    }
+    normalized.truncate(boundary);
+    (normalized, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run_id(value: &str) -> RunId {
+        RunId::new(value)
+    }
+
+    fn diagnostic(run_id: RunId, text: String) -> NewOperatorDiagnostic {
+        NewOperatorDiagnostic {
+            run_id,
+            code: "git_push_failed",
+            operation: "delivery.git_push",
+            exit_status: Some(128),
+            stdout: text.clone(),
+            stderr: text,
+            stdout_truncated: false,
+            stderr_truncated: false,
+        }
+    }
+
+    #[test]
+    fn snapshots_are_run_scoped_and_the_global_queue_is_bounded() {
+        let store = OperatorDiagnosticStore::default();
+        let requested = run_id("018f5e78-7f95-7c22-8d98-3f15af20c991");
+        let other = run_id("018f5e78-7f95-7c22-8d98-3f15af20c992");
+        store.record(diagnostic(requested.clone(), "evicted".to_owned()));
+        store.record(diagnostic(other, "other".to_owned()));
+        store.record(diagnostic(requested.clone(), "retained".to_owned()));
+
+        let snapshot = store.snapshot(&requested);
+
+        assert_eq!(snapshot.diagnostics.len(), 1);
+        assert_eq!(snapshot.diagnostics[0].id, "3");
+        assert_eq!(snapshot.diagnostics[0].stdout, "retained");
+        let debug = format!("{store:?}");
+        assert!(!debug.contains("retained"));
+    }
+
+    #[test]
+    fn worst_case_snapshot_stays_below_the_transport_response_limit() {
+        let store = OperatorDiagnosticStore::default();
+        let requested = run_id("018f5e78-7f95-7c22-8d98-3f15af20c991");
+        let escaped = "\n".repeat(MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES);
+        store.record(diagnostic(requested.clone(), escaped.clone()));
+        store.record(diagnostic(requested.clone(), escaped));
+
+        let encoded = serde_json::to_vec(&store.snapshot(&requested)).expect("serialize snapshot");
+
+        assert!(encoded.len() < 64 * 1024, "{} bytes", encoded.len());
+    }
+}

--- a/zeroshot/src/native_v2_target_authority/tests.rs
+++ b/zeroshot/src/native_v2_target_authority/tests.rs
@@ -174,6 +174,10 @@ fn run_id() -> RunId {
     RunId::new("018f5e78-7f95-7c22-8d98-3f15af20c991")
 }
 
+fn other_run_id() -> RunId {
+    RunId::new("018f5e78-7f95-7c22-8d98-3f15af20c992")
+}
+
 async fn direct_test_server(
     factory: Arc<dyn TargetControllerFactory>,
 ) -> (
@@ -263,6 +267,19 @@ async fn hosted_sessions_are_authenticated_and_run_scoped() {
     let document: TargetDiscoveryDocument = serde_json::from_slice(&discovery.body).assert_value();
     assert_eq!(document.authentication, TargetAuthentication::HostedOauth);
     assert_eq!(document.kind, DISCOVERY_KIND);
+    assert_eq!(
+        http(
+            address,
+            TestHttpRequest::empty(
+                "GET",
+                &format!("{OPERATOR_DIAGNOSTICS_PATH_PREFIX}{}", run_id().as_str()),
+                Some("control-token"),
+            ),
+        )
+        .await
+        .status,
+        404
+    );
 
     let encoded = serde_json::to_vec(&request()).assert_value();
     http(
@@ -337,6 +354,19 @@ async fn run_rejection_returns_a_bounded_public_diagnostic() {
 #[tokio::test]
 async fn direct_target_remains_auth_free_without_private_bootstrap() {
     let (address, endpoint, task) = direct_test_server(Arc::new(FakeFactory::default())).await;
+    assert_eq!(
+        http(
+            address,
+            TestHttpRequest::empty(
+                "GET",
+                &format!("{OPERATOR_DIAGNOSTICS_PATH_PREFIX}{}", run_id().as_str()),
+                None,
+            ),
+        )
+        .await
+        .status,
+        404
+    );
     let session = http(
         address,
         TestHttpRequest::body("POST", SESSION_PATH, None, b"{}"),
@@ -381,6 +411,70 @@ async fn private_target_closes_bootstrap_and_rejects_unprivileged_children() {
     assert_eq!(session.status, 200);
     connect_and_list(&endpoint, Some(&token)).await;
 
+    assert_eq!(
+        http(
+            address,
+            TestHttpRequest::empty(
+                "GET",
+                &format!("{OPERATOR_DIAGNOSTICS_PATH_PREFIX}{}", run_id().as_str()),
+                Some("wrong-token"),
+            ),
+        )
+        .await
+        .status,
+        401
+    );
+
+    http(
+        address,
+        TestHttpRequest::empty("GET", OPERATOR_DIAGNOSTICS_PATH_PREFIX, Some(&token)),
+    )
+    .await
+    .assert_problem(
+        400,
+        "request.invalid",
+        "operator diagnostic request is malformed",
+    );
+    http(
+        address,
+        TestHttpRequest::empty(
+            "GET",
+            &format!("{OPERATOR_DIAGNOSTICS_PATH_PREFIX}not-a-run"),
+            Some(&token),
+        ),
+    )
+    .await
+    .assert_problem(
+        400,
+        "request.invalid",
+        "operator diagnostic request is malformed",
+    );
+    let response = http(
+        address,
+        TestHttpRequest::empty(
+            "GET",
+            &format!("{OPERATOR_DIAGNOSTICS_PATH_PREFIX}{}", run_id().as_str()),
+            Some(&token),
+        ),
+    )
+    .await;
+    assert_eq!(response.status, 200);
+    let diagnostics: TargetOperatorDiagnostics =
+        serde_json::from_slice(&response.body).assert_value();
+    assert_eq!(diagnostics.diagnostics.len(), 1);
+    let diagnostic = diagnostics.diagnostics.first().assert_value();
+    assert_eq!(diagnostic.id, "2");
+    assert_eq!(diagnostic.run_id, run_id());
+    assert_eq!(diagnostic.code, "git_push_failed");
+    assert_eq!(diagnostic.operation, "delivery.git_push");
+    assert_eq!(diagnostic.exit_status, Some(128));
+    assert_eq!(diagnostic.stderr, "remote rejected the update");
+    assert!(
+        !String::from_utf8(response.body)
+            .assert_value()
+            .contains("other run")
+    );
+
     task.abort();
     let _ = std::fs::remove_dir(&root);
 }
@@ -405,11 +499,33 @@ async fn private_test_server() -> (
     let listener = TcpListener::bind("127.0.0.1:0").await.assert_value();
     let address = listener.local_addr().assert_value();
     let endpoint = format!("ws://{address}{OECP_PATH}");
+    let diagnostics = Arc::new(OperatorDiagnosticStore::default());
+    diagnostics.record(NewOperatorDiagnostic {
+        run_id: other_run_id(),
+        code: "git_push_failed",
+        operation: "delivery.git_push",
+        exit_status: Some(1),
+        stdout: String::new(),
+        stderr: "other run".to_owned(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    });
+    diagnostics.record(NewOperatorDiagnostic {
+        run_id: run_id(),
+        code: "git_push_failed",
+        operation: "delivery.git_push",
+        exit_status: Some(128),
+        stdout: "error refs/heads/zeroshot/run rejected".to_owned(),
+        stderr: "remote rejected the update".to_owned(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+    });
     let server = Arc::new(
         NativeV2TargetServer::new_private(
-            Arc::new(NativeV2TargetAuthority::new(Arc::new(
-                FakeFactory::default(),
-            ))),
+            Arc::new(NativeV2TargetAuthority::new_with_operator_diagnostics(
+                Arc::new(FakeFactory::default()),
+                diagnostics,
+            )),
             identity(),
             endpoint.clone(),
             bootstrap_key,
@@ -426,6 +542,19 @@ async fn assert_private_routes_require_capability(address: std::net::SocketAddr,
         http(
             address,
             TestHttpRequest::body("POST", RUN_PATH, None, &encoded)
+        )
+        .await
+        .status,
+        401
+    );
+    assert_eq!(
+        http(
+            address,
+            TestHttpRequest::empty(
+                "GET",
+                &format!("{OPERATOR_DIAGNOSTICS_PATH_PREFIX}{}", run_id().as_str()),
+                None,
+            )
         )
         .await
         .status,

--- a/zeroshot/src/native_v2_target_authority/transport.rs
+++ b/zeroshot/src/native_v2_target_authority/transport.rs
@@ -22,9 +22,9 @@ use tokio_tungstenite::accept_async_with_config;
 use url::Url;
 
 use super::{
-    DISCOVERY_PATH, NativeV2TargetAuthority, OECP_PATH, RUN_PATH, SESSION_PATH,
-    TargetAuthorityError, TargetDiscoveryDocument, TargetOecpSession, TargetRunRequest,
-    TargetAuthentication, TargetSessionAuthority,
+    DISCOVERY_PATH, NativeV2TargetAuthority, OECP_PATH, OPERATOR_DIAGNOSTICS_PATH_PREFIX, RUN_PATH,
+    SESSION_PATH, TargetAuthentication, TargetAuthorityError, TargetDiscoveryDocument,
+    TargetOecpSession, TargetRunRequest, TargetSessionAuthority,
 };
 use crate::native_v2_cloud::NativeV2CloudController;
 use super::private_access::{PrivateTargetAccess, TargetBootstrapKey};
@@ -182,10 +182,29 @@ impl NativeV2TargetServer {
                 &TargetDiscoveryDocument::direct(self.access.authentication()),
             ),
             ("POST", TARGET_PRIVATE_BOOTSTRAP_PATH) => self.handle_private_bootstrap(request).await,
+            ("GET", path) if is_operator_diagnostics_path(path) => {
+                self.handle_operator_diagnostics(request).await
+            }
             ("POST", RUN_PATH) => self.handle_run(request).await,
             ("POST", SESSION_PATH) => self.handle_session(request).await,
             _ => not_found_response(),
         }
+    }
+
+    async fn handle_operator_diagnostics(&self, request: HttpRequest) -> HttpResponse {
+        if !matches!(self.access, TargetServerAccess::Private { .. }) {
+            return not_found_response();
+        }
+        if let Err(error) = self.authenticate_control(&request.head).await {
+            return authority_error_response(error);
+        }
+        if !request.body.is_empty() {
+            return invalid_request_response("operator diagnostic request is malformed");
+        }
+        let Some(run_id) = operator_diagnostics_run_id(&request.path) else {
+            return invalid_request_response("operator diagnostic request is malformed");
+        };
+        HttpResponse::private_json(200, &self.target.operator_diagnostics(&run_id))
     }
 
     async fn handle_private_bootstrap(&self, request: HttpRequest) -> HttpResponse {
@@ -318,6 +337,16 @@ impl NativeV2TargetServer {
             TargetServerAccess::Direct(identity) => Ok(identity.clone()),
         }
     }
+}
+
+fn is_operator_diagnostics_path(path: &str) -> bool {
+    path.starts_with(OPERATOR_DIAGNOSTICS_PATH_PREFIX)
+}
+
+fn operator_diagnostics_run_id(path: &str) -> Option<openengine_cluster_protocol::RunId> {
+    let value = path.strip_prefix(OPERATOR_DIAGNOSTICS_PATH_PREFIX)?;
+    let run_id = openengine_cluster_protocol::RunId::new(value);
+    is_canonical_uuid_v7(&run_id).then_some(run_id)
 }
 
 async fn read_request_head(stream: &TcpStream) -> io::Result<RequestHead> {


### PR DESCRIPTION
Supports the-open-engine/zero-cloud#257.

- capture bounded Git push stdout and stderr concurrently
- scrub the raw token and derived Basic credential
- expose run-scoped diagnostics only on the private control surface
- keep public run logs short and terminal semantics unchanged

Validation:
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps
- focused delivery, redaction, timeout, target-route, and public-log tests
- opcore-zero staged Verify and Sense