### PR TITLE
feat: add hosted merge plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,10 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   ceiling while still observing cancellation and cleanup.
 - GitHub delivery treats aggregate merge policy and required contexts as authority, waits through
   merge queues/deferrals, and succeeds only after observing the exact merged result. Outside merge
-  queues, branch freshness advances only through an authorized compare-and-swap response.
+  queues, branch freshness advances only through an authorized compare-and-swap response. A
+  reported conflict is routable only after the trusted lane fetches the exact current target and
+  leaves a verified nonempty Git merge conflict in the workspace; repair agents receive no GitHub
+  credential. Merge receipts preserve GitHub's authoritative merged revision.
 - Delivery-enabled software-change templates make the acceptance verifier the sole author of the
   current change title and description after every review pass. Git delivery uses that manifest for
   commits and reviews, refreshes only its marker-delimited body section while preserving surrounding
@@ -112,6 +115,9 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   bodies are invalid, and details contain only user-safe structured metadata.
 - Operator diagnostics are private-capability-only, run-scoped, bounded, sanitized, and excluded
   from public run status and logs.
+- Hosted merge plans are atomic, immutable, merge-only DAGs over one explicit repository, branch,
+  and profile. The target resolves each node's exact revision only after its dependencies succeed;
+  plans have static inputs, no cross-node dataflow, and no retry-in-place.
 - Read-only safe commands include `zeroshot list`, `zeroshot status`, and `zeroshot logs`.
 - Destructive commands such as `zeroshot force-stop` require explicit user intent.
 
@@ -125,6 +131,7 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 | Built-in templates            | `zeroshot/src/native_v2_templates.rs`, `zeroshot/src/native_v2_templates/`                                    |
 | Local run composition         | `zeroshot/src/native_v2_local.rs`                                                                             |
 | Hosted/cloud composition      | `zeroshot/src/native_v2_cloud.rs`, `zeroshot/src/native_v2_hosting.rs`                                        |
+| Hosted merge plans            | `crates/openengine-cluster-protocol/src/native_v2_hosted/merge_plan.rs`, `zeroshot/src/native_v2_cli/execution/merge_plans.rs`, `zeroshot/src/native_v2_target/controller_authority/hosted_runs/` |
 | Portable controller           | `zeroshot/src/native_v2_portable_controller.rs`, `zeroshot/src/native_v2_portable_controller/`                |
 | Provider/delivery composition | `zeroshot/src/native_v2_candidate.rs`, `zeroshot/src/native_v2_candidate/`                                    |
 | Target server                 | `zeroshot/src/native_v2_target.rs`, `zeroshot/src/native_v2_target/`                                          |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2340,6 +2340,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2347,6 +2348,16 @@ name = "time-core"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3186,6 +3197,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "time",
  "tokio",
  "tokio-tungstenite",
  "url",

--- a/crates/openengine-cluster-protocol/src/native_v2_hosted.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_hosted.rs
@@ -5,6 +5,10 @@
 
 use serde::{Deserialize, Serialize};
 
+#[path = "native_v2_hosted/merge_plan.rs"]
+mod merge_plan;
+pub use merge_plan::*;
+
 use crate::{
     Cursor, ResolvedSource, RunForceResult, RunId, RunListResult, RunLogEventNotification, RunSize,
     RunStatus, RunStatusResult, RunTitle, RunWatchEventNotification, SubscriptionCloseReason,

--- a/crates/openengine-cluster-protocol/src/native_v2_hosted/merge_plan.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_hosted/merge_plan.rs
@@ -1,0 +1,222 @@
+//! Hosted merge-plan admission and aggregate lifecycle contracts.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    IdempotencyKey, RunConnectionValues, RunId, RunProfileName, RunProfileSelector, RunTitle,
+    SourceBranchId, SourceRepositoryId, SourceRevisionId,
+};
+
+pub const MERGE_PLANS_KIND: &str = "zeroshot.merge-plans/v1";
+pub const MERGE_PLAN_SCHEMA: &str = "zeroshot.merge-plan/v1";
+pub const MAX_MERGE_PLAN_RUNS: usize = 64;
+
+/// Merge-plan IDs share the host-assigned opaque identity representation used by runs.
+pub type MergePlanId = RunId;
+/// Symbolic plan run names use the existing compact ASCII identifier contract.
+pub type MergePlanRunName = RunProfileName;
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MergePlanSource {
+    pub repository: SourceRepositoryId,
+    pub branch: SourceBranchId,
+}
+
+/// One unresolved merge-plan run whose source revision is assigned only after dependencies pass.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MergePlanRunRequest {
+    pub name: MergePlanRunName,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub needs: Vec<MergePlanRunName>,
+    pub initial_input: serde_json::Value,
+}
+
+/// Atomic merge-plan submission. Secret values deliberately do not implement Debug.
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MergePlanSubmitRequest {
+    pub submission_key: IdempotencyKey,
+    pub title: RunTitle,
+    pub expires_at: String,
+    pub source: MergePlanSource,
+    pub profile: RunProfileSelector,
+    pub runs: Vec<MergePlanRunRequest>,
+    #[serde(default, skip_serializing_if = "RunConnectionValues::is_empty")]
+    pub connections: RunConnectionValues,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_token: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergePlanState {
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Cancelled,
+    Expired,
+}
+
+impl MergePlanState {
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::Expired
+        )
+    }
+
+    #[must_use]
+    pub const fn succeeded(self) -> bool {
+        matches!(self, Self::Succeeded)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MergePlanRunState {
+    Blocked,
+    Materializing,
+    Queued,
+    Provisioning,
+    Running,
+    Cancelling,
+    Succeeded,
+    Failed,
+    Cancelled,
+    Expired,
+}
+
+impl MergePlanRunState {
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::Expired
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MergePlanRunStatus {
+    pub name: MergePlanRunName,
+    pub run_id: RunId,
+    pub state: MergePlanRunState,
+    pub needs: Vec<MergePlanRunName>,
+    #[serde(with = "explicit_nullable")]
+    #[schemars(with = "Option<SourceRevisionId>")]
+    pub source_revision: Option<SourceRevisionId>,
+    #[serde(with = "explicit_nullable")]
+    #[schemars(with = "Option<String>")]
+    pub ready_at: Option<String>,
+    #[serde(with = "explicit_nullable")]
+    #[schemars(with = "Option<String>")]
+    pub queue_expires_at: Option<String>,
+    #[serde(with = "explicit_nullable")]
+    #[schemars(with = "Option<String>")]
+    pub terminal_at: Option<String>,
+    #[serde(with = "explicit_nullable")]
+    #[schemars(with = "Option<String>")]
+    pub waiting_reason: Option<String>,
+    #[serde(with = "explicit_nullable")]
+    #[schemars(with = "Option<String>")]
+    pub error_code: Option<String>,
+}
+
+mod explicit_nullable {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(super) fn serialize<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+        S: Serializer,
+    {
+        value.serialize(serializer)
+    }
+
+    pub(super) fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<T>, D::Error>
+    where
+        T: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        Option::deserialize(deserializer)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct MergePlan {
+    pub plan_id: MergePlanId,
+    pub title: RunTitle,
+    pub state: MergePlanState,
+    pub repository: SourceRepositoryId,
+    pub branch: SourceBranchId,
+    pub submitted_at: String,
+    pub expires_at: String,
+    pub runs: Vec<MergePlanRunStatus>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TargetMergePlanRoutes {
+    pub create: String,
+    pub status: String,
+    pub force: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct TargetMergePlansDiscovery {
+    pub kind: String,
+    pub base_url: String,
+    pub route_templates: TargetMergePlanRoutes,
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_testkit::assertions::AssertValue;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn plan_run_names_use_the_compact_ascii_identifier_contract() {
+        for valid in ["backend", "frontend_2", "integrate.final"] {
+            assert!(MergePlanRunName::new(valid).is_ok());
+        }
+        for invalid in ["", "-leading", "has space", "has/slash", &"x".repeat(65)] {
+            assert!(MergePlanRunName::new(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn plan_status_requires_explicit_nullable_lifecycle_fields() {
+        let missing = serde_json::from_value::<MergePlanRunStatus>(json!({
+            "name": "backend",
+            "runId": "run-1",
+            "state": "blocked",
+            "needs": []
+        }));
+        assert!(missing.is_err());
+
+        let status = serde_json::from_value::<MergePlanRunStatus>(json!({
+            "name": "backend",
+            "runId": "run-1",
+            "state": "blocked",
+            "needs": [],
+            "sourceRevision": null,
+            "readyAt": null,
+            "queueExpiresAt": null,
+            "terminalAt": null,
+            "waitingReason": null,
+            "errorCode": null
+        }))
+        .assert_value();
+        assert_eq!(status.name.as_str(), "backend");
+    }
+}

--- a/crates/openengine-cluster-protocol/src/native_v2_target.rs
+++ b/crates/openengine-cluster-protocol/src/native_v2_target.rs
@@ -388,6 +388,8 @@ pub struct TargetDiscoveryExtensions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hosted_runs: Option<TargetHostedRunsDiscovery>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge_plans: Option<crate::TargetMergePlansDiscovery>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub connections: Option<TargetConnectionsDiscovery>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub run_profiles: Option<TargetRunProfilesDiscovery>,
@@ -416,7 +418,10 @@ pub struct TargetDiscoveryDocument {
 impl TargetDiscoveryExtensions {
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.hosted_runs.is_none() && self.connections.is_none() && self.run_profiles.is_none()
+        self.hosted_runs.is_none()
+            && self.merge_plans.is_none()
+            && self.connections.is_none()
+            && self.run_profiles.is_none()
     }
 }
 

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -1,8 +1,8 @@
 # Python SDK
 
-`the-open-engine-zeroshot` is a typed asynchronous client for local and direct targets. Each platform
-wheel contains the corresponding Zeroshot executable, which keeps the client and engine on one
-release line.
+`the-open-engine-zeroshot` is a typed asynchronous client for local, direct, and named hosted
+targets. Each platform wheel contains the corresponding Zeroshot executable, which keeps the client
+and engine on one release line.
 
 ## Install and run
 
@@ -76,8 +76,48 @@ async def run_direct(runtime: UniformRuntime) -> None:
     result.raise_for_failure()
 ```
 
-The Python target contract does not include hosted authentication, so use the CLI for a hosted
-target.
+## Submit a hosted merge plan
+
+Log in with the CLI first, then pass that target's local name to `HostedTarget`. A plan uses one
+explicit repository and branch plus one hosted profile. The profile must contain exactly one
+merge-delivery node.
+
+```python
+from datetime import UTC, datetime, timedelta
+
+from zeroshot import Client, HostedTarget, MergePlanRequest, MergePlanRun
+
+
+async def submit_release_plan() -> None:
+    request = MergePlanRequest(
+        title="Release checkout update",
+        repository="the-open-engine/zeroshot",
+        branch="main",
+        profile="org:software-change",
+        expires_at=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+        runs={
+            "backend": MergePlanRun(input={"task": "Update the API."}),
+            "frontend": MergePlanRun(input={"task": "Update the client."}),
+            "integrate": MergePlanRun(
+                input={"task": "Resolve conflicts and run the release tests."},
+                needs=("backend", "frontend"),
+            ),
+        },
+        submission_key="checkout-release-1",
+    )
+
+    async with Client(target=HostedTarget("cloud")) as client:
+        plan = await client.submit_plan(request)
+        status = await plan.wait(wait_timeout=21_600)
+
+    if not status.succeeded:
+        raise RuntimeError(f"merge plan ended as {status.state}")
+```
+
+Submission is atomic, and every node receives a stable run ID. `needs` gates readiness only; plan
+nodes have no output interpolation or shared mutable input. Cloud resolves a node's exact source
+revision after its dependencies merge, then starts that node's 24-hour queue deadline. The v1 API
+has no aggregate event stream, so `MergePlan.watch()` polls and yields changed snapshots.
 
 ## Pass exact protocol documents
 

--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -7,9 +7,10 @@ are copied defensively at their boundary.
 The reference is generated from the curated exports in `zeroshot.__init__` and their source
 docstrings:
 
-- [Client and run handle](python/client.md): submission, lookup, watch, logs, and stop operations.
-- [Configuration](python/configuration.md): targets, presets, graph inputs, and runtime plans.
-- [Result models](python/results.md): immutable status, log, source, and terminal values.
+- [Client and run handle](python/client.md): run and merge-plan submission, lookup, observation, and
+  stop operations.
+- [Configuration](python/configuration.md): targets, run requests, merge-plan DAGs, and runtimes.
+- [Result models](python/results.md): immutable run, plan, log, source, and terminal values.
 - [Exceptions](python/errors.md): request, target, protocol, timeout, and failed-run errors.
 
 See the [Python SDK guide](../guides/python-sdk.md) for complete submissions and target examples.

--- a/docs/reference/python/client.md
+++ b/docs/reference/python/client.md
@@ -4,5 +4,6 @@
     options:
       members:
         - Client
+        - MergePlan
         - Run
       show_if_no_docstring: false

--- a/docs/reference/python/configuration.md
+++ b/docs/reference/python/configuration.md
@@ -5,11 +5,14 @@
       members:
         - LocalTarget
         - DirectTarget
+        - HostedTarget
         - Target
         - Preset
         - GraphSpec
         - UniformRuntime
         - RuntimePlan
         - RunRequest
+        - MergePlanRequest
+        - MergePlanRun
         - JsonValue
       show_if_no_docstring: false

--- a/docs/reference/python/errors.md
+++ b/docs/reference/python/errors.md
@@ -11,5 +11,6 @@
         - RunFailedError
         - RunNotFoundError
         - RunWaitTimeout
+        - MergePlanWaitTimeout
         - SubmissionConflictError
       show_if_no_docstring: false

--- a/docs/reference/python/results.md
+++ b/docs/reference/python/results.md
@@ -5,6 +5,8 @@
       members:
         - ActiveExecution
         - LogEvent
+        - MergePlanRunStatus
+        - MergePlanStatus
         - ResolvedSource
         - RunResult
         - RunStatus

--- a/docs/zeroshot-cli.html
+++ b/docs/zeroshot-cli.html
@@ -43,6 +43,13 @@ section { margin-block: 2.5rem; }
 <li><a href="#zeroshot-template-list"><code>zeroshot template list</code></a></li>
 <li><a href="#zeroshot-template-show"><code>zeroshot template show</code></a></li>
 <li><a href="#zeroshot-template-help"><code>zeroshot template help</code></a></li>
+<li><a href="#zeroshot-plan"><code>zeroshot plan</code></a></li>
+<li><a href="#zeroshot-plan-validate"><code>zeroshot plan validate</code></a></li>
+<li><a href="#zeroshot-plan-submit"><code>zeroshot plan submit</code></a></li>
+<li><a href="#zeroshot-plan-status"><code>zeroshot plan status</code></a></li>
+<li><a href="#zeroshot-plan-watch"><code>zeroshot plan watch</code></a></li>
+<li><a href="#zeroshot-plan-force-stop"><code>zeroshot plan force-stop</code></a></li>
+<li><a href="#zeroshot-plan-help"><code>zeroshot plan help</code></a></li>
 <li><a href="#zeroshot-run"><code>zeroshot run</code></a></li>
 <li><a href="#zeroshot-list"><code>zeroshot list</code></a></li>
 <li><a href="#zeroshot-status"><code>zeroshot status</code></a></li>
@@ -65,6 +72,7 @@ Commands:
   connection  Inspect and manage named runtime connections
   profile     Manage reusable graph/runtime profiles
   template    Inspect built-in graph templates
+  plan        Validate, submit, and observe hosted merge plans
   run         Submit a graph run locally or to a named target
   list        List runs as JSON
   status      Read a run&#39;s current status as JSON
@@ -486,6 +494,133 @@ Commands:
   list  List built-in template names as JSON
   show  Write a built-in graph template as JSON
   help  Print this message or the help of the given subcommand(s)</code></pre></section>
+<section id="zeroshot-plan"><h3><code>zeroshot plan</code></h3>
+<pre><code>Validate, submit, and observe hosted merge plans
+
+Usage: zeroshot plan &lt;COMMAND&gt;
+
+Commands:
+  validate    Validate a merge-plan manifest without contacting a target
+  submit      Atomically submit every node in a merge-plan manifest
+  status      Read a merge plan&#39;s aggregate status as JSON
+  watch       Poll a merge plan and stream changed snapshots as NDJSON
+  force-stop  Force every nonterminal run in a merge plan to stop
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with &#39;-h&#39;)
+
+MANIFEST
+The JSON manifest is strict and self-contained:
+
+  {
+    &quot;schema&quot;: &quot;zeroshot.merge-plan/v1&quot;,
+    &quot;title&quot;: &quot;Release checkout update&quot;,
+    &quot;source&quot;: {&quot;repository&quot;: &quot;owner/repo&quot;, &quot;branch&quot;: &quot;main&quot;},
+    &quot;profile&quot;: &quot;org:software-change&quot;,
+    &quot;expiresAt&quot;: &quot;&lt;RFC3339 timestamp within 7 days&gt;&quot;,
+    &quot;runs&quot;: {
+      &quot;backend&quot;: {&quot;input&quot;: {&quot;task&quot;: &quot;Update the API.&quot;}},
+      &quot;integrate&quot;: {&quot;needs&quot;: [&quot;backend&quot;], &quot;input&quot;: {&quot;task&quot;: &quot;Run release tests.&quot;}}
+    }
+  }
+
+Every run uses the same source and profile. The profile must contain exactly one merge-delivery node;
+pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
+Cloud assigns all run IDs atomically, resolves each exact source revision only when that run becomes
+ready, and starts its 24-hour queue deadline then. `expiresAt` must be in the future and no more than
+seven days away. Plans cannot be edited or retried in place.</code></pre></section>
+<section id="zeroshot-plan-validate"><h4><code>zeroshot plan validate</code></h4>
+<pre><code>Validate a merge-plan manifest without contacting a target
+
+Usage: zeroshot plan validate &lt;FILE&gt;
+
+Arguments:
+  &lt;FILE&gt;
+          Merge-plan manifest JSON file
+
+Options:
+  -h, --help
+          Print help</code></pre></section>
+<section id="zeroshot-plan-submit"><h4><code>zeroshot plan submit</code></h4>
+<pre><code>Atomically submit every node in a merge-plan manifest
+
+Usage: zeroshot plan submit [OPTIONS] --target &lt;NAME&gt; --submission-key &lt;KEY&gt; &lt;FILE&gt;
+
+Arguments:
+  &lt;FILE&gt;
+          Merge-plan manifest JSON file
+
+Options:
+      --target &lt;NAME&gt;
+          Submit to this named hosted target
+
+      --submission-key &lt;KEY&gt;
+          Stable idempotency key for safely retrying the atomic submission
+
+  -d, --detach
+          Return after atomic submission instead of polling plan status
+
+  -h, --help
+          Print help</code></pre></section>
+<section id="zeroshot-plan-status"><h4><code>zeroshot plan status</code></h4>
+<pre><code>Read a merge plan&#39;s aggregate status as JSON
+
+Usage: zeroshot plan status --target &lt;NAME&gt; &lt;PLAN_ID&gt;
+
+Arguments:
+  &lt;PLAN_ID&gt;
+          Immutable merge-plan ID
+
+Options:
+      --target &lt;NAME&gt;
+          Use this named hosted target
+
+  -h, --help
+          Print help</code></pre></section>
+<section id="zeroshot-plan-watch"><h4><code>zeroshot plan watch</code></h4>
+<pre><code>Poll a merge plan and stream changed snapshots as NDJSON
+
+Usage: zeroshot plan watch --target &lt;NAME&gt; &lt;PLAN_ID&gt;
+
+Arguments:
+  &lt;PLAN_ID&gt;
+          Immutable merge-plan ID
+
+Options:
+      --target &lt;NAME&gt;
+          Use this named hosted target
+
+  -h, --help
+          Print help</code></pre></section>
+<section id="zeroshot-plan-force-stop"><h4><code>zeroshot plan force-stop</code></h4>
+<pre><code>Force every nonterminal run in a merge plan to stop
+
+Usage: zeroshot plan force-stop --target &lt;NAME&gt; &lt;PLAN_ID&gt;
+
+Arguments:
+  &lt;PLAN_ID&gt;
+          Immutable merge-plan ID
+
+Options:
+      --target &lt;NAME&gt;
+          Use this named hosted target
+
+  -h, --help
+          Print help</code></pre></section>
+<section id="zeroshot-plan-help"><h4><code>zeroshot plan help</code></h4>
+<pre><code>Print this message or the help of the given subcommand(s)
+
+Usage: zeroshot plan help [COMMAND]
+
+Commands:
+  validate    Validate a merge-plan manifest without contacting a target
+  submit      Atomically submit every node in a merge-plan manifest
+  status      Read a merge plan&#39;s aggregate status as JSON
+  watch       Poll a merge plan and stream changed snapshots as NDJSON
+  force-stop  Force every nonterminal run in a merge plan to stop
+  help        Print this message or the help of the given subcommand(s)</code></pre></section>
 <section id="zeroshot-run"><h3><code>zeroshot run</code></h3>
 <pre><code>Submit a graph run locally or to a named target.
 
@@ -708,6 +843,7 @@ Commands:
   connection  Inspect and manage named runtime connections
   profile     Manage reusable graph/runtime profiles
   template    Inspect built-in graph templates
+  plan        Validate, submit, and observe hosted merge plans
   run         Submit a graph run locally or to a named target
   list        List runs as JSON
   status      Read a run&#39;s current status as JSON

--- a/docs/zeroshot-cli.md
+++ b/docs/zeroshot-cli.md
@@ -18,6 +18,7 @@ Commands:
   connection  Inspect and manage named runtime connections
   profile     Manage reusable graph/runtime profiles
   template    Inspect built-in graph templates
+  plan        Validate, submit, and observe hosted merge plans
   run         Submit a graph run locally or to a named target
   list        List runs as JSON
   status      Read a run's current status as JSON
@@ -525,6 +526,161 @@ Commands:
   help  Print this message or the help of the given subcommand(s)
 ```
 
+### `zeroshot plan`
+
+```text
+Validate, submit, and observe hosted merge plans
+
+Usage: zeroshot plan <COMMAND>
+
+Commands:
+  validate    Validate a merge-plan manifest without contacting a target
+  submit      Atomically submit every node in a merge-plan manifest
+  status      Read a merge plan's aggregate status as JSON
+  watch       Poll a merge plan and stream changed snapshots as NDJSON
+  force-stop  Force every nonterminal run in a merge plan to stop
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+MANIFEST
+The JSON manifest is strict and self-contained:
+
+  {
+    "schema": "zeroshot.merge-plan/v1",
+    "title": "Release checkout update",
+    "source": {"repository": "owner/repo", "branch": "main"},
+    "profile": "org:software-change",
+    "expiresAt": "<RFC3339 timestamp within 7 days>",
+    "runs": {
+      "backend": {"input": {"task": "Update the API."}},
+      "integrate": {"needs": ["backend"], "input": {"task": "Run release tests."}}
+    }
+  }
+
+Every run uses the same source and profile. The profile must contain exactly one merge-delivery node;
+pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
+Cloud assigns all run IDs atomically, resolves each exact source revision only when that run becomes
+ready, and starts its 24-hour queue deadline then. `expiresAt` must be in the future and no more than
+seven days away. Plans cannot be edited or retried in place.
+```
+
+#### `zeroshot plan validate`
+
+```text
+Validate a merge-plan manifest without contacting a target
+
+Usage: zeroshot plan validate <FILE>
+
+Arguments:
+  <FILE>
+          Merge-plan manifest JSON file
+
+Options:
+  -h, --help
+          Print help
+```
+
+#### `zeroshot plan submit`
+
+```text
+Atomically submit every node in a merge-plan manifest
+
+Usage: zeroshot plan submit [OPTIONS] --target <NAME> --submission-key <KEY> <FILE>
+
+Arguments:
+  <FILE>
+          Merge-plan manifest JSON file
+
+Options:
+      --target <NAME>
+          Submit to this named hosted target
+
+      --submission-key <KEY>
+          Stable idempotency key for safely retrying the atomic submission
+
+  -d, --detach
+          Return after atomic submission instead of polling plan status
+
+  -h, --help
+          Print help
+```
+
+#### `zeroshot plan status`
+
+```text
+Read a merge plan's aggregate status as JSON
+
+Usage: zeroshot plan status --target <NAME> <PLAN_ID>
+
+Arguments:
+  <PLAN_ID>
+          Immutable merge-plan ID
+
+Options:
+      --target <NAME>
+          Use this named hosted target
+
+  -h, --help
+          Print help
+```
+
+#### `zeroshot plan watch`
+
+```text
+Poll a merge plan and stream changed snapshots as NDJSON
+
+Usage: zeroshot plan watch --target <NAME> <PLAN_ID>
+
+Arguments:
+  <PLAN_ID>
+          Immutable merge-plan ID
+
+Options:
+      --target <NAME>
+          Use this named hosted target
+
+  -h, --help
+          Print help
+```
+
+#### `zeroshot plan force-stop`
+
+```text
+Force every nonterminal run in a merge plan to stop
+
+Usage: zeroshot plan force-stop --target <NAME> <PLAN_ID>
+
+Arguments:
+  <PLAN_ID>
+          Immutable merge-plan ID
+
+Options:
+      --target <NAME>
+          Use this named hosted target
+
+  -h, --help
+          Print help
+```
+
+#### `zeroshot plan help`
+
+```text
+Print this message or the help of the given subcommand(s)
+
+Usage: zeroshot plan help [COMMAND]
+
+Commands:
+  validate    Validate a merge-plan manifest without contacting a target
+  submit      Atomically submit every node in a merge-plan manifest
+  status      Read a merge plan's aggregate status as JSON
+  watch       Poll a merge plan and stream changed snapshots as NDJSON
+  force-stop  Force every nonterminal run in a merge plan to stop
+  help        Print this message or the help of the given subcommand(s)
+```
+
 ### `zeroshot run`
 
 ```text
@@ -781,6 +937,7 @@ Commands:
   connection  Inspect and manage named runtime connections
   profile     Manage reusable graph/runtime profiles
   template    Inspect built-in graph templates
+  plan        Validate, submit, and observe hosted merge plans
   run         Submit a graph run locally or to a named target
   list        List runs as JSON
   status      Read a run's current status as JSON

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -42,7 +42,7 @@ harness, provider, or model. `run()` submits one durable graph run and waits for
 `submit()` returns a `Run` immediately for status, resumable watch/log streams, waiting, or durable
 force-stop control.
 
-## Local and direct targets
+## Local, direct, and hosted targets
 
 Local execution uses the current Git workspace by default. Agents mutate that workspace in place:
 
@@ -75,8 +75,49 @@ async def run_direct(runtime: UniformRuntime) -> None:
     result.raise_for_failure()
 ```
 
-Docker is a deployment of `DirectTarget`, not a separate client or target type. Authentication and
-hosted targets are intentionally outside this contract.
+Docker is a deployment of `DirectTarget`, not a separate client or target type.
+
+`HostedTarget` reuses a named target and login from the CLI. Merge plans are immutable DAGs over one
+repository, branch, and hosted profile. That profile must contain exactly one merge-delivery node;
+pull-request delivery isn't accepted for plans.
+
+```python
+from datetime import UTC, datetime, timedelta
+
+from zeroshot import Client, HostedTarget, MergePlanRequest, MergePlanRun
+
+
+async def run_plan() -> None:
+    request = MergePlanRequest(
+        title="Release checkout update",
+        repository="the-open-engine/zeroshot",
+        branch="main",
+        profile="org:software-change",
+        expires_at=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+        runs={
+            "backend": MergePlanRun(input={"task": "Update the API."}),
+            "frontend": MergePlanRun(input={"task": "Update the client."}),
+            "integrate": MergePlanRun(
+                input={"task": "Resolve conflicts and run the release tests."},
+                needs=("backend", "frontend"),
+            ),
+        },
+        submission_key="checkout-release-1",
+    )
+
+    async with Client(target=HostedTarget("cloud")) as client:
+        plan = await client.submit_plan(request)
+        status = await plan.wait(wait_timeout=21_600)
+
+    if not status.succeeded:
+        raise RuntimeError(f"merge plan ended as {status.state}")
+```
+
+Plan input is static JSON. A dependency controls when a node may start; it doesn't copy output into
+another node. Run IDs are assigned once during atomic submission, and each ready node resolves its
+source revision after its dependencies merge. Each node gets its own 24-hour queue deadline when it
+becomes ready. `MergePlan.watch()` polls the aggregate Cloud status and emits changed snapshots
+because the v1 plan API has no streaming endpoint.
 
 ## Exact graph and runtime control
 

--- a/sdks/python/examples/hosted_plan.py
+++ b/sdks/python/examples/hosted_plan.py
@@ -1,0 +1,37 @@
+"""Submit one atomic merge-only DAG through a configured hosted target."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+from zeroshot import Client, HostedTarget, MergePlanRequest, MergePlanRun
+
+
+async def main() -> None:
+    """Submit and wait for the example hosted merge plan."""
+    request = MergePlanRequest(
+        title="Release checkout update",
+        repository="the-open-engine/zeroshot",
+        branch="main",
+        profile="org:software-change",
+        expires_at=(datetime.now(UTC) + timedelta(days=1)).isoformat(),
+        runs={
+            "backend": MergePlanRun(input={"task": "Update the API."}),
+            "frontend": MergePlanRun(input={"task": "Update the client."}),
+            "integrate": MergePlanRun(
+                input={"task": "Resolve conflicts and run the release tests."},
+                needs=("backend", "frontend"),
+            ),
+        },
+        submission_key="checkout-release-1",
+    )
+
+    async with Client(target=HostedTarget("cloud")) as client:
+        plan = await client.submit_plan(request)
+        status = await plan.wait(wait_timeout=21_600)
+
+    if not status.succeeded:
+        raise RuntimeError(f"merge plan ended as {status.state}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/sdks/python/src/zeroshot/__init__.py
+++ b/sdks/python/src/zeroshot/__init__.py
@@ -2,6 +2,7 @@
 
 from ._version import __version__ as __version__
 from .client import Client as Client
+from .client import MergePlan as MergePlan
 from .client import Run as Run
 from .errors import (
     ClientClosedError as ClientClosedError,
@@ -17,6 +18,21 @@ from .errors import (
 )
 from .errors import (
     ZeroshotError as ZeroshotError,
+)
+from .plan_errors import (
+    MergePlanWaitTimeout as MergePlanWaitTimeout,
+)
+from .plans import (
+    MergePlanRequest as MergePlanRequest,
+)
+from .plans import (
+    MergePlanRun as MergePlanRun,
+)
+from .plans import (
+    MergePlanRunStatus as MergePlanRunStatus,
+)
+from .plans import (
+    MergePlanStatus as MergePlanStatus,
 )
 from .run_errors import (
     RunFailedError as RunFailedError,
@@ -56,6 +72,9 @@ from .runtime import (
 )
 from .runtime import (
     GraphSpec as GraphSpec,
+)
+from .runtime import (
+    HostedTarget as HostedTarget,
 )
 from .runtime import (
     LocalTarget as LocalTarget,

--- a/sdks/python/src/zeroshot/_projection.py
+++ b/sdks/python/src/zeroshot/_projection.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Literal, TypeAlias, cast
 
 from .errors import ProtocolError
+from .plans import MergePlanRunStatus, MergePlanStatus
 from .runs import ActiveExecution, LogEvent, ResolvedSource, RunResult, RunStatus, RunSummary
 from .values import JsonValue
 
@@ -175,4 +176,91 @@ def _enum_string(
     selected = _string(value, name, kind)
     if selected not in allowed:
         raise ProtocolError(f"Zeroshot emitted unsupported {kind}.{name} {selected!r}")
+    return selected
+
+
+def _plan_status(value: object) -> MergePlanStatus:
+    root = _mapping(value, "merge plan status")
+    runs = tuple(
+        _plan_run_status(item) for item in _mapping_list(root.get("runs"), "merge plan status.runs")
+    )
+    return MergePlanStatus(
+        plan_id=_string(root, "planId", "merge plan status"),
+        title=_string(root, "title", "merge plan status"),
+        state=cast(
+            Literal["queued", "running", "succeeded", "failed", "cancelled", "expired"],
+            _enum_string(
+                root,
+                "state",
+                {"queued", "running", "succeeded", "failed", "cancelled", "expired"},
+                "merge plan status",
+            ),
+        ),
+        repository=_string(root, "repository", "merge plan status"),
+        branch=_string(root, "branch", "merge plan status"),
+        submitted_at=_string(root, "submittedAt", "merge plan status"),
+        expires_at=_string(root, "expiresAt", "merge plan status"),
+        runs=runs,
+    )
+
+
+def _plan_run_status(value: Mapping[str, object]) -> MergePlanRunStatus:
+    kind = "merge plan status.runs"
+    return MergePlanRunStatus(
+        name=_string(value, "name", kind),
+        run_id=_string(value, "runId", kind),
+        state=cast(
+            Literal[
+                "blocked",
+                "materializing",
+                "queued",
+                "provisioning",
+                "running",
+                "cancelling",
+                "succeeded",
+                "failed",
+                "cancelled",
+                "expired",
+            ],
+            _enum_string(
+                value,
+                "state",
+                {
+                    "blocked",
+                    "materializing",
+                    "queued",
+                    "provisioning",
+                    "running",
+                    "cancelling",
+                    "succeeded",
+                    "failed",
+                    "cancelled",
+                    "expired",
+                },
+                kind,
+            ),
+        ),
+        needs=_string_list(value, "needs", kind),
+        source_revision=_nullable_string(value, "sourceRevision", kind),
+        ready_at=_nullable_string(value, "readyAt", kind),
+        queue_expires_at=_nullable_string(value, "queueExpiresAt", kind),
+        terminal_at=_nullable_string(value, "terminalAt", kind),
+        waiting_reason=_nullable_string(value, "waitingReason", kind),
+        error_code=_nullable_string(value, "errorCode", kind),
+    )
+
+
+def _string_list(value: Mapping[str, object], name: str, kind: str) -> tuple[str, ...]:
+    selected = value.get(name)
+    if not isinstance(selected, list) or not all(isinstance(item, str) for item in selected):
+        raise ProtocolError(f"Zeroshot emitted malformed {kind}.{name}")
+    return tuple(selected)
+
+
+def _nullable_string(value: Mapping[str, object], name: str, kind: str) -> str | None:
+    if name not in value:
+        raise ProtocolError(f"Zeroshot omitted {kind}.{name}")
+    selected = value[name]
+    if selected is not None and not isinstance(selected, str):
+        raise ProtocolError(f"Zeroshot emitted malformed {kind}.{name}")
     return selected

--- a/sdks/python/src/zeroshot/client.py
+++ b/sdks/python/src/zeroshot/client.py
@@ -1,4 +1,4 @@
-"""Async client for the Zeroshot executable and direct targets."""
+"""Async client for local, direct, and named hosted Zeroshot targets."""
 
 from __future__ import annotations
 
@@ -15,13 +15,16 @@ from typing import TypedDict, Unpack, overload
 
 from ._binary import resolve_binary
 from ._process import NativeProcess
-from ._projection import _log_event, _status, _summary
-from .errors import ClientClosedError, InvalidRequestError, ProtocolError
+from ._projection import _log_event, _plan_status, _status, _summary
+from .errors import ClientClosedError, InvalidRequestError, ProtocolError, TargetError
+from .plan_errors import MergePlanWaitTimeout
+from .plans import MergePlanRequest, MergePlanStatus
 from .run_errors import RunWaitTimeout
 from .runs import LogEvent, RunRequest, RunResult, RunStatus, RunSummary
 from .runtime import (
     DirectTarget,
     GraphSpec,
+    HostedTarget,
     LocalTarget,
     Preset,
     RuntimePlan,
@@ -86,10 +89,10 @@ class _RunOptions(_SubmitOptions, total=False):
 
 
 class Client:
-    """Submit and observe Zeroshot graph runs.
+    """Submit and observe Zeroshot graph runs and hosted merge plans.
 
     Args:
-        target: Local target by default, or an unauthenticated direct target such as Docker.
+        target: Local target by default, an unauthenticated direct target, or a named hosted target.
         preset: Default executable-owned graph preset. None selects software-change.
         runtime: Default runtime. None requires a runtime on each string submission.
         environment: Source for runtime-declared environment values. None reads the ambient
@@ -234,6 +237,56 @@ class Client:
         completes before local controller startup or direct-target contact.
         """
         return await self._submit(task, _overrides(options))
+
+    async def submit_plan(self, request: MergePlanRequest) -> MergePlan:
+        """Validate and atomically submit one merge-only DAG to a hosted target.
+
+        Args:
+            request: Immutable plan metadata, profile selector, and static run DAG.
+
+        Returns:
+            A durable merge-plan handle bound to this client's hosted target.
+
+        Raises:
+            InvalidRequestError: If this client does not use HostedTarget or validation fails.
+            TargetError: If the named target is unavailable or submission fails.
+            ProtocolError: If native output is malformed.
+        """
+        self._require_hosted_target()
+        submission_key = request.submission_key or _submission_key()
+        with tempfile.TemporaryDirectory(prefix="zeroshot-python-plan-") as directory:
+            manifest = _write_json(Path(directory) / "plan.json", request.to_dict())
+            await self._native(static=True).json(["plan", "validate", str(manifest)])
+            await self._ready()
+            value = await self._native().json(
+                [
+                    "plan",
+                    "submit",
+                    str(manifest),
+                    *self._route_arguments(),
+                    "--submission-key",
+                    submission_key,
+                    "--detach",
+                ]
+            )
+        status = _plan_status(value)
+        return MergePlan(self, status.plan_id)
+
+    def get_plan(self, plan_id: str) -> MergePlan:
+        """Reconstruct a durable hosted merge-plan handle without target I/O.
+
+        Args:
+            plan_id: Opaque server-assigned plan identity.
+
+        Returns:
+            A handle resolved lazily against this client's named hosted target.
+
+        Raises:
+            ClientClosedError: If this client is closed.
+            InvalidRequestError: If this client does not use HostedTarget.
+        """
+        self._require_hosted_target()
+        return MergePlan(self, plan_id)
 
     async def _submit(self, request: str | RunRequest, overrides: _Overrides) -> Run:
         self._ensure_open()
@@ -432,7 +485,49 @@ class Client:
         return environment, secrets
 
     def _route_arguments(self) -> list[str]:
-        return ["--target", "python-sdk"] if isinstance(self.target, DirectTarget) else []
+        if isinstance(self.target, DirectTarget):
+            return ["--target", "python-sdk"]
+        if isinstance(self.target, HostedTarget):
+            return ["--target", self.target.name]
+        return []
+
+    def _require_hosted_target(self) -> HostedTarget:
+        self._ensure_open()
+        if not isinstance(self.target, HostedTarget):
+            raise InvalidRequestError(
+                "merge plans require a named hosted target",
+                code="target.hosted_required",
+            )
+        return self.target
+
+    async def _plan_status(self, plan_id: str) -> MergePlanStatus:
+        self._require_hosted_target()
+        await self._ready()
+        value = await self._native().json(["plan", "status", plan_id, *self._route_arguments()])
+        return _plan_status(value)
+
+    async def _plan_watch(self, plan_id: str) -> AsyncGenerator[MergePlanStatus, None]:
+        self._require_hosted_target()
+        await self._ready()
+        stream = self._native().json_lines(["plan", "watch", plan_id, *self._route_arguments()])
+        unsuccessful_terminal_yielded = False
+        try:
+            async with aclosing(stream) as values:
+                async for value in values:
+                    status = _plan_status(value)
+                    unsuccessful_terminal_yielded = unsuccessful_terminal_yielded or (
+                        status.terminal and not status.succeeded
+                    )
+                    yield status
+        except TargetError:
+            if not unsuccessful_terminal_yielded:
+                raise
+
+    async def _plan_force_stop(self, plan_id: str) -> MergePlanStatus:
+        self._require_hosted_target()
+        await self._ready()
+        value = await self._native().json(["plan", "force-stop", plan_id, *self._route_arguments()])
+        return _plan_status(value)
 
     async def _status(self, run_id: str) -> RunStatus:
         await self._ready()
@@ -470,6 +565,76 @@ class Client:
         await self._ready()
         value = await self._native().json(["force-stop", run_id, *self._route_arguments()])
         return _status(value)
+
+
+class MergePlan:
+    """Durable hosted merge-plan handle bound to one Client target."""
+
+    __slots__ = ("_client", "_id")
+
+    def __init__(self, client: Client, plan_id: str) -> None:
+        self._client = client
+        self._id = plan_id
+
+    @property
+    def id(self) -> str:
+        """Return the opaque server-assigned merge-plan identity."""
+        return self._id
+
+    async def status(self) -> MergePlanStatus:
+        """Read the plan's current aggregate status."""
+        return await self._client._plan_status(self.id)
+
+    def watch(self) -> AsyncIterator[MergePlanStatus]:
+        """Poll and yield changed aggregate snapshots until the plan is terminal.
+
+        Cancelling or closing the iterator detaches observation and leaves runs active.
+        """
+        return self._client._plan_watch(self.id)
+
+    async def wait(self, *, wait_timeout: float | None = None) -> MergePlanStatus:
+        """Wait for a terminal aggregate status without controlling plan lifetime.
+
+        Args:
+            wait_timeout: Non-negative observation deadline in seconds. None waits indefinitely.
+
+        Raises:
+            ValueError: If wait_timeout is negative.
+            MergePlanWaitTimeout: If observation expires; it carries this durable handle.
+            TargetError: If the selected target is unavailable.
+            ProtocolError: If native output is malformed.
+        """
+        if wait_timeout is not None and wait_timeout < 0:
+            raise ValueError("wait_timeout must be non-negative")
+
+        async def observe() -> MergePlanStatus:
+            current = await self.status()
+            if current.terminal:
+                return current
+            stream = self._client._plan_watch(self.id)
+            async with aclosing(stream) as statuses:
+                async for status in statuses:
+                    if status.terminal:
+                        return status
+            current = await self.status()
+            if current.terminal:
+                return current
+            raise ProtocolError("Zeroshot plan watch closed before a terminal status")
+
+        if wait_timeout is None:
+            return await observe()
+        try:
+            async with asyncio.timeout(wait_timeout):
+                return await observe()
+        except TimeoutError as error:
+            raise MergePlanWaitTimeout(self, wait_timeout) from error
+
+    async def force_stop(self) -> MergePlanStatus:
+        """Force every nonterminal run to stop and wait for aggregate termination."""
+        status = await self._client._plan_force_stop(self.id)
+        if status.terminal:
+            return status
+        return await self.wait()
 
 
 class Run:

--- a/sdks/python/src/zeroshot/plan_errors.py
+++ b/sdks/python/src/zeroshot/plan_errors.py
@@ -1,0 +1,26 @@
+"""Merge-plan-specific public exceptions for the Zeroshot Python SDK."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .errors import ZeroshotError
+
+
+class _MergePlanHandle(Protocol):
+    @property
+    def id(self) -> str: ...
+
+
+class MergePlanWaitTimeout(ZeroshotError):
+    """Raised when observation times out while a durable merge plan remains active.
+
+    Args:
+        plan: Durable plan handle that can resume observation while its client remains open.
+        wait_timeout: Caller-supplied non-negative deadline in seconds.
+    """
+
+    def __init__(self, plan: _MergePlanHandle, wait_timeout: float) -> None:
+        super().__init__(f"merge plan {plan.id} did not finish within {wait_timeout} seconds")
+        self.plan = plan
+        self.wait_timeout = wait_timeout

--- a/sdks/python/src/zeroshot/plans.py
+++ b/sdks/python/src/zeroshot/plans.py
@@ -1,0 +1,155 @@
+"""Immutable hosted merge-plan request and status models."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+from .values import JsonValue
+
+_PLAN_SCHEMA = "zeroshot.merge-plan/v1"
+_PLAN_TERMINAL_STATES = frozenset({"succeeded", "failed", "cancelled", "expired"})
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MergePlanRun:
+    """One statically defined node in a hosted merge plan.
+
+    Args:
+        input: Closed JSON input validated against the selected profile graph.
+        needs: Symbolic node names that must merge successfully before this node becomes ready.
+    """
+
+    input: JsonValue
+    needs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "input", deepcopy(self.input))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return this node's exact manifest representation."""
+        value: dict[str, JsonValue] = {"input": deepcopy(self.input)}
+        if self.needs:
+            value["needs"] = list(self.needs)
+        return value
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MergePlanRequest:
+    """A complete merge-only DAG submitted atomically to one hosted target.
+
+    Args:
+        title: Human-readable immutable plan title.
+        repository: Source repository in owner/name form, shared by every node.
+        branch: Source branch shared by every node.
+        profile: Hosted profile selector in user:name or org:name form.
+        expires_at: RFC 3339 deadline for the whole plan, at most seven days in the future.
+        runs: Node names mapped to static inputs and symbolic dependencies.
+        submission_key: Stable idempotency key; None generates one before native validation.
+    """
+
+    title: str
+    repository: str
+    branch: str
+    profile: str
+    expires_at: str
+    runs: Mapping[str, MergePlanRun]
+    submission_key: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "runs", MappingProxyType(dict(self.runs)))
+
+    def to_dict(self) -> dict[str, JsonValue]:
+        """Return the strict public merge-plan manifest consumed by Zeroshot."""
+        nodes: dict[str, JsonValue] = {name: run.to_dict() for name, run in self.runs.items()}
+        return {
+            "schema": _PLAN_SCHEMA,
+            "title": self.title,
+            "source": {"repository": self.repository, "branch": self.branch},
+            "profile": self.profile,
+            "expiresAt": self.expires_at,
+            "runs": nodes,
+        }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MergePlanRunStatus:
+    """Current lifecycle projection for one hosted merge-plan node.
+
+    Args:
+        name: Stable symbolic node name from the manifest.
+        run_id: Server-assigned public run identity.
+        state: Current materialization or run state.
+        needs: Stable symbolic dependency names.
+        source_revision: Exact source revision once the node materializes.
+        ready_at: RFC 3339 time at which all dependencies had succeeded.
+        queue_expires_at: RFC 3339 per-node queue deadline, set 24 hours after readiness.
+        terminal_at: RFC 3339 terminal time.
+        waiting_reason: Stable explanation while queued or blocked, when supplied.
+        error_code: Stable terminal error category, including dependency_failed.
+    """
+
+    name: str
+    run_id: str
+    state: Literal[
+        "blocked",
+        "materializing",
+        "queued",
+        "provisioning",
+        "running",
+        "cancelling",
+        "succeeded",
+        "failed",
+        "cancelled",
+        "expired",
+    ]
+    needs: tuple[str, ...]
+    source_revision: str | None
+    ready_at: str | None
+    queue_expires_at: str | None
+    terminal_at: str | None
+    waiting_reason: str | None
+    error_code: str | None
+
+    @property
+    def terminal(self) -> bool:
+        """Whether this node can no longer change state."""
+        return self.state in _PLAN_TERMINAL_STATES
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class MergePlanStatus:
+    """Current aggregate projection for an immutable hosted merge plan.
+
+    Args:
+        plan_id: Server-assigned immutable plan identity.
+        title: Human-readable immutable plan title.
+        state: Aggregate plan state.
+        repository: Source repository from the submitted manifest, shared by every node.
+        branch: Source branch shared by every node.
+        submitted_at: RFC 3339 admission time.
+        expires_at: RFC 3339 whole-plan deadline.
+        runs: Stable server-assigned node receipts and their current states.
+    """
+
+    plan_id: str
+    title: str
+    state: Literal["queued", "running", "succeeded", "failed", "cancelled", "expired"]
+    repository: str
+    branch: str
+    submitted_at: str
+    expires_at: str
+    runs: tuple[MergePlanRunStatus, ...]
+
+    @property
+    def terminal(self) -> bool:
+        """Whether every possible transition for this plan has completed."""
+        return self.state in _PLAN_TERMINAL_STATES
+
+    @property
+    def succeeded(self) -> bool:
+        """Whether the complete plan merged successfully."""
+        return self.state == "succeeded"

--- a/sdks/python/src/zeroshot/runtime.py
+++ b/sdks/python/src/zeroshot/runtime.py
@@ -40,7 +40,19 @@ class DirectTarget:
     workspace: str | PathLike[str] | None = field(default=None, kw_only=True)
 
 
-Target: TypeAlias = LocalTarget | DirectTarget
+@dataclass(frozen=True, slots=True)
+class HostedTarget:
+    """Use a named hosted target already configured and logged in through the CLI.
+
+    Args:
+        name: Exact local target name from ``zeroshot target list``. The SDK reuses that
+            target's stored origin and login.
+    """
+
+    name: str
+
+
+Target: TypeAlias = LocalTarget | DirectTarget | HostedTarget
 
 
 @dataclass(frozen=True, slots=True)

--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -36,12 +36,40 @@ def projection(run_id, status, cursor):
         "status": status,
     }
 
+def plan_projection(state):
+    terminal = state in ("succeeded", "failed", "cancelled", "expired")
+    node_state = state if state != "running" else "running"
+    return {
+        "planId": "01900000-0000-7000-8000-000000000010",
+        "title": "Fake plan",
+        "state": state,
+        "repository": "owner/repo",
+        "branch": "main",
+        "submittedAt": "2026-09-10T00:00:00Z",
+        "expiresAt": "2026-09-11T00:00:00Z",
+        "runs": [{
+            "name": "build",
+            "runId": "01900000-0000-7000-8000-000000000011",
+            "state": node_state,
+            "needs": [],
+            "sourceRevision": None if state == "queued" else "0" * 40,
+            "readyAt": None if state == "queued" else "2026-09-10T00:01:00Z",
+            "queueExpiresAt": "2026-09-11T00:01:00Z",
+            "terminalAt": "2026-09-10T00:02:00Z" if terminal else None,
+            "waitingReason": "queue_capacity" if state == "queued" else None,
+            "errorCode": None,
+        }],
+    }
+
 entry = {"args": args}
 for name in ("--input", "--graph", "--runtime-config", "--uniform-runtime-config"):
     path = option(name)
     if path:
         with open(path, encoding="utf-8") as stream:
             entry[name] = json.load(stream)
+if args[:2] in (["plan", "validate"], ["plan", "submit"]):
+    with open(args[2], encoding="utf-8") as stream:
+        entry["plan"] = json.load(stream)
 if log_path:
     with open(log_path, "a", encoding="utf-8") as stream:
         stream.write(json.dumps(entry) + "\n")
@@ -58,6 +86,24 @@ elif args[:2] == ["template", "show"]:
     }))
 elif args[:2] == ["target", "add"] or args[:2] == ["target", "setup"]:
     pass
+elif args[:2] == ["plan", "validate"]:
+    print(json.dumps({"valid": True}))
+elif args[:2] == ["plan", "submit"]:
+    print(json.dumps(plan_projection("queued")))
+elif args[:2] == ["plan", "status"]:
+    print(json.dumps(plan_projection("queued")))
+elif args[:2] == ["plan", "watch"]:
+    print(json.dumps(plan_projection("running")), flush=True)
+    if os.environ.get("FAKE_PLAN_WATCH_FAIL_BEFORE_TERMINAL") == "1":
+        print("zeroshot: plan watch failed before terminal status", file=sys.stderr)
+        raise SystemExit(1)
+    terminal = os.environ.get("FAKE_PLAN_WATCH_TERMINAL", "succeeded")
+    print(json.dumps(plan_projection(terminal)), flush=True)
+    if terminal != "succeeded" or os.environ.get("FAKE_PLAN_WATCH_EXIT_NONZERO") == "1":
+        print("zeroshot: merge plan finished unsuccessfully", file=sys.stderr)
+        raise SystemExit(1)
+elif args[:2] == ["plan", "force-stop"]:
+    print(json.dumps(plan_projection("cancelled")))
 elif args and args[0] == "run":
     task = entry.get("--input", {}).get("task")
     if task == "invalid":

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -13,13 +13,17 @@ from zeroshot import (
     ClientClosedError,
     DirectTarget,
     GraphSpec,
+    HostedTarget,
     InvalidRequestError,
     LocalTarget,
+    MergePlanRequest,
+    MergePlanRun,
     RunFailedError,
     RunRequest,
     RunResult,
     RuntimePlan,
     RunWaitTimeout,
+    TargetError,
     UniformRuntime,
 )
 
@@ -281,3 +285,142 @@ def test_failed_result_has_opt_in_exception_projection() -> None:
     with pytest.raises(RunFailedError) as caught:
         result.raise_for_failure()
     assert caught.value.result is result
+
+
+def test_hosted_plan_submission_uses_one_strict_manifest(fake_native: Path) -> None:
+    request = MergePlanRequest(
+        title="Release",
+        repository="owner/repo",
+        branch="main",
+        profile="org:software-change",
+        expires_at="2026-09-11T00:00:00Z",
+        runs={
+            "build": MergePlanRun(input={"task": "build"}),
+            "integrate": MergePlanRun(input={"task": "integrate"}, needs=("build",)),
+        },
+        submission_key="release-1",
+    )
+
+    async def exercise() -> None:
+        async with Client(target=HostedTarget("cloud")) as client:
+            plan = await client.submit_plan(request)
+            assert plan.id == "01900000-0000-7000-8000-000000000010"
+
+    asyncio.run(exercise())
+    invocations = read_invocations(fake_native)
+    assert [item["args"][:2] for item in invocations] == [
+        ["plan", "validate"],
+        ["plan", "submit"],
+    ]
+    expected = {
+        "schema": "zeroshot.merge-plan/v1",
+        "title": "Release",
+        "source": {"repository": "owner/repo", "branch": "main"},
+        "profile": "org:software-change",
+        "expiresAt": "2026-09-11T00:00:00Z",
+        "runs": {
+            "build": {"input": {"task": "build"}},
+            "integrate": {"input": {"task": "integrate"}, "needs": ["build"]},
+        },
+    }
+    assert all(item["plan"] == expected for item in invocations)
+    submitted = invocations[1]["args"]
+    assert submitted[submitted.index("--target") + 1] == "cloud"
+    assert submitted[submitted.index("--submission-key") + 1] == "release-1"
+    assert "--detach" in submitted
+
+
+def test_hosted_plan_handle_observes_waits_and_force_stops(fake_native: Path) -> None:
+    async def exercise() -> None:
+        async with Client(target=HostedTarget("cloud")) as client:
+            plan = client.get_plan("01900000-0000-7000-8000-000000000010")
+            status = await plan.status()
+            assert status.state == "queued"
+            assert status.runs[0].waiting_reason == "queue_capacity"
+            snapshots = [item async for item in plan.watch()]
+            assert [item.state for item in snapshots] == ["running", "succeeded"]
+            terminal = await plan.wait(wait_timeout=2)
+            assert terminal.succeeded
+            stopped = await plan.force_stop()
+            assert stopped.state == "cancelled"
+
+    asyncio.run(exercise())
+    arguments = [item["args"] for item in read_invocations(fake_native)]
+    assert all(args[args.index("--target") + 1] == "cloud" for args in arguments)
+    assert any(args[:2] == ["plan", "status"] for args in arguments)
+    assert any(args[:2] == ["plan", "watch"] for args in arguments)
+    assert any(args[:2] == ["plan", "force-stop"] for args in arguments)
+
+
+@pytest.mark.parametrize("state", ["failed", "cancelled", "expired"])
+def test_hosted_plan_watch_accepts_terminal_status_before_cli_failure(
+    fake_native: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    state: str,
+) -> None:
+    monkeypatch.setenv("FAKE_PLAN_WATCH_TERMINAL", state)
+
+    async def exercise() -> None:
+        async with Client(target=HostedTarget("cloud")) as client:
+            plan = client.get_plan("01900000-0000-7000-8000-000000000010")
+            statuses = [status.state async for status in plan.watch()]
+            assert statuses == ["running", state]
+
+    asyncio.run(exercise())
+
+
+def test_hosted_plan_watch_propagates_preterminal_cli_failure(
+    fake_native: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAKE_PLAN_WATCH_FAIL_BEFORE_TERMINAL", "1")
+
+    async def exercise() -> None:
+        observed = []
+        async with Client(target=HostedTarget("cloud")) as client:
+            plan = client.get_plan("01900000-0000-7000-8000-000000000010")
+            with pytest.raises(TargetError, match="failed before terminal") as caught:
+                async for status in plan.watch():
+                    observed.append(status.state)
+        assert caught.value.exit_code == 1
+        assert observed == ["running"]
+
+    asyncio.run(exercise())
+
+
+def test_hosted_plan_watch_propagates_unexpected_failure_after_success(
+    fake_native: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("FAKE_PLAN_WATCH_EXIT_NONZERO", "1")
+
+    async def exercise() -> None:
+        observed = []
+        async with Client(target=HostedTarget("cloud")) as client:
+            plan = client.get_plan("01900000-0000-7000-8000-000000000010")
+            with pytest.raises(TargetError, match="finished unsuccessfully"):
+                async for status in plan.watch():
+                    observed.append(status.state)
+        assert observed == ["running", "succeeded"]
+
+    asyncio.run(exercise())
+
+
+def test_merge_plan_requires_a_hosted_target(fake_native: Path) -> None:
+    request = MergePlanRequest(
+        title="Release",
+        repository="owner/repo",
+        branch="main",
+        profile="org:software-change",
+        expires_at="2026-09-11T00:00:00Z",
+        runs={"build": MergePlanRun(input={"task": "build"})},
+    )
+
+    async def exercise() -> None:
+        async with Client() as client:
+            with pytest.raises(InvalidRequestError) as caught:
+                await client.submit_plan(request)
+            assert caught.value.code == "target.hosted_required"
+
+    asyncio.run(exercise())
+    assert read_invocations(fake_native) == []

--- a/sdks/python/tests/test_plans.py
+++ b/sdks/python/tests/test_plans.py
@@ -1,0 +1,12 @@
+"""Hosted merge-plan value-model tests."""
+
+from zeroshot import MergePlanRun
+
+
+def test_merge_plan_run_defensively_copies_authored_input() -> None:
+    authored_input = {"task": {"labels": ["initial"]}}
+
+    run = MergePlanRun(input=authored_input)
+    authored_input["task"]["labels"].append("mutated")
+
+    assert run.to_dict() == {"input": {"task": {"labels": ["initial"]}}}

--- a/sdks/python/tests/test_projection.py
+++ b/sdks/python/tests/test_projection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from zeroshot._projection import _log_event
+from zeroshot._projection import _log_event, _plan_status
 from zeroshot.errors import ProtocolError
 
 
@@ -36,3 +36,46 @@ def test_log_event_rejects_missing_timestamp() -> None:
     del value["timestamp"]
     with pytest.raises(ProtocolError, match=r"malformed log event\.timestamp"):
         _log_event(value)
+
+
+def plan_status() -> dict[str, object]:
+    return {
+        "planId": "plan-1",
+        "title": "Release",
+        "state": "queued",
+        "repository": "owner/repo",
+        "branch": "main",
+        "submittedAt": "2026-09-10T00:00:00Z",
+        "expiresAt": "2026-09-11T00:00:00Z",
+        "runs": [
+            {
+                "name": "build",
+                "runId": "run-1",
+                "state": "blocked",
+                "needs": [],
+                "sourceRevision": None,
+                "readyAt": None,
+                "queueExpiresAt": None,
+                "terminalAt": None,
+                "waitingReason": "dependencies_pending",
+                "errorCode": None,
+            }
+        ],
+    }
+
+
+def test_merge_plan_projection_preserves_explicit_nullable_fields() -> None:
+    status = _plan_status(plan_status())
+    assert status.plan_id == "plan-1"
+    assert status.runs[0].source_revision is None
+    assert status.runs[0].waiting_reason == "dependencies_pending"
+    assert not status.terminal
+
+
+def test_merge_plan_projection_rejects_omitted_nullable_fields() -> None:
+    value = plan_status()
+    runs = value["runs"]
+    assert isinstance(runs, list)
+    del runs[0]["queueExpiresAt"]
+    with pytest.raises(ProtocolError, match="queueExpiresAt"):
+        _plan_status(value)

--- a/zeroshot/Cargo.toml
+++ b/zeroshot/Cargo.toml
@@ -38,6 +38,7 @@ serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 sha2.workspace = true
 thiserror.workspace = true
+time = { workspace = true, features = ["parsing"] }
 tokio.workspace = true
 tokio-tungstenite.workspace = true
 url.workspace = true

--- a/zeroshot/src/native_v2_admission.rs
+++ b/zeroshot/src/native_v2_admission.rs
@@ -21,7 +21,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::native_v2_contract::{
-    AdmittedRun, NodeRuntimeBinding, RunSubmission, RunSubmissionIntent, RuntimePlan,
+    AdmittedRun, GIT_DELIVERY_MERGE_V2_WORKER_REF, NodeRuntimeBinding, RunSubmission,
+    RunSubmissionIntent, RuntimePlan,
 };
 use openengine_cluster_protocol::MAX_DECLARED_ENVIRONMENT_NAMES;
 
@@ -65,6 +66,8 @@ pub enum NativeV2AdmissionError {
         policy: DeliveryPolicy,
         found: usize,
     },
+    #[error("merge plans require exactly one graph-visible Git merge delivery node")]
+    MergeDeliveryRequired,
     #[error(
         "run declares {found} unique environment names; maximum is {MAX_DECLARED_ENVIRONMENT_NAMES}"
     )]
@@ -113,6 +116,23 @@ impl NativeV2Admission {
             .await
             .map(|_| ())
             .map_err(Into::into)
+    }
+
+    /// Validates a reusable profile for merge-plan use, requiring merge rather than PR delivery.
+    pub(crate) async fn validate_merge_profile(
+        &self,
+        graph: &GraphSpec,
+        runtime: &RuntimePlan,
+    ) -> Result<(), NativeV2AdmissionError> {
+        self.validate_profile(graph, runtime, DeliveryPolicy::Required)
+            .await?;
+        let has_merge = executable_declarations(&graph.root)
+            .iter()
+            .any(|declaration| declaration.worker.as_str() == GIT_DELIVERY_MERGE_V2_WORKER_REF);
+        if !has_merge {
+            return Err(NativeV2AdmissionError::MergeDeliveryRequired);
+        }
+        Ok(())
     }
 
     /// Admits with the local policy, where graph-visible delivery is optional.

--- a/zeroshot/src/native_v2_admission/tests.rs
+++ b/zeroshot/src/native_v2_admission/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::native_v2_contract::{
     ClaudeProvider, CodexProvider, DeclaredConnections, DeclaredEnvironment,
-    EnvironmentVariableName, GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF,
-    ResolvedSource, RunSize, RunTitle, SessionScope,
+    EnvironmentVariableName, GIT_DELIVERY_MERGE_V2_WORKER_REF, GIT_DELIVERY_MERGE_WORKER_REF,
+    GIT_DELIVERY_PR_WORKER_REF, ResolvedSource, RunSize, RunTitle, SessionScope,
 };
 use crate::native_v2_delivery::DeliveryMode;
 use crate::native_v2_delivery::contract::{delivery_result_schema, delivery_signal_labels};
@@ -44,7 +44,8 @@ fn authored_instructions(worker: &str) -> Value {
 fn delivery_verifier(name: &str, mode: DeliveryMode) -> Value {
     let worker = match mode {
         DeliveryMode::PullRequest => GIT_DELIVERY_PR_WORKER_REF,
-        DeliveryMode::Merge => GIT_DELIVERY_MERGE_WORKER_REF,
+        DeliveryMode::MergeV1 => GIT_DELIVERY_MERGE_WORKER_REF,
+        DeliveryMode::Merge => GIT_DELIVERY_MERGE_V2_WORKER_REF,
     };
     let output = delivery_result_schema(mode).assert_value();
     let labels = delivery_signal_labels(mode).assert_value();

--- a/zeroshot/src/native_v2_admission/tests/delivery.rs
+++ b/zeroshot/src/native_v2_admission/tests/delivery.rs
@@ -107,3 +107,63 @@ async fn enforces_graph_visible_delivery_policy_counts() {
         })
     );
 }
+
+#[tokio::test]
+async fn merge_profile_validation_rejects_pull_request_delivery() {
+    let pull_request = submission(
+        graph(vec![
+            delivery_verifier("deliver", DeliveryMode::PullRequest),
+            succeed("done"),
+        ]),
+        BTreeMap::from([(named("deliver"), delivery_binding())]),
+    );
+    assert_eq!(
+        NativeV2Admission
+            .validate_merge_profile(&pull_request.graph, &pull_request.runtime)
+            .await,
+        Err(NativeV2AdmissionError::MergeDeliveryRequired)
+    );
+
+    let merge = submission(
+        graph(vec![
+            delivery_verifier("deliver", DeliveryMode::Merge),
+            succeed("done"),
+        ]),
+        BTreeMap::from([(named("deliver"), delivery_binding())]),
+    );
+    NativeV2Admission
+        .validate_merge_profile(&merge.graph, &merge.runtime)
+        .await
+        .assert_value_with("merge plans accept the sole merge delivery worker");
+}
+
+#[tokio::test]
+async fn legacy_merge_worker_remains_admissible_but_is_not_a_merge_plan_profile() {
+    let legacy_graph = graph(vec![
+        delivery_verifier("deliver", DeliveryMode::MergeV1),
+        succeed("done"),
+    ]);
+    let legacy_nodes = BTreeMap::from([(named("deliver"), delivery_binding())]);
+
+    NativeV2Admission
+        .admit_with_policy(
+            submission(legacy_graph.clone(), legacy_nodes.clone()),
+            DeliveryPolicy::Required,
+        )
+        .await
+        .assert_value_with("stored merge@1 graphs remain admissible");
+
+    assert_eq!(
+        NativeV2Admission
+            .validate_merge_profile(
+                &legacy_graph,
+                &RuntimePlan::Claude {
+                    provider: ClaudeProvider::Anthropic,
+                    size: RunSize::Medium,
+                    nodes: legacy_nodes,
+                },
+            )
+            .await,
+        Err(NativeV2AdmissionError::MergeDeliveryRequired)
+    );
+}

--- a/zeroshot/src/native_v2_admission/validation.rs
+++ b/zeroshot/src/native_v2_admission/validation.rs
@@ -7,7 +7,8 @@ use openengine_cluster_protocol::{
 
 use super::{DeliveryPolicy, NativeV2AdmissionError};
 use crate::native_v2_contract::{
-    AdmittedRun, NodeRuntimeBinding, GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF,
+    AdmittedRun, NodeRuntimeBinding, GIT_DELIVERY_MERGE_V2_WORKER_REF,
+    GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF,
 };
 use crate::native_v2_delivery::{validate_delivery_contract, DeliveryMode};
 use crate::native_v2_runner::NodeResponseContract;
@@ -235,7 +236,9 @@ fn validate_delivery_policy(
 fn is_git_delivery_worker(worker: &WorkerRef) -> bool {
     matches!(
         worker.as_str(),
-        GIT_DELIVERY_PR_WORKER_REF | GIT_DELIVERY_MERGE_WORKER_REF
+        GIT_DELIVERY_PR_WORKER_REF
+            | GIT_DELIVERY_MERGE_WORKER_REF
+            | GIT_DELIVERY_MERGE_V2_WORKER_REF
     )
 }
 

--- a/zeroshot/src/native_v2_candidate/test_support.rs
+++ b/zeroshot/src/native_v2_candidate/test_support.rs
@@ -11,7 +11,7 @@ use serde_json::{Value, json};
 use crate::native_v2_admission::NativeV2Admission;
 use crate::native_v2_contract::{
     self, AdmittedRun, ExecutionId, ExecutionRef, NodeInstanceId, NodeInvocation,
-    NodeRuntimeBinding, RunSubmission, GIT_DELIVERY_MERGE_WORKER_REF,
+    NodeRuntimeBinding, RunSubmission, GIT_DELIVERY_MERGE_V2_WORKER_REF,
 };
 use crate::native_v2_delivery::{
     DELIVERY_CI_FAILED_LABEL, DELIVERY_CONFLICT_LABEL, DELIVERY_MERGED_LABEL, DeliveryMode,
@@ -152,7 +152,7 @@ pub(crate) fn success_node() -> Value {
 
 pub(crate) fn git_delivery_node() -> Value {
     serde_json::json!({
-        "kind":"verifier","name":"deliver","worker":GIT_DELIVERY_MERGE_WORKER_REF,
+        "kind":"verifier","name":"deliver","worker":GIT_DELIVERY_MERGE_V2_WORKER_REF,
         "input":{"kind":"null"},"output":delivery_result_schema(DeliveryMode::Merge)
             .assert_value_with("delivery result schema"),
         "inputBindings":[],"writeBindings":[],"timeoutMs":1000,"attempts":1,

--- a/zeroshot/src/native_v2_cli.rs
+++ b/zeroshot/src/native_v2_cli.rs
@@ -12,9 +12,10 @@ use async_trait::async_trait;
 use openengine_cluster_protocol::{
     ConnectionDeleteRequest, ConnectionDeleteResult, ConnectionKey, ConnectionListRequest,
     ConnectionListResult, ConnectionMutationResult, ConnectionScope, ConnectionSetRequest, Cursor,
-    EnvironmentVariableName, ExecutionRef, IdempotencyKey, RunAttachEventNotification,
-    RunAttachParams, RunForceParams, RunListParams, RunLogEventNotification, RunLogsParams, RunId,
-    RunConnectionValues, RunProfile, RunProfileDefaultRequest, RunProfileDefaultResult,
+    EnvironmentVariableName, ExecutionRef, IdempotencyKey, MergePlan, MergePlanId,
+    MergePlanRunRequest, MergePlanSource, RunAttachEventNotification, RunAttachParams,
+    RunConnectionValues, RunForceParams, RunId, RunListParams, RunLogEventNotification,
+    RunLogsParams, RunProfile, RunProfileDefaultRequest, RunProfileDefaultResult,
     RunProfileDeleteResult, RunProfileListRequest, RunProfileListResult, RunProfileMutationResult,
     RunProfileName, RunProfileSelector, RunProfileSetRequest, RunStatusParams, RunTitle,
     RunWatchParams, ResolvedSource, SourceBranchId, SourceRepositoryId, SourceRevisionId,
@@ -160,6 +161,33 @@ impl fmt::Debug for PreparedRunRequest {
     }
 }
 
+/// CLI-materialized hosted merge plan with an explicit unresolved source selector.
+#[derive(Clone, PartialEq)]
+pub struct PreparedMergePlanRequest {
+    pub submission_key: IdempotencyKey,
+    pub title: RunTitle,
+    pub expires_at: String,
+    pub source: MergePlanSource,
+    pub profile: RunProfileSelector,
+    pub runs: Vec<MergePlanRunRequest>,
+    pub connections: RunConnectionValues,
+    pub github_token: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MergePlanSubmitCommand {
+    pub target: String,
+    pub file: PathBuf,
+    pub detach: bool,
+    pub submission_key: IdempotencyKey,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MergePlanSelector {
+    pub target: String,
+    pub plan_id: MergePlanId,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NamedRunSource {
     pub resolved: ResolvedSource,
@@ -228,6 +256,13 @@ pub enum NativeV2CliCommand {
         template: BuiltinGraphTemplate,
         delivery: TemplateDelivery,
     },
+    PlanValidate {
+        file: PathBuf,
+    },
+    PlanSubmit(MergePlanSubmitCommand),
+    PlanStatus(MergePlanSelector),
+    PlanWatch(MergePlanSelector),
+    PlanForceStop(MergePlanSelector),
     Run(RunCommand),
     List {
         target: Option<String>,
@@ -249,6 +284,13 @@ impl NativeV2CliCommand {
             Self::Version => Some(VERSION),
             _ => None,
         }
+    }
+
+    fn is_plan_operation(&self) -> bool {
+        matches!(
+            self,
+            Self::PlanSubmit(_) | Self::PlanStatus(_) | Self::PlanWatch(_) | Self::PlanForceStop(_)
+        )
     }
 
     fn is_connection_operation(&self) -> bool {
@@ -338,6 +380,8 @@ pub enum NativeV2CliError {
     Disconnected,
     #[error("run finished unsuccessfully")]
     RunFailed,
+    #[error("merge plan finished unsuccessfully")]
+    MergePlanFailed,
     #[error("could not write CLI output: {0}")]
     Output(#[from] std::io::Error),
     #[error("could not encode CLI output: {0}")]
@@ -458,6 +502,36 @@ pub trait NativeV2CliBackend: Send + Sync {
     ) -> Result<RunProfileDefaultResult, NativeV2CliError> {
         Err(NativeV2CliError::Target(
             "target does not advertise profile management".to_owned(),
+        ))
+    }
+
+    async fn merge_plan_submit(
+        &self,
+        _target: &str,
+        _request: PreparedMergePlanRequest,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        Err(NativeV2CliError::Target(
+            "target does not advertise merge plans".to_owned(),
+        ))
+    }
+
+    async fn merge_plan_status(
+        &self,
+        _target: &str,
+        _plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        Err(NativeV2CliError::Target(
+            "target does not advertise merge plans".to_owned(),
+        ))
+    }
+
+    async fn merge_plan_force(
+        &self,
+        _target: &str,
+        _plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        Err(NativeV2CliError::Target(
+            "target does not advertise merge plans".to_owned(),
         ))
     }
 

--- a/zeroshot/src/native_v2_cli/execution.rs
+++ b/zeroshot/src/native_v2_cli/execution.rs
@@ -21,6 +21,8 @@ mod attach;
 mod connections;
 #[path = "execution/context.rs"]
 mod context;
+#[path = "execution/merge_plans.rs"]
+mod merge_plans;
 #[path = "execution/profiles.rs"]
 mod profiles;
 #[path = "execution/status.rs"]
@@ -62,6 +64,9 @@ where
 {
     if let Some(outcome) = try_execute_native_v2_static(&command, output)? {
         return Ok(outcome);
+    }
+    if command.is_plan_operation() {
+        return merge_plans::execute(command, context, signal, output).await;
     }
     if command.is_connection_operation() {
         return connections::execute_connection(command, context.backend, output).await;

--- a/zeroshot/src/native_v2_cli/execution/merge_plans.rs
+++ b/zeroshot/src/native_v2_cli/execution/merge_plans.rs
@@ -1,0 +1,528 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::Path;
+use std::time::Duration;
+
+use openengine_cluster_protocol::{
+    IdempotencyKey, MergePlan, MergePlanRunName, MergePlanRunRequest, MergePlanSource,
+    MergePlanState, RunProfile, RunProfileName, RunProfileScope, RunProfileSelector, RunTitle,
+    MAX_MERGE_PLAN_RUNS, MERGE_PLAN_SCHEMA,
+};
+use serde::Deserialize;
+use time::format_description::well_known::Rfc3339;
+use time::{Duration as TimeDuration, OffsetDateTime};
+
+use super::submission::{read_json, select_connections, validate_github_token};
+use super::{CliExecutionContext, write_json};
+use crate::native_v2_admission::NativeV2Admission;
+use crate::native_v2_cli::{
+    CliOutcome, DetachSignal, MergePlanSelector, MergePlanSubmitCommand, NativeV2CliBackend,
+    NativeV2CliCommand, NativeV2CliError, PreparedMergePlanRequest,
+};
+
+const PLAN_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct MergePlanManifest {
+    schema: String,
+    title: RunTitle,
+    source: MergePlanSource,
+    profile: String,
+    expires_at: String,
+    runs: BTreeMap<String, MergePlanManifestRun>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MergePlanManifestRun {
+    input: serde_json::Value,
+    #[serde(default)]
+    needs: Vec<String>,
+}
+
+struct ValidatedMergePlan {
+    title: RunTitle,
+    source: MergePlanSource,
+    profile: RunProfileSelector,
+    expires_at: String,
+    runs: Vec<MergePlanRunRequest>,
+}
+
+pub(super) fn validate_file(
+    path: &Path,
+    output: &mut impl Write,
+) -> Result<CliOutcome, NativeV2CliError> {
+    load_manifest(path)?;
+    write_json(output, &serde_json::json!({ "valid": true }))?;
+    Ok(CliOutcome::Completed)
+}
+
+pub(super) async fn execute<B, S>(
+    command: NativeV2CliCommand,
+    context: &CliExecutionContext<'_, B>,
+    signal: &mut S,
+    output: &mut impl Write,
+) -> Result<CliOutcome, NativeV2CliError>
+where
+    B: NativeV2CliBackend,
+    S: DetachSignal,
+{
+    match command {
+        NativeV2CliCommand::PlanSubmit(command) => submit(command, context, signal, output).await,
+        NativeV2CliCommand::PlanStatus(selector) => {
+            unary(selector, context.backend, output, PlanOperation::Status).await
+        }
+        NativeV2CliCommand::PlanWatch(selector) => {
+            watch(selector, context.backend, signal, output).await
+        }
+        NativeV2CliCommand::PlanForceStop(selector) => {
+            unary(selector, context.backend, output, PlanOperation::Force).await
+        }
+        _ => Err(NativeV2CliError::Usage(
+            "expected a merge-plan operation".to_owned(),
+        )),
+    }
+}
+
+async fn submit<B, S>(
+    command: MergePlanSubmitCommand,
+    context: &CliExecutionContext<'_, B>,
+    signal: &mut S,
+    output: &mut impl Write,
+) -> Result<CliOutcome, NativeV2CliError>
+where
+    B: NativeV2CliBackend,
+    S: DetachSignal,
+{
+    let manifest = load_manifest(&command.file)?;
+    let profile = context
+        .backend
+        .profile_show(Some(&command.target), manifest.profile.clone())
+        .await?;
+    validate_profile_and_inputs(&profile, &manifest.runs).await?;
+    let request = prepared_request(
+        command.submission_key,
+        manifest,
+        &profile,
+        context.environment,
+    )?;
+    let plan = context
+        .backend
+        .merge_plan_submit(&command.target, request)
+        .await?;
+    write_json(output, &plan)?;
+    if command.detach {
+        return Ok(CliOutcome::Detached);
+    }
+    let outcome = follow(
+        plan,
+        PlanFollow {
+            target: &command.target,
+            backend: context.backend,
+        },
+        signal,
+        output,
+    )
+    .await?;
+    foreground_outcome(outcome)
+}
+
+fn prepared_request(
+    submission_key: IdempotencyKey,
+    manifest: ValidatedMergePlan,
+    profile: &RunProfile,
+    environment: &dyn Fn(&str) -> Option<OsString>,
+) -> Result<PreparedMergePlanRequest, NativeV2CliError> {
+    let connections = select_connections(&profile.runtime, environment)?;
+    let github_token = environment("GH_TOKEN")
+        .map(|value| {
+            value
+                .into_string()
+                .map_err(|_| NativeV2CliError::GitHubToken)
+        })
+        .transpose()?
+        .map(validate_github_token)
+        .transpose()?;
+    Ok(PreparedMergePlanRequest {
+        submission_key,
+        title: manifest.title,
+        expires_at: manifest.expires_at,
+        source: manifest.source,
+        profile: manifest.profile,
+        runs: manifest.runs,
+        connections,
+        github_token,
+    })
+}
+
+async fn validate_profile_and_inputs(
+    profile: &RunProfile,
+    runs: &[MergePlanRunRequest],
+) -> Result<(), NativeV2CliError> {
+    NativeV2Admission
+        .validate_merge_profile(&profile.graph, &profile.runtime)
+        .await
+        .map_err(NativeV2CliError::InvalidRun)?;
+    for run in runs {
+        profile
+            .graph
+            .initial_input
+            .validate_value(&run.initial_input)
+            .map_err(|error| NativeV2CliError::InitialInput(error.to_string()))?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum PlanOperation {
+    Status,
+    Force,
+}
+
+async fn unary<B: NativeV2CliBackend>(
+    selector: MergePlanSelector,
+    backend: &B,
+    output: &mut impl Write,
+    operation: PlanOperation,
+) -> Result<CliOutcome, NativeV2CliError> {
+    let plan = match operation {
+        PlanOperation::Status => {
+            backend
+                .merge_plan_status(&selector.target, selector.plan_id)
+                .await?
+        }
+        PlanOperation::Force => {
+            backend
+                .merge_plan_force(&selector.target, selector.plan_id)
+                .await?
+        }
+    };
+    write_json(output, &plan)?;
+    Ok(CliOutcome::Completed)
+}
+
+async fn watch<B, S>(
+    selector: MergePlanSelector,
+    backend: &B,
+    signal: &mut S,
+    output: &mut impl Write,
+) -> Result<CliOutcome, NativeV2CliError>
+where
+    B: NativeV2CliBackend,
+    S: DetachSignal,
+{
+    let plan = backend
+        .merge_plan_status(&selector.target, selector.plan_id)
+        .await?;
+    write_json(output, &plan)?;
+    let outcome = follow(
+        plan,
+        PlanFollow {
+            target: &selector.target,
+            backend,
+        },
+        signal,
+        output,
+    )
+    .await?;
+    foreground_outcome(outcome)
+}
+
+struct PlanFollow<'a, B> {
+    target: &'a str,
+    backend: &'a B,
+}
+
+async fn follow<B, S>(
+    mut current: MergePlan,
+    follow: PlanFollow<'_, B>,
+    signal: &mut S,
+    output: &mut impl Write,
+) -> Result<CliOutcome, NativeV2CliError>
+where
+    B: NativeV2CliBackend,
+    S: DetachSignal,
+{
+    while !current.state.is_terminal() {
+        tokio::select! {
+            () = signal.wait() => return Ok(CliOutcome::Detached),
+            () = tokio::time::sleep(PLAN_POLL_INTERVAL) => {}
+        }
+        let next = follow
+            .backend
+            .merge_plan_status(follow.target, current.plan_id.clone())
+            .await?;
+        if next != current {
+            write_json(output, &next)?;
+            current = next;
+        }
+    }
+    Ok(outcome_for_plan(&current))
+}
+
+fn outcome_for_plan(plan: &MergePlan) -> CliOutcome {
+    match plan.state {
+        MergePlanState::Succeeded => CliOutcome::Finished,
+        MergePlanState::Failed | MergePlanState::Cancelled | MergePlanState::Expired => {
+            CliOutcome::Failed
+        }
+        MergePlanState::Queued | MergePlanState::Running => CliOutcome::Completed,
+    }
+}
+
+fn foreground_outcome(outcome: CliOutcome) -> Result<CliOutcome, NativeV2CliError> {
+    match outcome {
+        CliOutcome::Failed => Err(NativeV2CliError::MergePlanFailed),
+        outcome => Ok(outcome),
+    }
+}
+
+fn load_manifest(path: &Path) -> Result<ValidatedMergePlan, NativeV2CliError> {
+    let manifest = read_json::<MergePlanManifest>("merge plan", path)?;
+    if manifest.schema != MERGE_PLAN_SCHEMA {
+        return Err(plan_usage(format!("schema must be {MERGE_PLAN_SCHEMA:?}")));
+    }
+    validate_deadline(&manifest.expires_at)?;
+    let profile = parse_profile(&manifest.profile)?;
+    let runs = compile_runs(&manifest.title, manifest.runs)?;
+    Ok(ValidatedMergePlan {
+        title: manifest.title,
+        source: manifest.source,
+        profile,
+        expires_at: manifest.expires_at,
+        runs,
+    })
+}
+
+fn validate_deadline(value: &str) -> Result<(), NativeV2CliError> {
+    validate_deadline_at(value, OffsetDateTime::now_utc())
+}
+
+fn validate_deadline_at(value: &str, now: OffsetDateTime) -> Result<(), NativeV2CliError> {
+    let expires = OffsetDateTime::parse(value, &Rfc3339)
+        .map_err(|_| plan_usage("expiresAt must be an RFC 3339 timestamp"))?;
+    if expires <= now {
+        return Err(plan_usage("expiresAt must be in the future"));
+    }
+    if expires > now + TimeDuration::days(7) {
+        return Err(plan_usage("expiresAt must be at most seven days away"));
+    }
+    Ok(())
+}
+
+fn parse_profile(value: &str) -> Result<RunProfileSelector, NativeV2CliError> {
+    let (scope, name) = value
+        .split_once(':')
+        .ok_or_else(|| plan_usage("profile must be user:NAME or org:NAME"))?;
+    let scope = match scope {
+        "user" => RunProfileScope::User,
+        "org" => RunProfileScope::Org,
+        _ => return Err(plan_usage("profile must be user:NAME or org:NAME")),
+    };
+    let name = RunProfileName::new(name)
+        .map_err(|error| plan_usage(format!("invalid profile: {error}")))?;
+    Ok(RunProfileSelector { scope, name })
+}
+
+fn compile_runs(
+    title: &RunTitle,
+    raw: BTreeMap<String, MergePlanManifestRun>,
+) -> Result<Vec<MergePlanRunRequest>, NativeV2CliError> {
+    if raw.is_empty() || raw.len() > MAX_MERGE_PLAN_RUNS {
+        return Err(plan_usage(format!(
+            "runs must contain 1..={MAX_MERGE_PLAN_RUNS} nodes"
+        )));
+    }
+    let names = raw
+        .keys()
+        .map(|name| {
+            MergePlanRunName::new(name)
+                .map_err(|error| plan_usage(format!("invalid run name {name:?}: {error}")))
+        })
+        .collect::<Result<BTreeSet<_>, _>>()?;
+    let mut runs = Vec::with_capacity(raw.len());
+    for (raw_name, run) in raw {
+        let name =
+            MergePlanRunName::new(raw_name).map_err(|error| plan_usage(error.to_string()))?;
+        validate_derived_title(title, &name)?;
+        let needs = compile_needs(&name, run.needs, &names)?;
+        runs.push(MergePlanRunRequest {
+            name,
+            needs,
+            initial_input: run.input,
+        });
+    }
+    validate_acyclic(&runs)?;
+    Ok(runs)
+}
+
+fn validate_derived_title(
+    title: &RunTitle,
+    name: &MergePlanRunName,
+) -> Result<(), NativeV2CliError> {
+    RunTitle::new(format!("{}: {}", title.as_str(), name.as_str()))
+        .map(|_| ())
+        .map_err(|_| {
+            plan_usage(format!(
+                "derived title for run {:?} is too long",
+                name.as_str()
+            ))
+        })
+}
+
+fn compile_needs(
+    name: &MergePlanRunName,
+    raw: Vec<String>,
+    names: &BTreeSet<MergePlanRunName>,
+) -> Result<Vec<MergePlanRunName>, NativeV2CliError> {
+    let needs = raw
+        .into_iter()
+        .map(|need| {
+            MergePlanRunName::new(need)
+                .map_err(|error| plan_usage(format!("invalid dependency: {error}")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let unique = needs.iter().cloned().collect::<BTreeSet<_>>();
+    if unique.len() != needs.len() {
+        return Err(plan_usage(format!(
+            "run {:?} lists a dependency more than once",
+            name.as_str()
+        )));
+    }
+    if unique.contains(name) {
+        return Err(plan_usage(format!(
+            "run {:?} cannot depend on itself",
+            name.as_str()
+        )));
+    }
+    if let Some(missing) = unique.iter().find(|need| !names.contains(*need)) {
+        return Err(plan_usage(format!(
+            "run {:?} needs missing run {:?}",
+            name.as_str(),
+            missing.as_str()
+        )));
+    }
+    Ok(unique.into_iter().collect())
+}
+
+fn validate_acyclic(runs: &[MergePlanRunRequest]) -> Result<(), NativeV2CliError> {
+    let mut completed = BTreeSet::new();
+    loop {
+        let before = completed.len();
+        for run in runs {
+            if run.needs.iter().all(|need| completed.contains(need)) {
+                completed.insert(run.name.clone());
+            }
+        }
+        if completed.len() == runs.len() {
+            return Ok(());
+        }
+        if completed.len() == before {
+            return Err(plan_usage("runs must form an acyclic graph"));
+        }
+    }
+}
+
+fn plan_usage(message: impl Into<String>) -> NativeV2CliError {
+    NativeV2CliError::Usage(format!("invalid merge plan: {}", message.into()))
+}
+
+#[cfg(test)]
+fn test_manifest_json() -> serde_json::Value {
+    serde_json::json!({
+        "schema": MERGE_PLAN_SCHEMA,
+        "title": "Release",
+        "source": {"repository": "owner/repo", "branch": "main"},
+        "profile": "org:software-change",
+        "expiresAt": "2026-09-11T00:00:00Z",
+        "runs": {"build": {"input": {}}}
+    })
+}
+
+#[cfg(test)]
+fn test_run(input: i64, needs: &[&str]) -> MergePlanManifestRun {
+    MergePlanManifestRun {
+        input: serde_json::json!({ "value": input }),
+        needs: needs.iter().map(|value| (*value).to_owned()).collect(),
+    }
+}
+
+#[test]
+fn manifest_json_rejects_unknown_fields_at_every_level() {
+    let mut top_level = test_manifest_json();
+    top_level["extra"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<MergePlanManifest>(top_level).is_err());
+
+    let mut node = test_manifest_json();
+    node["runs"]["build"]["outputFrom"] = serde_json::json!("other");
+    assert!(serde_json::from_value::<MergePlanManifest>(node).is_err());
+}
+
+#[test]
+fn manifest_compiler_preserves_static_inputs_and_dependencies() {
+    let mut raw = BTreeMap::new();
+    raw.insert("build".to_owned(), test_run(1, &[]));
+    raw.insert("integrate".to_owned(), test_run(2, &["build"]));
+    let runs = compile_runs(&RunTitle::new("Release").unwrap(), raw).unwrap();
+
+    assert_eq!(runs.len(), 2);
+    assert_eq!(runs[0].name.as_str(), "build");
+    assert!(runs[0].needs.is_empty());
+    assert_eq!(runs[1].name.as_str(), "integrate");
+    assert_eq!(runs[1].needs[0].as_str(), "build");
+    assert_eq!(runs[1].initial_input, serde_json::json!({ "value": 2 }));
+}
+
+#[test]
+fn manifest_compiler_canonicalizes_dependency_order() {
+    let name = MergePlanRunName::new("integrate").unwrap();
+    let names = ["backend", "frontend", "integrate"]
+        .map(|value| MergePlanRunName::new(value).unwrap())
+        .into_iter()
+        .collect();
+    let needs = compile_needs(
+        &name,
+        vec!["frontend".to_owned(), "backend".to_owned()],
+        &names,
+    )
+    .unwrap();
+
+    assert_eq!(
+        needs
+            .iter()
+            .map(MergePlanRunName::as_str)
+            .collect::<Vec<_>>(),
+        ["backend", "frontend"]
+    );
+}
+
+#[test]
+fn manifest_compiler_rejects_invalid_dependency_graphs() {
+    let title = RunTitle::new("Release").unwrap();
+    let mut missing = BTreeMap::new();
+    missing.insert("build".to_owned(), test_run(1, &["absent"]));
+    assert!(compile_runs(&title, missing).is_err());
+
+    let mut self_edge = BTreeMap::new();
+    self_edge.insert("build".to_owned(), test_run(1, &["build"]));
+    assert!(compile_runs(&title, self_edge).is_err());
+
+    let mut cycle = BTreeMap::new();
+    cycle.insert("a".to_owned(), test_run(1, &["b"]));
+    cycle.insert("b".to_owned(), test_run(2, &["a"]));
+    assert!(compile_runs(&title, cycle).is_err());
+}
+
+#[test]
+fn manifest_requires_scoped_profile_and_rfc3339_deadline() {
+    assert!(parse_profile("org:software-change").is_ok());
+    assert!(parse_profile("software-change").is_err());
+    assert!(parse_profile("local:software-change").is_err());
+    let now = OffsetDateTime::parse("2026-09-10T00:00:00Z", &Rfc3339).unwrap();
+    assert!(validate_deadline_at("2026-09-11T00:00:00Z", now).is_ok());
+    assert!(validate_deadline_at("2026-09-09T00:00:00Z", now).is_err());
+    assert!(validate_deadline_at("2026-09-18T00:00:00Z", now).is_err());
+    assert!(validate_deadline_at("tomorrow", now).is_err());
+}

--- a/zeroshot/src/native_v2_cli/execution/submission.rs
+++ b/zeroshot/src/native_v2_cli/execution/submission.rs
@@ -80,6 +80,9 @@ pub fn try_execute_native_v2_static(
         return Ok(Some(CliOutcome::Completed));
     }
     let outcome = match command {
+        NativeV2CliCommand::PlanValidate { file } => {
+            return super::merge_plans::validate_file(file, output).map(Some);
+        }
         NativeV2CliCommand::TemplateList => execute_template_list(output)?,
         NativeV2CliCommand::TemplateShow { template, delivery } => {
             execute_template_show(*template, *delivery, output)?
@@ -201,7 +204,7 @@ fn named_source_record(run: &RunCommand, params: &PreparedRunRequest) -> Option<
     }))
 }
 
-fn validate_github_token(value: String) -> Result<String, NativeV2CliError> {
+pub(super) fn validate_github_token(value: String) -> Result<String, NativeV2CliError> {
     if value.is_empty() || value.len() > 4_096 || value.contains('\0') {
         Err(NativeV2CliError::GitHubToken)
     } else {
@@ -234,7 +237,7 @@ fn prepare_intent(
     })
 }
 
-fn select_connections<F>(
+pub(super) fn select_connections<F>(
     runtime: &RuntimePlan,
     available: F,
 ) -> Result<RunConnectionValues, NativeV2CliError>
@@ -482,7 +485,7 @@ fn validate_graph_profile(graph: &GraphSpec) -> Result<(), NativeV2CliError> {
     ))
 }
 
-fn read_json<T>(kind: &'static str, path: &Path) -> Result<T, NativeV2CliError>
+pub(super) fn read_json<T>(kind: &'static str, path: &Path) -> Result<T, NativeV2CliError>
 where
     T: serde::de::DeserializeOwned,
 {

--- a/zeroshot/src/native_v2_cli/oecp.rs
+++ b/zeroshot/src/native_v2_cli/oecp.rs
@@ -8,18 +8,19 @@ use openengine_cluster_client::{
 };
 use openengine_cluster_protocol::{
     ConnectionDeleteRequest, ConnectionDeleteResult, ConnectionListRequest, ConnectionListResult,
-    ConnectionMutationResult, ConnectionSetRequest, Cursor, RunAttachEventNotification,
-    RunAttachParams, RunForceParams, RunListParams, RunLogEventNotification, RunLogsParams,
-    RunProfile, RunProfileDefaultRequest, RunProfileDefaultResult, RunProfileDeleteResult,
-    RunProfileListRequest, RunProfileListResult, RunProfileMutationResult, RunProfileSelector,
-    RunProfileSetRequest, RunStatus, RunStatusParams, RunSubmitResult, RunWatchParams,
+    ConnectionMutationResult, ConnectionSetRequest, Cursor, MergePlan, MergePlanId,
+    RunAttachEventNotification, RunAttachParams, RunForceParams, RunListParams,
+    RunLogEventNotification, RunLogsParams, RunProfile, RunProfileDefaultRequest,
+    RunProfileDefaultResult, RunProfileDeleteResult, RunProfileListRequest, RunProfileListResult,
+    RunProfileMutationResult, RunProfileSelector, RunProfileSetRequest, RunStatus, RunStatusParams,
+    RunSubmitResult, RunWatchParams,
 };
 use tokio::sync::mpsc;
 
 use super::{
     CliRunForceResult, CliRunListResult, CliRunStatus, CliRunStatusResult,
     CliRunWatchEventNotification, CliSubscription, CliSubscriptionItem, NativeV2CliBackend,
-    NativeV2CliError, PreparedRunRequest, TargetAdd,
+    NativeV2CliError, PreparedMergePlanRequest, PreparedRunRequest, TargetAdd,
 };
 
 #[path = "oecp/errors.rs"]
@@ -213,6 +214,30 @@ where
         self.connector
             .profile_default(require_named_target(target)?, request)
             .await
+    }
+
+    async fn merge_plan_submit(
+        &self,
+        target: &str,
+        request: PreparedMergePlanRequest,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        self.connector.merge_plan_submit(target, request).await
+    }
+
+    async fn merge_plan_status(
+        &self,
+        target: &str,
+        plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        self.connector.merge_plan_status(target, plan_id).await
+    }
+
+    async fn merge_plan_force(
+        &self,
+        target: &str,
+        plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        self.connector.merge_plan_force(target, plan_id).await
     }
 
     async fn run_submit(

--- a/zeroshot/src/native_v2_cli/oecp/target_connector.rs
+++ b/zeroshot/src/native_v2_cli/oecp/target_connector.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use openengine_cluster_client::SubscriptionTransport;
 use openengine_cluster_protocol::{
     ConnectionDeleteRequest, ConnectionDeleteResult, ConnectionListRequest, ConnectionListResult,
-    ConnectionMutationResult, ConnectionSetRequest, RunForceParams, RunListParams,
-    RunLogEventNotification, RunLogsParams, RunProfile, RunProfileDefaultRequest,
+    ConnectionMutationResult, ConnectionSetRequest, MergePlan, MergePlanId, RunForceParams,
+    RunListParams, RunLogEventNotification, RunLogsParams, RunProfile, RunProfileDefaultRequest,
     RunProfileDefaultResult, RunProfileDeleteResult, RunProfileListRequest, RunProfileListResult,
     RunProfileMutationResult, RunProfileSelector, RunProfileSetRequest, RunStatusParams,
     RunSubmitResult, RunWatchParams,
@@ -14,7 +14,7 @@ use openengine_cluster_protocol::{
 use super::BoxedSubscription;
 use crate::native_v2_cli::{
     CliRunForceResult, CliRunListResult, CliRunStatusResult, CliRunWatchEventNotification,
-    NativeV2CliError, PreparedRunRequest, TargetAdd,
+    NativeV2CliError, PreparedMergePlanRequest, PreparedRunRequest, TargetAdd,
 };
 
 /// Named-target authority. The CLI does not interpret login credentials or runtime configuration.
@@ -64,6 +64,33 @@ pub trait TargetConnector: Send + Sync {
         name: &str,
         request: RunProfileDefaultRequest,
     ) -> Result<RunProfileDefaultResult, NativeV2CliError>;
+    async fn merge_plan_submit(
+        &self,
+        _name: &str,
+        _request: PreparedMergePlanRequest,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        Err(NativeV2CliError::Target(
+            "target does not advertise merge plans".to_owned(),
+        ))
+    }
+    async fn merge_plan_status(
+        &self,
+        _name: &str,
+        _plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        Err(NativeV2CliError::Target(
+            "target does not advertise merge plans".to_owned(),
+        ))
+    }
+    async fn merge_plan_force(
+        &self,
+        _name: &str,
+        _plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        Err(NativeV2CliError::Target(
+            "target does not advertise merge plans".to_owned(),
+        ))
+    }
     async fn submit(
         &self,
         name: &str,

--- a/zeroshot/src/native_v2_cli/parser.rs
+++ b/zeroshot/src/native_v2_cli/parser.rs
@@ -49,6 +49,12 @@ enum CliCommand {
         command: TemplateCommand,
     },
 
+    /// Validate, submit, and observe hosted merge plans.
+    Plan {
+        #[command(subcommand)]
+        command: PlanCommand,
+    },
+
     /// Submit a graph run locally or to a named target.
     ///
     /// When --target is omitted, the run uses the current local repository. A foreground run
@@ -84,6 +90,44 @@ enum UtilityCommand {
 
     /// Print the Zeroshot version.
     Version,
+}
+
+#[derive(Debug, Subcommand)]
+#[command(after_long_help = r#"MANIFEST
+The JSON manifest is strict and self-contained:
+
+  {
+    "schema": "zeroshot.merge-plan/v1",
+    "title": "Release checkout update",
+    "source": {"repository": "owner/repo", "branch": "main"},
+    "profile": "org:software-change",
+    "expiresAt": "<RFC3339 timestamp within 7 days>",
+    "runs": {
+      "backend": {"input": {"task": "Update the API."}},
+      "integrate": {"needs": ["backend"], "input": {"task": "Run release tests."}}
+    }
+  }
+
+Every run uses the same source and profile. The profile must contain exactly one merge-delivery node;
+pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
+Cloud assigns all run IDs atomically, resolves each exact source revision only when that run becomes
+ready, and starts its 24-hour queue deadline then. `expiresAt` must be in the future and no more than
+seven days away. Plans cannot be edited or retried in place."#)]
+enum PlanCommand {
+    /// Validate a merge-plan manifest without contacting a target.
+    Validate(PlanFileArgs),
+
+    /// Atomically submit every node in a merge-plan manifest.
+    Submit(PlanSubmitArgs),
+
+    /// Read a merge plan's aggregate status as JSON.
+    Status(PlanSelectorArgs),
+
+    /// Poll a merge plan and stream changed snapshots as NDJSON.
+    Watch(PlanSelectorArgs),
+
+    /// Force every nonterminal run in a merge plan to stop.
+    ForceStop(PlanSelectorArgs),
 }
 
 #[derive(Debug, Subcommand)]
@@ -381,6 +425,43 @@ struct RunArgs {
 
     #[command(flatten)]
     delivery: DeliveryArgs,
+}
+
+#[derive(Debug, Args)]
+struct PlanFileArgs {
+    /// Merge-plan manifest JSON file.
+    #[arg(value_name = "FILE")]
+    file: PathBuf,
+}
+
+#[derive(Debug, Args)]
+struct PlanSubmitArgs {
+    /// Merge-plan manifest JSON file.
+    #[arg(value_name = "FILE")]
+    file: PathBuf,
+
+    /// Submit to this named hosted target.
+    #[arg(long, value_name = "NAME")]
+    target: String,
+
+    /// Stable idempotency key for safely retrying the atomic submission.
+    #[arg(long, value_name = "KEY")]
+    submission_key: String,
+
+    /// Return after atomic submission instead of polling plan status.
+    #[arg(short = 'd', long)]
+    detach: bool,
+}
+
+#[derive(Debug, Args)]
+struct PlanSelectorArgs {
+    /// Immutable merge-plan ID.
+    #[arg(value_name = "PLAN_ID")]
+    plan_id: String,
+
+    /// Use this named hosted target.
+    #[arg(long, value_name = "NAME")]
+    target: String,
 }
 
 #[derive(Debug, Args)]

--- a/zeroshot/src/native_v2_cli/parser/convert.rs
+++ b/zeroshot/src/native_v2_cli/parser/convert.rs
@@ -8,14 +8,15 @@ use openengine_cluster_protocol::{
 };
 
 use super::{
-    AttachArgs, Cli, CliCommand, ConnectionCommand, ConnectionScopeArg, RunArgs, RunLogsArgs,
-    RunSelectorArgs, RunWatchArgs, TargetCommand, TemplateCommand, TemplateName, UtilityCommand,
+    AttachArgs, Cli, CliCommand, ConnectionCommand, ConnectionScopeArg, PlanCommand,
+    PlanSelectorArgs, PlanSubmitArgs, RunArgs, RunLogsArgs, RunSelectorArgs, RunWatchArgs,
+    TargetCommand, TemplateCommand, TemplateName, UtilityCommand,
 };
 use crate::native_v2_cli::{
     BuiltinGraphTemplate, ConnectionInput, ConnectionRoute, ConnectionSetCommand,
-    NativeV2CliCommand, NativeV2CliError, ProfileQualifier, ProfileReference, RunCommand, RunGraph,
-    RunLogsCommand, RunRuntime, RunSelection, RunSelector, RunWatchCommand, TargetAdd, TargetServe,
-    TemplateDelivery,
+    MergePlanSelector, MergePlanSubmitCommand, NativeV2CliCommand, NativeV2CliError,
+    ProfileQualifier, ProfileReference, RunCommand, RunGraph, RunLogsCommand, RunRuntime,
+    RunSelection, RunSelector, RunWatchCommand, TargetAdd, TargetServe, TemplateDelivery,
 };
 
 #[path = "convert/profile_commands.rs"]
@@ -63,6 +64,7 @@ impl CliCommand {
             Self::Connection { command } => command.into_command(),
             Self::Profile { command } => command.into_command(),
             Self::Template { command } => command.into_command(),
+            Self::Plan { command } => command.into_command(),
             Self::Run(args) => args.into_command(),
             Self::Utility(command) => command.into_command(),
         }
@@ -189,6 +191,40 @@ impl TemplateCommand {
             }
         }
     }
+}
+
+impl PlanCommand {
+    fn into_command(self) -> Result<NativeV2CliCommand, NativeV2CliError> {
+        match self {
+            Self::Validate(args) => Ok(NativeV2CliCommand::PlanValidate { file: args.file }),
+            Self::Submit(args) => args.into_command(),
+            Self::Status(args) => plan_selector(args).map(NativeV2CliCommand::PlanStatus),
+            Self::Watch(args) => plan_selector(args).map(NativeV2CliCommand::PlanWatch),
+            Self::ForceStop(args) => plan_selector(args).map(NativeV2CliCommand::PlanForceStop),
+        }
+    }
+}
+
+impl PlanSubmitArgs {
+    fn into_command(self) -> Result<NativeV2CliCommand, NativeV2CliError> {
+        let target = required_target(self.target)?;
+        let submission_key = IdempotencyKey::new(self.submission_key)
+            .map_err(|error| usage(format!("invalid --submission-key: {error}")))?;
+        Ok(NativeV2CliCommand::PlanSubmit(MergePlanSubmitCommand {
+            target,
+            file: self.file,
+            detach: self.detach,
+            submission_key,
+        }))
+    }
+}
+
+fn plan_selector(args: PlanSelectorArgs) -> Result<MergePlanSelector, NativeV2CliError> {
+    validate_public_id(&args.plan_id, "plan ID")?;
+    Ok(MergePlanSelector {
+        target: required_target(args.target)?,
+        plan_id: openengine_cluster_protocol::MergePlanId::new(args.plan_id),
+    })
 }
 
 impl TemplateName {
@@ -448,6 +484,11 @@ fn template_delivery(
         ));
     }
     Ok(delivery)
+}
+
+fn required_target(target: String) -> Result<String, NativeV2CliError> {
+    validate_public_id(&target, "target name")?;
+    Ok(target)
 }
 
 fn validated_target(target: Option<String>) -> Result<Option<String>, NativeV2CliError> {

--- a/zeroshot/src/native_v2_cli/tests/outcome.rs
+++ b/zeroshot/src/native_v2_cli/tests/outcome.rs
@@ -1,7 +1,9 @@
+use openengine_cluster_protocol::MergePlanState;
 use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
 use serde_json::json;
 
 use super::*;
+use crate::native_v2_cli::execution::{CliExecutionContext, execute_native_v2_cli_with_context};
 
 #[test]
 fn version_reports_the_packaged_binary_version_without_a_backend() {
@@ -29,4 +31,123 @@ async fn foreground_run_reports_a_terminal_failure_after_printing_it() {
             .assert_value()
             .contains("\"reason\":\"worker_failed\"")
     );
+}
+
+fn merge_plan_fixture() -> FixtureFiles {
+    let expires = time::OffsetDateTime::now_utc() + time::Duration::days(1);
+    let expires_at = format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        expires.year(),
+        u8::from(expires.month()),
+        expires.day(),
+        expires.hour(),
+        expires.minute(),
+        expires.second()
+    );
+    FixtureFiles::new(
+        graph(),
+        json!({
+            "schema":"zeroshot.merge-plan/v1",
+            "title":"Release",
+            "source":{"repository":"open-engine/zeroshot","branch":"main"},
+            "profile":"org:software-change",
+            "expiresAt":expires_at,
+            "runs":{"build":{"input":{"task":"fail"}}}
+        }),
+    )
+}
+
+fn plan_submit_command(file: &Path, detach: bool) -> NativeV2CliCommand {
+    let mut values = vec![
+        OsString::from("plan"),
+        OsString::from("submit"),
+        file.as_os_str().to_owned(),
+        OsString::from("--target"),
+        OsString::from("prod"),
+        OsString::from("--submission-key"),
+        OsString::from("release-1"),
+    ];
+    if detach {
+        values.push(OsString::from("--detach"));
+    }
+    parse_native_v2_args(values).assert_value()
+}
+
+async fn execute_plan(
+    command: NativeV2CliCommand,
+    state: MergePlanState,
+) -> (Result<CliOutcome, NativeV2CliError>, String) {
+    let backend = FakeBackend::with_terminal_plan_state(state);
+    let environment = |name: &str| (name == "GH_TOKEN").then(|| OsString::from("test-token"));
+    let context = CliExecutionContext::new(&backend, &environment);
+    let mut output = Vec::new();
+    let result =
+        execute_native_v2_cli_with_context(command, &context, &mut NeverDetach, &mut output).await;
+    (result, String::from_utf8(output).assert_value())
+}
+
+#[tokio::test]
+async fn foreground_plan_submit_reports_a_terminal_failure_after_printing_it() {
+    let files = merge_plan_fixture();
+    let command = plan_submit_command(&files.input, false);
+
+    let (result, output) = execute_plan(command, MergePlanState::Failed).await;
+
+    assert!(matches!(
+        result.assert_error(),
+        NativeV2CliError::MergePlanFailed
+    ));
+    assert!(output.contains("\"planId\":\"plan-public\""));
+    assert!(output.contains("\"state\":\"failed\""));
+}
+
+#[tokio::test]
+async fn plan_watch_reports_each_unsuccessful_terminal_state_after_printing_it() {
+    for (state, expected) in [
+        (MergePlanState::Failed, "failed"),
+        (MergePlanState::Cancelled, "cancelled"),
+        (MergePlanState::Expired, "expired"),
+    ] {
+        let command =
+            parse_native_v2_args(args(&["plan", "watch", "plan-public", "--target", "prod"]))
+                .assert_value();
+
+        let (result, output) = execute_plan(command, state).await;
+
+        assert!(matches!(
+            result.assert_error(),
+            NativeV2CliError::MergePlanFailed
+        ));
+        assert!(output.contains(&format!("\"state\":\"{expected}\"")));
+    }
+}
+
+#[tokio::test]
+async fn detached_plan_submit_does_not_project_a_terminal_failure() {
+    let files = merge_plan_fixture();
+    let command = plan_submit_command(&files.input, true);
+
+    let (result, output) = execute_plan(command, MergePlanState::Failed).await;
+
+    assert_eq!(result.assert_value(), CliOutcome::Detached);
+    assert!(output.contains("\"state\":\"failed\""));
+}
+
+#[tokio::test]
+async fn plan_status_and_force_stop_keep_ordinary_command_outcomes() {
+    for operation in ["status", "force-stop"] {
+        let command = parse_native_v2_args(args(&[
+            "plan",
+            operation,
+            "plan-public",
+            "--target",
+            "prod",
+        ]))
+        .assert_value();
+
+        let (result, output) = execute_plan(command, MergePlanState::Expired).await;
+
+        assert_eq!(result.assert_value(), CliOutcome::Completed);
+        assert!(output.contains("\"state\":\"expired\""));
+    }
 }

--- a/zeroshot/src/native_v2_cli/tests/parser.rs
+++ b/zeroshot/src/native_v2_cli/tests/parser.rs
@@ -14,6 +14,44 @@ fn parser_exposes_static_help_and_version_commands() {
 }
 
 #[test]
+fn parser_exposes_the_closed_hosted_plan_surface() {
+    let submit = parse_native_v2_args(args(&[
+        "plan",
+        "submit",
+        "plan.json",
+        "--target",
+        "prod",
+        "--submission-key",
+        "plan-retry-1",
+        "--detach",
+    ]))
+    .assert_value();
+    let NativeV2CliCommand::PlanSubmit(submit) = submit else {
+        panic!("expected plan submit command");
+    };
+    assert_eq!(submit.file, PathBuf::from("plan.json"));
+    assert_eq!(submit.target, "prod");
+    assert_eq!(submit.submission_key.as_str(), "plan-retry-1");
+    assert!(submit.detach);
+
+    let status = parse_native_v2_args(args(&["plan", "status", "plan-7", "--target", "prod"]))
+        .assert_value();
+    assert!(matches!(
+        status,
+        NativeV2CliCommand::PlanStatus(MergePlanSelector { target, plan_id })
+            if target == "prod" && plan_id.as_str() == "plan-7"
+    ));
+
+    for invalid in [
+        &["plan", "submit", "plan.json", "--target", "prod"][..],
+        &["plan", "submit", "plan.json", "--submission-key", "key"][..],
+        &["plan", "watch", "plan-7"][..],
+    ] {
+        assert!(parse_native_v2_args(args(invalid)).is_err());
+    }
+}
+
+#[test]
 fn durable_observation_accepts_native_resume_and_execution_filters() {
     let watch = parse_native_v2_args(args(&[
         "watch", "run-7", "--target", "prod", "--after", "cloud:12",

--- a/zeroshot/src/native_v2_cli/tests/support.rs
+++ b/zeroshot/src/native_v2_cli/tests/support.rs
@@ -2,9 +2,10 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
 use openengine_cluster_protocol::{
-    RunAttachEventNotification, RunAttachParams, RunConnectionValues, RunForceParams, RunId,
-    RunListParams, RunLogEventNotification, RunLogsParams, RunStatusParams, RunSubmitResult,
-    RunTitle, RunWatchParams, RuntimePlan,
+    MergePlan, MergePlanState, RunAttachEventNotification, RunAttachParams, RunConnectionValues,
+    RunForceParams, RunId, RunListParams, RunLogEventNotification, RunLogsParams, RunProfile,
+    RunProfileName, RunProfileScope, RunStatusParams, RunSubmitResult, RunTitle, RunWatchParams,
+    RuntimePlan,
 };
 use openengine_cluster_testkit::assertions::AssertValue;
 use serde_json::{json, Value};
@@ -138,6 +139,7 @@ pub(super) struct FakeBackend {
     attach_behavior: AttachBehavior,
     failed_watch: bool,
     queued_lifecycle: bool,
+    terminal_plan_state: Option<MergePlanState>,
 }
 
 #[derive(Clone, Copy)]
@@ -189,6 +191,13 @@ impl FakeBackend {
         }
     }
 
+    pub(super) fn with_terminal_plan_state(state: MergePlanState) -> Self {
+        Self {
+            terminal_plan_state: Some(state),
+            ..Self::default()
+        }
+    }
+
     pub(super) fn with_reconnecting_attach_after_disconnect() -> Self {
         Self {
             attach_behavior: AttachBehavior::Disconnect,
@@ -220,6 +229,54 @@ impl FakeBackend {
     pub(super) fn calls(&self) -> Vec<Call> {
         self.calls.lock().assert_value().clone()
     }
+
+    fn terminal_plan(&self) -> Result<MergePlan, NativeV2CliError> {
+        self.terminal_plan_state
+            .map(terminal_merge_plan)
+            .ok_or_else(|| {
+                NativeV2CliError::Target("target does not advertise merge plans".to_owned())
+            })
+    }
+}
+
+fn merge_plan_profile() -> RunProfile {
+    let runtime = serde_json::from_str(
+        r#"{
+            "harness":"codex","provider":"openai","size":"medium","nodes":{
+                "worker":{"kind":"agent","model":"gpt-5.6-sol"},
+                "acceptance":{"kind":"agent","model":"gpt-5.6-sol"},
+                "code":{"kind":"agent","model":"gpt-5.6-sol"},
+                "review_repair":{"kind":"agent","model":"gpt-5.6-sol"},
+                "delivery_repair":{"kind":"agent","model":"gpt-5.6-sol"},
+                "deliver":{"kind":"git_delivery","connections":{"github":["GH_TOKEN"]}}
+            }
+        }"#,
+    )
+    .assert_value();
+    RunProfile {
+        id: "profile-plan".to_owned(),
+        name: RunProfileName::new("software-change").assert_value(),
+        scope: RunProfileScope::Org,
+        graph: BuiltinGraphTemplate::SoftwareChange
+            .materialize(TemplateDelivery::Merge)
+            .assert_value(),
+        runtime,
+        is_default: false,
+    }
+}
+
+fn terminal_merge_plan(state: MergePlanState) -> MergePlan {
+    serde_json::from_value(json!({
+        "planId":"plan-public",
+        "title":"Release",
+        "state":state,
+        "repository":"open-engine/zeroshot",
+        "branch":"main",
+        "submittedAt":"2026-09-10T00:00:00Z",
+        "expiresAt":"2026-09-11T00:00:00Z",
+        "runs":[]
+    }))
+    .assert_value()
 }
 
 #[async_trait]
@@ -242,6 +299,43 @@ impl NativeV2CliBackend for FakeBackend {
             name: name.to_owned(),
         });
         Ok(())
+    }
+
+    async fn profile_show(
+        &self,
+        _target: Option<&str>,
+        _selector: RunProfileSelector,
+    ) -> Result<RunProfile, NativeV2CliError> {
+        if self.terminal_plan_state.is_some() {
+            return Ok(merge_plan_profile());
+        }
+        Err(NativeV2CliError::Target(
+            "target does not advertise profile management".to_owned(),
+        ))
+    }
+
+    async fn merge_plan_submit(
+        &self,
+        _target: &str,
+        _request: PreparedMergePlanRequest,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        self.terminal_plan()
+    }
+
+    async fn merge_plan_status(
+        &self,
+        _target: &str,
+        _plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        self.terminal_plan()
+    }
+
+    async fn merge_plan_force(
+        &self,
+        _target: &str,
+        _plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        self.terminal_plan()
     }
 
     async fn run_submit(

--- a/zeroshot/src/native_v2_contract.rs
+++ b/zeroshot/src/native_v2_contract.rs
@@ -27,6 +27,8 @@ use thiserror::Error;
 pub const GIT_DELIVERY_PR_WORKER_REF: &str = "builtin.git-delivery.pr@1";
 /// Graph-visible merge delivery worker backed by the shared Git delivery implementation.
 pub const GIT_DELIVERY_MERGE_WORKER_REF: &str = "builtin.git-delivery.merge@1";
+/// Merge delivery with an authoritative merge revision in its v2 receipt.
+pub const GIT_DELIVERY_MERGE_V2_WORKER_REF: &str = "builtin.git-delivery.merge@2";
 /// Conventional connection key used by built-in GitHub checkout and delivery behavior.
 pub const GITHUB_CONNECTION_KEY: &str = "github";
 

--- a/zeroshot/src/native_v2_delivery.rs
+++ b/zeroshot/src/native_v2_delivery.rs
@@ -36,8 +36,8 @@ use openengine_cluster_protocol::{EnumLabel, FieldName, WorkerErrorCode, WorkerO
 use serde_json::{Map, Value, json};
 
 use crate::native_v2_contract::{
-    EnvironmentVariableName, GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF,
-    NodeInvocation, NodeRuntimeBinding,
+    EnvironmentVariableName, GIT_DELIVERY_MERGE_V2_WORKER_REF, GIT_DELIVERY_MERGE_WORKER_REF,
+    GIT_DELIVERY_PR_WORKER_REF, NodeInvocation, NodeRuntimeBinding,
 };
 use crate::native_v2_runner::{
     DriverControl, DriverInvocation, LiveOutput, LiveOutputStream, NodeDriver,
@@ -55,13 +55,15 @@ pub const DELIVERY_MERGED_LABEL: &str = "merged";
 pub const DELIVERY_CONFLICT_LABEL: &str = "conflict";
 pub const DELIVERY_CI_FAILED_LABEL: &str = "ci_failed";
 
-const DELIVERY_RESULT_VERSION: &str = "v1";
+const DELIVERY_PR_RESULT_VERSION: &str = "v1";
+const DELIVERY_MERGE_RESULT_VERSION: &str = "v2";
 const DELIVERY_VERSION_FIELD: &str = "version";
 const DELIVERY_MODE_FIELD: &str = "mode";
 const DELIVERY_OUTCOME_FIELD: &str = "outcome";
 const DELIVERY_REPOSITORY_FIELD: &str = "repository";
 const DELIVERY_TARGET_BRANCH_FIELD: &str = "targetBranch";
 const DELIVERY_HEAD_REVISION_FIELD: &str = "headRevision";
+const DELIVERY_MERGE_REVISION_FIELD: &str = "mergeRevision";
 const DELIVERY_PULL_REQUEST_ID_FIELD: &str = "pullRequestId";
 
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(20);
@@ -71,10 +73,14 @@ const REVIEW_SYNC_INTERVAL: Duration = Duration::from_secs(1);
 const REVIEW_SYNC_MAX_INTERVAL: Duration = Duration::from_secs(8);
 const MAX_TOKEN_BYTES: usize = 4_096;
 const MAX_REVIEW_ID_BYTES: usize = 32;
+const MAX_CONFLICT_DIAGNOSTIC_BYTES: usize = 8 * 1_024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DeliveryMode {
     PullRequest,
+    /// The shipped merge@1 receipt contract, retained for stored and in-flight graphs.
+    MergeV1,
+    /// The merge@2 receipt contract with an authoritative merge revision.
     Merge,
 }
 
@@ -83,7 +89,8 @@ impl DeliveryMode {
     pub fn from_worker(worker: &WorkerRef) -> Option<Self> {
         match worker.as_str() {
             GIT_DELIVERY_PR_WORKER_REF => Some(Self::PullRequest),
-            GIT_DELIVERY_MERGE_WORKER_REF => Some(Self::Merge),
+            GIT_DELIVERY_MERGE_WORKER_REF => Some(Self::MergeV1),
+            GIT_DELIVERY_MERGE_V2_WORKER_REF => Some(Self::Merge),
             _ => None,
         }
     }
@@ -91,15 +98,26 @@ impl DeliveryMode {
     const fn label(self) -> &'static str {
         match self {
             Self::PullRequest => "pr",
-            Self::Merge => "merge",
+            Self::MergeV1 | Self::Merge => "merge",
         }
     }
 
     const fn success_outcome(self) -> &'static str {
         match self {
             Self::PullRequest => DELIVERY_OPENED_LABEL,
-            Self::Merge => DELIVERY_MERGED_LABEL,
+            Self::MergeV1 | Self::Merge => DELIVERY_MERGED_LABEL,
         }
+    }
+
+    const fn result_version(self) -> &'static str {
+        match self {
+            Self::PullRequest | Self::MergeV1 => DELIVERY_PR_RESULT_VERSION,
+            Self::Merge => DELIVERY_MERGE_RESULT_VERSION,
+        }
+    }
+
+    const fn includes_merge_revision(self) -> bool {
+        matches!(self, Self::Merge)
     }
 }
 
@@ -279,6 +297,24 @@ pub struct GitHubReviewObservation {
     pub state: GitHubReviewState,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubConflictRequest {
+    pub workspace: PathBuf,
+    pub review: GitHubReviewReceipt,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitHubConflictMaterialization {
+    pub target_revision: String,
+    pub conflicted_paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum GitHubConflictOutcome {
+    Materialized(GitHubConflictMaterialization),
+    ObservationChanged,
+}
+
 /// Target-owned, bounded GitHub effects. Implementations must bound every network operation.
 #[async_trait]
 pub trait GitHubDeliveryAuthority: Send + Sync {
@@ -328,6 +364,17 @@ pub trait GitHubDeliveryAuthority: Send + Sync {
     ) -> Result<(), GitHubAuthorityError> {
         Ok(())
     }
+
+    /// Fetches and integrates the exact current target revision without exposing credentials to
+    /// an agent. A materialized conflict must remain in the workspace; a changed observation must
+    /// leave the original review head clean so delivery can re-observe GitHub.
+    async fn materialize_merge_conflict(
+        &self,
+        _request: &GitHubConflictRequest,
+        _credential: GitHubCredential<'_>,
+    ) -> Result<GitHubConflictOutcome, GitHubAuthorityError> {
+        Err(GitHubAuthorityError::Rejected)
+    }
 }
 
 pub use adapter::NativeV2DeliveryAdapter;
@@ -338,66 +385,123 @@ fn github_credential(environment: &ResolvedEnvironment) -> Option<GitHubCredenti
     (!token.trim().is_empty() && token.len() <= MAX_TOKEN_BYTES).then_some(GitHubCredential(token))
 }
 
-fn delivery_outcome(
+struct DeliveryResult<'a> {
     mode: DeliveryMode,
-    outcome: &str,
-    review: &GitHubReviewReceipt,
+    outcome: &'a str,
+    review: &'a GitHubReviewReceipt,
+    merge_revision: Option<&'a str>,
+}
+
+fn delivery_outcome(
+    result: DeliveryResult<'_>,
     diagnostic: &str,
 ) -> Result<WorkerOutcome, NodeRunnerError> {
-    if !valid_mode_outcome(mode, outcome) {
+    if !valid_delivery_result(&result) {
         return Err(NodeRunnerError::Driver);
     }
     let field = FieldName::new(DELIVERY_SIGNAL_FIELD).map_err(|_| NodeRunnerError::Driver)?;
-    let label = EnumLabel::new(outcome).map_err(|_| NodeRunnerError::Driver)?;
+    let label = EnumLabel::new(result.outcome).map_err(|_| NodeRunnerError::Driver)?;
     Ok(WorkerOutcome::Verifier {
-        output: delivery_result(mode, outcome, review),
+        output: delivery_result(&result),
         signals: BTreeMap::from([(field, label)]),
         diagnostic: json!({"message":diagnostic}),
         artifacts: Vec::new(),
     })
 }
 
+fn valid_delivery_result(result: &DeliveryResult<'_>) -> bool {
+    valid_mode_outcome(result.mode, result.outcome)
+        && match (result.mode, result.outcome, result.merge_revision) {
+            (
+                DeliveryMode::MergeV1 | DeliveryMode::Merge,
+                DELIVERY_MERGED_LABEL,
+                Some(revision),
+            ) => valid_revision(revision),
+            (DeliveryMode::MergeV1 | DeliveryMode::Merge, _, None)
+            | (DeliveryMode::PullRequest, _, None) => true,
+            _ => false,
+        }
+}
+
 fn valid_mode_outcome(mode: DeliveryMode, outcome: &str) -> bool {
     match mode {
         DeliveryMode::PullRequest => outcome == DELIVERY_OPENED_LABEL,
-        DeliveryMode::Merge => matches!(
+        DeliveryMode::MergeV1 | DeliveryMode::Merge => matches!(
             outcome,
             DELIVERY_MERGED_LABEL | DELIVERY_CONFLICT_LABEL | DELIVERY_CI_FAILED_LABEL
         ),
     }
 }
 
-fn delivery_result(mode: DeliveryMode, outcome: &str, review: &GitHubReviewReceipt) -> Value {
-    Value::Object(Map::from_iter([
+fn conflict_diagnostic(
+    authority_diagnostic: &str,
+    materialization: &GitHubConflictMaterialization,
+) -> Option<String> {
+    if !valid_revision(&materialization.target_revision)
+        || materialization.conflicted_paths.is_empty()
+        || !materialization
+            .conflicted_paths
+            .iter()
+            .all(|path| valid_conflicted_path(path))
+    {
+        return None;
+    }
+    let paths = serde_json::to_string(&materialization.conflicted_paths).ok()?;
+    let diagnostic = format!(
+        "{authority_diagnostic}; targetRevision={}; conflictedPaths={paths}",
+        materialization.target_revision
+    );
+    (diagnostic.len() <= MAX_CONFLICT_DIAGNOSTIC_BYTES).then_some(diagnostic)
+}
+
+fn valid_conflicted_path(value: &str) -> bool {
+    use std::path::Component;
+
+    !value.is_empty()
+        && !std::path::Path::new(value).is_absolute()
+        && std::path::Path::new(value)
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+}
+
+fn delivery_result(result: &DeliveryResult<'_>) -> Value {
+    let mut fields = Map::from_iter([
         (
             DELIVERY_VERSION_FIELD.to_owned(),
-            Value::String(DELIVERY_RESULT_VERSION.to_owned()),
+            Value::String(result.mode.result_version().to_owned()),
         ),
         (
             DELIVERY_MODE_FIELD.to_owned(),
-            Value::String(mode.label().to_owned()),
+            Value::String(result.mode.label().to_owned()),
         ),
         (
             DELIVERY_OUTCOME_FIELD.to_owned(),
-            Value::String(outcome.to_owned()),
+            Value::String(result.outcome.to_owned()),
         ),
         (
             DELIVERY_REPOSITORY_FIELD.to_owned(),
-            Value::String(review.repository.clone()),
+            Value::String(result.review.repository.clone()),
         ),
         (
             DELIVERY_TARGET_BRANCH_FIELD.to_owned(),
-            Value::String(review.target_branch.clone()),
+            Value::String(result.review.target_branch.clone()),
         ),
         (
             DELIVERY_HEAD_REVISION_FIELD.to_owned(),
-            Value::String(review.head_revision.clone()),
+            Value::String(result.review.head_revision.clone()),
         ),
         (
             DELIVERY_PULL_REQUEST_ID_FIELD.to_owned(),
-            Value::String(review.review_id.clone()),
+            Value::String(result.review.review_id.clone()),
         ),
-    ]))
+    ]);
+    if result.mode.includes_merge_revision() {
+        fields.insert(
+            DELIVERY_MERGE_REVISION_FIELD.to_owned(),
+            Value::String(result.merge_revision.unwrap_or_default().to_owned()),
+        );
+    }
+    Value::Object(fields)
 }
 
 fn valid_review(request: &GitHubReviewRequest, review: &GitHubReviewReceipt) -> bool {

--- a/zeroshot/src/native_v2_delivery/adapter.rs
+++ b/zeroshot/src/native_v2_delivery/adapter.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod conflict;
 mod head;
 mod input;
 mod review;
@@ -344,7 +345,9 @@ impl NativeV2DeliveryAdapter {
     ) -> Result<ReviewStep, DeliveryStop> {
         match drive.mode {
             DeliveryMode::PullRequest => self.advance_pull_request(drive, progress).await,
-            DeliveryMode::Merge => self.advance_merge(drive, progress).await,
+            DeliveryMode::MergeV1 | DeliveryMode::Merge => {
+                self.advance_merge(drive, progress).await
+            }
         }
     }
 
@@ -362,10 +365,11 @@ impl NativeV2DeliveryAdapter {
                     drive,
                     DELIVERY_OPENED_LABEL,
                     "GitHub authoritatively confirmed the pull request is open",
+                    None,
                 )
                 .await
             }
-            ReviewProgress::Merged | ReviewProgress::Closed => Err(crash_outcome()),
+            ReviewProgress::Merged(_) | ReviewProgress::Closed => Err(crash_outcome()),
         }
     }
 
@@ -375,24 +379,21 @@ impl NativeV2DeliveryAdapter {
         progress: ReviewProgress,
     ) -> Result<ReviewStep, DeliveryStop> {
         match progress {
-            ReviewProgress::Merged => {
+            ReviewProgress::Merged(merge_revision) => {
                 review_completion(
                     drive,
                     DELIVERY_MERGED_LABEL,
                     "GitHub authoritatively confirmed merge",
+                    Some(&merge_revision),
                 )
                 .await
             }
             ReviewProgress::Conflict => {
-                review_completion(
-                    drive,
-                    DELIVERY_CONFLICT_LABEL,
-                    "GitHub authoritatively reported a merge conflict",
-                )
-                .await
+                self.complete_conflict(drive, "GitHub authoritatively reported a merge conflict")
+                    .await
             }
             ReviewProgress::CiFailed(diagnostic) => {
-                review_completion(drive, DELIVERY_CI_FAILED_LABEL, &diagnostic).await
+                review_completion(drive, DELIVERY_CI_FAILED_LABEL, &diagnostic, None).await
             }
             ReviewProgress::Mergeable => self.advance_mergeable(drive).await,
             ReviewProgress::Pending => {
@@ -422,12 +423,12 @@ impl NativeV2DeliveryAdapter {
                 return self.advance_review_head(drive).await;
             }
             GitHubMergeRequestOutcome::Conflict => {
-                return review_completion(
-                    drive,
-                    DELIVERY_CONFLICT_LABEL,
-                    "GitHub authoritatively rejected merge due to conflict",
-                )
-                .await;
+                return self
+                    .complete_conflict(
+                        drive,
+                        "GitHub authoritatively rejected merge due to conflict",
+                    )
+                    .await;
             }
         }
         Ok(ReviewStep::Continue)

--- a/zeroshot/src/native_v2_delivery/adapter/conflict.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/conflict.rs
@@ -1,0 +1,53 @@
+use super::*;
+
+impl NativeV2DeliveryAdapter {
+    pub(super) async fn complete_conflict(
+        &self,
+        drive: &mut ReviewDrive<'_>,
+        authority_diagnostic: &str,
+    ) -> Result<ReviewStep, DeliveryStop> {
+        emit(drive.control, "delivery: materializing merge conflict").await?;
+        let request = GitHubConflictRequest {
+            workspace: self.config.workspace.clone(),
+            review: drive.review.clone(),
+        };
+        let outcome = self
+            .materialize_conflict(&request, &mut drive.credentials, drive.control)
+            .await?;
+        let GitHubConflictOutcome::Materialized(materialization) = outcome else {
+            emit(
+                drive.control,
+                "delivery: conflict observation changed; rechecking GitHub",
+            )
+            .await?;
+            return Ok(ReviewStep::Continue);
+        };
+        let diagnostic = conflict_diagnostic(authority_diagnostic, &materialization)
+            .ok_or_else(|| DeliveryStop::Outcome(WorkerOutcome::malformed()))?;
+        review_completion(drive, DELIVERY_CONFLICT_LABEL, &diagnostic, None).await
+    }
+
+    async fn materialize_conflict(
+        &self,
+        request: &GitHubConflictRequest,
+        credentials: &mut DeliveryCredentials<'_>,
+        control: &DriverControl,
+    ) -> Result<GitHubConflictOutcome, DeliveryStop> {
+        match self
+            .authority
+            .materialize_merge_conflict(request, credentials.current())
+            .await
+        {
+            Ok(materialization) => Ok(materialization),
+            Err(error) if error.authentication_failed() && credentials.can_refresh() => {
+                emit(control, "delivery: refreshing GitHub credential").await?;
+                credentials.refresh().await?;
+                self.authority
+                    .materialize_merge_conflict(request, credentials.current())
+                    .await
+                    .map_err(|_| crash_outcome())
+            }
+            Err(_) => Err(crash_outcome()),
+        }
+    }
+}

--- a/zeroshot/src/native_v2_delivery/adapter/head.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/head.rs
@@ -22,9 +22,8 @@ impl NativeV2DeliveryAdapter {
                 Ok(ReviewStep::Continue)
             }
             GitHubHeadUpdateOutcome::Conflict => {
-                review_completion(
+                self.complete_conflict(
                     drive,
-                    DELIVERY_CONFLICT_LABEL,
                     "GitHub authoritatively rejected branch update due to conflict",
                 )
                 .await

--- a/zeroshot/src/native_v2_delivery/adapter/review.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/review.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(super) enum ReviewProgress {
-    Merged,
+    Merged(String),
     CiFailed(String),
     Mergeable,
     Pending,
@@ -18,7 +18,7 @@ impl ReviewProgress {
     pub(super) fn from_state(state: GitHubReviewState) -> Result<Self, DeliveryStop> {
         match state {
             GitHubReviewState::Merged { merge_revision } if valid_revision(&merge_revision) => {
-                Ok(Self::Merged)
+                Ok(Self::Merged(merge_revision))
             }
             GitHubReviewState::Merged { .. } => {
                 Err(DeliveryStop::Outcome(WorkerOutcome::malformed()))
@@ -46,10 +46,19 @@ pub(super) async fn review_completion(
     drive: &ReviewDrive<'_>,
     label: &'static str,
     diagnostic: &str,
+    merge_revision: Option<&str>,
 ) -> Result<ReviewStep, DeliveryStop> {
     emit(drive.control, diagnostic).await?;
     validate_delivery_contract(drive.mode, drive.response).map_err(DeliveryStop::Runner)?;
-    delivery_outcome(drive.mode, label, &drive.review, diagnostic)
-        .map(ReviewStep::Complete)
-        .map_err(DeliveryStop::Runner)
+    delivery_outcome(
+        DeliveryResult {
+            mode: drive.mode,
+            outcome: label,
+            review: &drive.review,
+            merge_revision,
+        },
+        diagnostic,
+    )
+    .map(ReviewStep::Complete)
+    .map_err(DeliveryStop::Runner)
 }

--- a/zeroshot/src/native_v2_delivery/contract.rs
+++ b/zeroshot/src/native_v2_delivery/contract.rs
@@ -8,10 +8,10 @@ use crate::native_v2_runner::{NodeResponseContract, NodeRunnerError};
 
 use super::{
     DELIVERY_CI_FAILED_LABEL, DELIVERY_CONFLICT_LABEL, DELIVERY_HEAD_REVISION_FIELD,
-    DELIVERY_MERGED_LABEL, DELIVERY_MODE_FIELD, DELIVERY_OPENED_LABEL, DELIVERY_OUTCOME_FIELD,
-    DELIVERY_PULL_REQUEST_ID_FIELD, DELIVERY_REPOSITORY_FIELD, DELIVERY_RESULT_VERSION,
-    DELIVERY_SIGNAL_FIELD, DELIVERY_TARGET_BRANCH_FIELD, DELIVERY_VERSION_FIELD, DeliveryMode,
-    DeliveryTarget, valid_review_id, valid_revision,
+    DELIVERY_MERGED_LABEL, DELIVERY_MERGE_REVISION_FIELD, DELIVERY_MODE_FIELD,
+    DELIVERY_OPENED_LABEL, DELIVERY_OUTCOME_FIELD, DELIVERY_PULL_REQUEST_ID_FIELD,
+    DELIVERY_REPOSITORY_FIELD, DELIVERY_SIGNAL_FIELD, DELIVERY_TARGET_BRANCH_FIELD,
+    DELIVERY_VERSION_FIELD, DeliveryMode, DeliveryTarget, valid_review_id, valid_revision,
 };
 
 pub fn validate_delivery_contract(
@@ -67,18 +67,27 @@ pub fn is_matching_success_receipt(
     let Ok(result) = serde_json::from_value::<DeliveryResultWire>(output.clone()) else {
         return false;
     };
-    result.version == DELIVERY_RESULT_VERSION
+    result.version == mode.result_version()
         && result.mode == mode.label()
         && result.outcome == mode.success_outcome()
-        && receipt_matches_target(&result, target)
+        && receipt_matches_target(&result, mode, target)
 }
 
-fn receipt_matches_target(result: &DeliveryResultWire, target: &DeliveryTarget) -> bool {
+fn receipt_matches_target(
+    result: &DeliveryResultWire,
+    mode: DeliveryMode,
+    target: &DeliveryTarget,
+) -> bool {
     result.repository == target.repository
         && result.target_branch == target.target_branch
         && valid_revision(&result.head_revision)
         && result.head_revision != target.base_revision
         && valid_review_id(&result.pull_request_id)
+        && match mode {
+            DeliveryMode::PullRequest => result.merge_revision.is_none(),
+            DeliveryMode::MergeV1 => result.merge_revision.is_none(),
+            DeliveryMode::Merge => result.merge_revision.as_deref().is_some_and(valid_revision),
+        }
 }
 
 #[derive(Deserialize)]
@@ -91,29 +100,39 @@ struct DeliveryResultWire {
     target_branch: String,
     head_revision: String,
     pull_request_id: String,
+    merge_revision: Option<String>,
 }
 
 pub(crate) fn delivery_result_schema(
     mode: DeliveryMode,
 ) -> Result<PayloadType, ContractValueError> {
-    let mut fields = delivery_identity_fields()?;
+    let mut fields = delivery_identity_fields(mode)?;
     fields.extend(delivery_mode_fields(mode)?);
     Ok(PayloadType::Record {
         fields: fields.into_iter().collect(),
     })
 }
 
-fn delivery_identity_fields() -> Result<Vec<(FieldName, RecordField)>, ContractValueError> {
-    Ok(vec![
+fn delivery_identity_fields(
+    mode: DeliveryMode,
+) -> Result<Vec<(FieldName, RecordField)>, ContractValueError> {
+    let mut fields = vec![
         contract_field(
             DELIVERY_VERSION_FIELD,
-            contract_enum(&[DELIVERY_RESULT_VERSION])?,
+            contract_enum(&[mode.result_version()])?,
         )?,
         contract_field(DELIVERY_REPOSITORY_FIELD, PayloadType::String)?,
         contract_field(DELIVERY_TARGET_BRANCH_FIELD, PayloadType::String)?,
         contract_field(DELIVERY_HEAD_REVISION_FIELD, PayloadType::String)?,
         contract_field(DELIVERY_PULL_REQUEST_ID_FIELD, PayloadType::String)?,
-    ])
+    ];
+    if mode.includes_merge_revision() {
+        fields.push(contract_field(
+            DELIVERY_MERGE_REVISION_FIELD,
+            PayloadType::String,
+        )?);
+    }
+    Ok(fields)
 }
 
 fn delivery_mode_fields(
@@ -135,7 +154,7 @@ pub(crate) fn delivery_signal_labels(
 ) -> Result<NonEmptyEnumSet, ContractValueError> {
     match mode {
         DeliveryMode::PullRequest => contract_labels(&[DELIVERY_OPENED_LABEL]),
-        DeliveryMode::Merge => contract_labels(&[
+        DeliveryMode::MergeV1 | DeliveryMode::Merge => contract_labels(&[
             DELIVERY_MERGED_LABEL,
             DELIVERY_CONFLICT_LABEL,
             DELIVERY_CI_FAILED_LABEL,

--- a/zeroshot/src/native_v2_delivery/github.rs
+++ b/zeroshot/src/native_v2_delivery/github.rs
@@ -12,13 +12,14 @@ use crate::native_v2_delivery::git_auth::encode_basic_credential;
 use crate::native_v2_target_authority::OperatorDiagnosticStore;
 
 use super::{
-    GitHubAuthorityError, GitHubChecks, GitHubCredential, GitHubDeliveryAuthority,
-    GitHubHeadSynchronization, GitHubHeadUpdateOutcome, GitHubMergeRequestOutcome,
-    GitHubPushRequest, GitHubReviewObservation, GitHubReviewReceipt, GitHubReviewRequest,
-    GitHubReviewState, valid_head_update, valid_revision,
+    GitHubAuthorityError, GitHubChecks, GitHubConflictMaterialization, GitHubConflictOutcome,
+    GitHubConflictRequest, GitHubCredential, GitHubDeliveryAuthority, GitHubHeadSynchronization,
+    GitHubHeadUpdateOutcome, GitHubMergeRequestOutcome, GitHubPushRequest, GitHubReviewObservation,
+    GitHubReviewReceipt, GitHubReviewRequest, GitHubReviewState, valid_head_update, valid_revision,
 };
 
 mod api;
+mod conflict;
 mod metadata;
 mod push;
 
@@ -376,6 +377,14 @@ impl GitHubDeliveryAuthority for GhCliDeliveryAuthority {
     ) -> Result<(), GitHubAuthorityError> {
         head::synchronize_review_head(self, request, credential).await
     }
+
+    async fn materialize_merge_conflict(
+        &self,
+        request: &GitHubConflictRequest,
+        credential: GitHubCredential<'_>,
+    ) -> Result<GitHubConflictOutcome, GitHubAuthorityError> {
+        conflict::materialize(self, request, credential).await
+    }
 }
 
 enum MergeAction {
@@ -466,8 +475,20 @@ fn git_command(
     workspace: &std::path::Path,
     credential: GitHubCredential<'_>,
 ) -> Command {
-    let mut command = clean_command(config, &config.git_program, credential);
+    let mut command = local_git_command(config, workspace);
     command
+        .env("GH_HOST", "github.com")
+        .env("GH_TOKEN", credential.expose());
+    command
+}
+
+fn local_git_command(config: &GhCliAuthorityConfig, workspace: &std::path::Path) -> Command {
+    let mut command = Command::new(&config.git_program);
+    command
+        .kill_on_drop(true)
+        .env_clear()
+        .env("HOME", &config.home_directory)
+        .env("LANG", "C")
         .env("GIT_CONFIG_NOSYSTEM", "1")
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .env("GIT_TERMINAL_PROMPT", "0")
@@ -476,7 +497,10 @@ fn git_command(
         .arg("-c")
         .arg(format!("safe.directory={}", workspace.display()))
         .arg("-C")
-        .arg(workspace);
+        .arg(workspace)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
     command
 }
 
@@ -511,6 +535,22 @@ async fn bounded_status(
         .success()
         .then_some(())
         .ok_or(GitHubAuthorityError::Rejected)
+}
+
+async fn bounded_git_output(
+    command: &mut Command,
+    deadline: Duration,
+    maximum_bytes: usize,
+) -> Result<String, GitHubAuthorityError> {
+    command.stdout(Stdio::piped());
+    let output = timeout(deadline, command.output())
+        .await
+        .map_err(|_| GitHubAuthorityError::Unavailable)?
+        .map_err(|_| GitHubAuthorityError::Unavailable)?;
+    if !output.status.success() || output.stdout.len() > maximum_bytes {
+        return Err(GitHubAuthorityError::Rejected);
+    }
+    String::from_utf8(output.stdout).map_err(|_| GitHubAuthorityError::Rejected)
 }
 
 #[cfg(test)]

--- a/zeroshot/src/native_v2_delivery/github/api.rs
+++ b/zeroshot/src/native_v2_delivery/github/api.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-use super::wire::{GitReferenceWire, require_review_head};
+use super::wire::{GitReferenceWire, reference_revision, require_review_head};
 use super::*;
 
 const MAX_API_OUTPUT_BYTES: usize = 16 * 1024 * 1024;
@@ -45,6 +45,25 @@ impl GhCliDeliveryAuthority {
         let reference: GitReferenceWire =
             serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
         require_review_head(reference, request)
+    }
+
+    pub(super) async fn target_revision(
+        &self,
+        review: &GitHubReviewReceipt,
+        credential: GitHubCredential<'_>,
+    ) -> Result<String, GitHubAuthorityError> {
+        let value = self
+            .api(
+                &[format!(
+                    "repos/{}/git/ref/heads/{}",
+                    review.repository, review.target_branch
+                )],
+                credential,
+            )
+            .await?;
+        let reference: GitReferenceWire =
+            serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
+        reference_revision(reference, &review.target_branch)
     }
 }
 

--- a/zeroshot/src/native_v2_delivery/github/conflict.rs
+++ b/zeroshot/src/native_v2_delivery/github/conflict.rs
@@ -1,0 +1,251 @@
+use std::path::{Component, Path};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use super::*;
+
+const MAX_CONFLICT_PATH_OUTPUT_BYTES: usize = 6 * 1_024;
+
+#[derive(Clone, Copy)]
+struct ConflictContext<'a> {
+    authority: &'a GhCliDeliveryAuthority,
+    request: &'a GitHubConflictRequest,
+    credential: GitHubCredential<'a>,
+}
+
+pub(super) async fn materialize(
+    authority: &GhCliDeliveryAuthority,
+    request: &GitHubConflictRequest,
+    credential: GitHubCredential<'_>,
+) -> Result<GitHubConflictOutcome, GitHubAuthorityError> {
+    let context = ConflictContext {
+        authority,
+        request,
+        credential,
+    };
+    require_clean_review_head(context).await?;
+    let target_revision = authority
+        .target_revision(&request.review, credential)
+        .await?;
+    fetch_target(context, &target_revision).await?;
+    require_commit(context, &target_revision).await?;
+    let merge_status = merge_target(context, &target_revision).await?;
+    let conflicted_paths = conflicted_paths(context).await?;
+    if observation_changed(merge_status, &conflicted_paths) {
+        restore_clean_review_head(context).await?;
+        return Ok(GitHubConflictOutcome::ObservationChanged);
+    }
+    require_materialized_state(context, &target_revision, merge_status, &conflicted_paths).await?;
+    Ok(GitHubConflictOutcome::Materialized(
+        GitHubConflictMaterialization {
+            target_revision,
+            conflicted_paths,
+        },
+    ))
+}
+
+fn observation_changed(merge_status: i32, conflicted_paths: &[String]) -> bool {
+    merge_status == 0 && conflicted_paths.is_empty()
+}
+
+async fn require_clean_review_head(
+    context: ConflictContext<'_>,
+) -> Result<(), GitHubAuthorityError> {
+    let head = workspace_head(context).await?;
+    let status = bounded_git_output(
+        local_git_command(&context.authority.config, &context.request.workspace).args([
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+        ]),
+        context.authority.config.api_deadline,
+        1,
+    )
+    .await?;
+    (head.trim() == context.request.review.head_revision && status.is_empty())
+        .then_some(())
+        .ok_or(GitHubAuthorityError::Rejected)
+}
+
+async fn fetch_target(
+    context: ConflictContext<'_>,
+    target_revision: &str,
+) -> Result<(), GitHubAuthorityError> {
+    let mut command = authenticated_git_command(
+        &context.authority.config,
+        &context.request.workspace,
+        context.credential,
+    );
+    command.args([
+        "fetch",
+        "--no-tags",
+        "--quiet",
+        "--no-write-fetch-head",
+        &format!(
+            "https://github.com/{}.git",
+            context.request.review.repository
+        ),
+        target_revision,
+    ]);
+    bounded_status(command, context.authority.config.push_deadline).await
+}
+
+async fn require_commit(
+    context: ConflictContext<'_>,
+    target_revision: &str,
+) -> Result<(), GitHubAuthorityError> {
+    let mut command = local_git_command(&context.authority.config, &context.request.workspace);
+    command.args(["cat-file", "-e", &format!("{target_revision}^{{commit}}")]);
+    bounded_status(command, context.authority.config.api_deadline).await
+}
+
+async fn merge_target(
+    context: ConflictContext<'_>,
+    target_revision: &str,
+) -> Result<i32, GitHubAuthorityError> {
+    let mut command = local_git_command(&context.authority.config, &context.request.workspace);
+    command.args([
+        "-c",
+        "rerere.enabled=false",
+        "-c",
+        "user.name=Zeroshot",
+        "-c",
+        "user.email=delivery@zeroshot.invalid",
+        "merge",
+        "--no-commit",
+        "--no-ff",
+        "--no-edit",
+        target_revision,
+    ]);
+    bounded_exit_code(command, context.authority.config.api_deadline).await
+}
+
+async fn conflicted_paths(
+    context: ConflictContext<'_>,
+) -> Result<Vec<String>, GitHubAuthorityError> {
+    let output = bounded_git_output(
+        local_git_command(&context.authority.config, &context.request.workspace).args([
+            "diff",
+            "--name-only",
+            "--diff-filter=U",
+            "-z",
+        ]),
+        context.authority.config.api_deadline,
+        MAX_CONFLICT_PATH_OUTPUT_BYTES,
+    )
+    .await?;
+    if !output.is_empty() && !output.ends_with('\0') {
+        return Err(GitHubAuthorityError::Rejected);
+    }
+    output
+        .split_terminator('\0')
+        .map(|path| {
+            let valid = !path.is_empty()
+                && !Path::new(path).is_absolute()
+                && Path::new(path)
+                    .components()
+                    .all(|component| matches!(component, Component::Normal(_)));
+            valid
+                .then(|| path.to_owned())
+                .ok_or(GitHubAuthorityError::Rejected)
+        })
+        .collect()
+}
+
+async fn require_materialized_state(
+    context: ConflictContext<'_>,
+    target_revision: &str,
+    merge_status: i32,
+    conflicted_paths: &[String],
+) -> Result<(), GitHubAuthorityError> {
+    require_merge_result(merge_status, conflicted_paths)?;
+    require_unchanged_head(context).await?;
+    require_merge_head(context, target_revision).await
+}
+
+fn require_merge_result(
+    merge_status: i32,
+    conflicted_paths: &[String],
+) -> Result<(), GitHubAuthorityError> {
+    if merge_status != 1 || conflicted_paths.is_empty() {
+        return Err(GitHubAuthorityError::Rejected);
+    }
+    Ok(())
+}
+
+async fn require_unchanged_head(context: ConflictContext<'_>) -> Result<(), GitHubAuthorityError> {
+    let head = workspace_head(context).await?;
+    if head.trim() != context.request.review.head_revision {
+        return Err(GitHubAuthorityError::Rejected);
+    }
+    Ok(())
+}
+
+async fn restore_clean_review_head(
+    context: ConflictContext<'_>,
+) -> Result<(), GitHubAuthorityError> {
+    if merge_in_progress(context).await? {
+        let mut command = local_git_command(&context.authority.config, &context.request.workspace);
+        command.args(["merge", "--abort"]);
+        bounded_status(command, context.authority.config.api_deadline).await?;
+    }
+    require_clean_review_head(context).await
+}
+
+async fn merge_in_progress(context: ConflictContext<'_>) -> Result<bool, GitHubAuthorityError> {
+    let mut command = local_git_command(&context.authority.config, &context.request.workspace);
+    command.args(["rev-parse", "-q", "--verify", "MERGE_HEAD"]);
+    match bounded_exit_code(command, context.authority.config.api_deadline).await? {
+        0 => Ok(true),
+        1 => Ok(false),
+        _ => Err(GitHubAuthorityError::Rejected),
+    }
+}
+
+async fn require_merge_head(
+    context: ConflictContext<'_>,
+    target_revision: &str,
+) -> Result<(), GitHubAuthorityError> {
+    let merge_head = bounded_git_output(
+        local_git_command(&context.authority.config, &context.request.workspace).args([
+            "rev-parse",
+            "-q",
+            "--verify",
+            "MERGE_HEAD",
+        ]),
+        context.authority.config.api_deadline,
+        128,
+    )
+    .await;
+    merge_head
+        .ok()
+        .filter(|merge_head| merge_head.trim() == target_revision)
+        .map(|_| ())
+        .ok_or(GitHubAuthorityError::Rejected)
+}
+
+async fn workspace_head(context: ConflictContext<'_>) -> Result<String, GitHubAuthorityError> {
+    bounded_git_output(
+        local_git_command(&context.authority.config, &context.request.workspace)
+            .args(["rev-parse", "HEAD"]),
+        context.authority.config.api_deadline,
+        128,
+    )
+    .await
+}
+
+async fn bounded_exit_code(
+    mut command: Command,
+    deadline: Duration,
+) -> Result<i32, GitHubAuthorityError> {
+    timeout(deadline, command.status())
+        .await
+        .map_err(|_| GitHubAuthorityError::Unavailable)?
+        .map_err(|_| GitHubAuthorityError::Unavailable)?
+        .code()
+        .ok_or(GitHubAuthorityError::Rejected)
+}
+
+#[cfg(test)]
+#[path = "conflict/tests.rs"]
+mod tests;

--- a/zeroshot/src/native_v2_delivery/github/conflict/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/conflict/tests.rs
@@ -1,0 +1,258 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use openengine_cluster_testkit::assertions::AssertValue;
+
+use super::*;
+use crate::native_v2_candidate::test_support::{TestGitRepository, git, git_output, path_text};
+
+struct ConflictFixture {
+    repository: TestGitRepository,
+    authority: GhCliDeliveryAuthority,
+    request: GitHubConflictRequest,
+    target_revision: String,
+    git_program: PathBuf,
+    gh_program: PathBuf,
+}
+
+enum ExpectedCleanup {
+    AbortedPendingMerge,
+    AlreadyClean,
+}
+
+impl ConflictFixture {
+    fn new(target_file: &str) -> Self {
+        let repository = TestGitRepository::delivery();
+        commit_all(&repository.workspace, "worker change");
+        let head_revision = git_output(&repository.workspace, &["rev-parse", "HEAD"]);
+        let target = repository.root.child("target");
+        git(
+            repository.root.path(),
+            &["clone", path_text(&repository.remote), path_text(&target)],
+        );
+        fs::write(target.join(target_file), "target\n").assert_value();
+        commit_all(&target, "target change");
+        git(&target, &["push", "origin", "main"]);
+        let target_revision = git_output(&target, &["rev-parse", "HEAD"]);
+        Self::with_revisions(repository, head_revision, target_revision)
+    }
+
+    fn target_is_ancestor() -> Self {
+        let repository = TestGitRepository::delivery();
+        commit_all(&repository.workspace, "worker change");
+        let head_revision = git_output(&repository.workspace, &["rev-parse", "HEAD"]);
+        let target_revision = repository.base.clone();
+        Self::with_revisions(repository, head_revision, target_revision)
+    }
+
+    fn with_revisions(
+        repository: TestGitRepository,
+        head_revision: String,
+        target_revision: String,
+    ) -> Self {
+        let git_program = git_wrapper(&repository);
+        let gh_program = gh_script(&repository, &target_revision);
+        let authority = GhCliDeliveryAuthority::new(GhCliAuthorityConfig {
+            git_program: git_program.clone(),
+            gh_program: gh_program.clone(),
+            home_directory: repository.root.path().to_owned(),
+            api_deadline: Duration::from_secs(10),
+            push_deadline: Duration::from_secs(10),
+        });
+        let request = GitHubConflictRequest {
+            workspace: repository.workspace.clone(),
+            review: GitHubReviewReceipt {
+                review_id: "17".to_owned(),
+                repository: "acme/project".to_owned(),
+                target_branch: "main".to_owned(),
+                head_branch: "zeroshot/v2-test".to_owned(),
+                head_revision,
+            },
+        };
+        Self {
+            repository,
+            authority,
+            request,
+            target_revision,
+            git_program,
+            gh_program,
+        }
+    }
+}
+
+#[tokio::test]
+async fn authenticated_target_fetch_leaves_exact_conflict_for_repair() {
+    let fixture = ConflictFixture::new("result.txt");
+
+    let outcome = fixture
+        .authority
+        .materialize_merge_conflict(&fixture.request, GitHubCredential("test-token"))
+        .await
+        .assert_value();
+    let GitHubConflictOutcome::Materialized(materialized) = outcome else {
+        panic!("expected a materialized merge conflict");
+    };
+
+    assert_eq!(materialized.target_revision, fixture.target_revision);
+    assert_eq!(materialized.conflicted_paths, vec!["result.txt"]);
+    assert_eq!(
+        git_output(&fixture.repository.workspace, &["rev-parse", "MERGE_HEAD"]),
+        fixture.target_revision
+    );
+    assert!(
+        fs::read_to_string(fixture.repository.workspace.join("result.txt"))
+            .assert_value()
+            .contains("<<<<<<<")
+    );
+    assert!(
+        git_output(&fixture.repository.workspace, &["status", "--porcelain=v1"])
+            .contains("AA result.txt")
+    );
+    assert_transport_keeps_credential_ephemeral(&fixture);
+}
+
+#[tokio::test]
+async fn stale_conflict_observation_restores_the_review_head_for_reobservation() {
+    let fixture = ConflictFixture::new("target.txt");
+
+    let outcome = fixture
+        .authority
+        .materialize_merge_conflict(&fixture.request, GitHubCredential("test-token"))
+        .await
+        .assert_value();
+
+    assert_reobservation_cleanup(&fixture, outcome, ExpectedCleanup::AbortedPendingMerge);
+    assert!(!fixture.repository.workspace.join("target.txt").exists());
+}
+
+#[tokio::test]
+async fn stale_conflict_observation_accepts_an_already_integrated_target() {
+    let fixture = ConflictFixture::target_is_ancestor();
+
+    let outcome = fixture
+        .authority
+        .materialize_merge_conflict(&fixture.request, GitHubCredential("test-token"))
+        .await
+        .assert_value();
+
+    assert_reobservation_cleanup(&fixture, outcome, ExpectedCleanup::AlreadyClean);
+}
+
+fn assert_reobservation_cleanup(
+    fixture: &ConflictFixture,
+    outcome: GitHubConflictOutcome,
+    expected: ExpectedCleanup,
+) {
+    assert_eq!(outcome, GitHubConflictOutcome::ObservationChanged);
+    assert_eq!(
+        git_output(&fixture.repository.workspace, &["rev-parse", "HEAD"]),
+        fixture.request.review.head_revision
+    );
+    assert_eq!(
+        git_output(
+            &fixture.repository.workspace,
+            &["status", "--porcelain=v1", "--untracked-files=all"]
+        ),
+        ""
+    );
+    assert!(
+        !fixture
+            .repository
+            .workspace
+            .join(".git/MERGE_HEAD")
+            .exists()
+    );
+    let git_capture =
+        fs::read_to_string(format!("{}.capture", fixture.git_program.display())).assert_value();
+    match expected {
+        ExpectedCleanup::AbortedPendingMerge => assert!(git_capture.contains("arg=--abort")),
+        ExpectedCleanup::AlreadyClean => assert!(!git_capture.contains("arg=--abort")),
+    }
+    assert_transport_keeps_credential_ephemeral(fixture);
+}
+
+fn commit_all(workspace: &Path, message: &str) {
+    git(workspace, &["add", "--all"]);
+    git(
+        workspace,
+        &[
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "--no-verify",
+            "--message",
+            message,
+        ],
+    );
+}
+
+fn git_wrapper(repository: &TestGitRepository) -> PathBuf {
+    let remote = path_text(&repository.remote);
+    assert!(!remote.contains('\''));
+    repository.root.write_executable(
+        "git-wrapper",
+        &format!(
+            r#"#!/bin/bash
+set -eu
+capture="${{0}}.capture"
+/usr/bin/printf 'token=%s\n' "${{GH_TOKEN-unset}}" >> "$capture"
+for argument in "$@"; do /usr/bin/printf 'arg=%s\n' "$argument" >> "$capture"; done
+arguments=()
+for argument in "$@"; do
+  if [[ "$argument" == 'https://github.com/acme/project.git' ]]; then
+    arguments+=('{remote}')
+  else
+    arguments+=("$argument")
+  fi
+done
+exec /usr/bin/git "${{arguments[@]}}"
+"#,
+        ),
+    )
+}
+
+fn gh_script(repository: &TestGitRepository, target_revision: &str) -> PathBuf {
+    repository.root.write_executable(
+        "gh-target-ref",
+        &format!(
+            r#"#!/bin/sh
+set -eu
+/usr/bin/printf 'token=%s\n' "${{GH_TOKEN-unset}}" >> "${{0}}.capture"
+for argument in "$@"; do /usr/bin/printf 'arg=%s\n' "$argument" >> "${{0}}.capture"; done
+/usr/bin/printf '%s\n' '{{"ref":"refs/heads/main","object":{{"sha":"{target_revision}","type":"commit"}}}}'
+"#,
+        ),
+    )
+}
+
+fn assert_transport_keeps_credential_ephemeral(fixture: &ConflictFixture) {
+    let git_capture =
+        fs::read_to_string(format!("{}.capture", fixture.git_program.display())).assert_value();
+    assert!(git_capture.contains("token=test-token"));
+    assert!(git_capture.contains("token=unset"));
+    let merge_invocation = git_capture
+        .split("token=")
+        .find(|invocation| invocation.contains("arg=merge\n"))
+        .assert_value();
+    assert!(merge_invocation.starts_with("unset\n"));
+    let fetch_invocation = git_capture
+        .split("token=")
+        .find(|invocation| invocation.contains("arg=fetch\n"))
+        .assert_value();
+    assert!(fetch_invocation.starts_with("test-token\n"));
+    assert!(git_capture.contains(&format!("arg={}", fixture.target_revision)));
+    assert!(!git_capture.lines().any(|line| line == "arg=test-token"));
+    let gh_capture =
+        fs::read_to_string(format!("{}.capture", fixture.gh_program.display())).assert_value();
+    assert!(gh_capture.contains("token=test-token"));
+    assert!(gh_capture.contains("arg=api"));
+    assert!(gh_capture.contains("arg=repos/acme/project/git/ref/heads/main"));
+    assert!(!gh_capture.lines().any(|line| line == "arg=test-token"));
+    let config =
+        fs::read_to_string(fixture.repository.workspace.join(".git/config")).assert_value();
+    assert!(!config.contains("test-token"));
+    assert!(!config.contains("extraheader"));
+}

--- a/zeroshot/src/native_v2_delivery/github/head.rs
+++ b/zeroshot/src/native_v2_delivery/github/head.rs
@@ -251,15 +251,7 @@ async fn git_output(
     command: &mut Command,
     deadline: Duration,
 ) -> Result<String, GitHubAuthorityError> {
-    command.stdout(Stdio::piped());
-    let output = timeout(deadline, command.output())
-        .await
-        .map_err(|_| GitHubAuthorityError::Unavailable)?
-        .map_err(|_| GitHubAuthorityError::Unavailable)?;
-    if !output.status.success() || output.stdout.len() > MAX_GIT_OUTPUT_BYTES {
-        return Err(GitHubAuthorityError::Rejected);
-    }
-    String::from_utf8(output.stdout).map_err(|_| GitHubAuthorityError::Rejected)
+    bounded_git_output(command, deadline, MAX_GIT_OUTPUT_BYTES).await
 }
 
 #[cfg(test)]

--- a/zeroshot/src/native_v2_delivery/github/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/tests.rs
@@ -94,6 +94,15 @@ fn classify(page: Value) -> PolicySnapshot {
     classify_policy(json!([page]), &review()).assert_value()
 }
 
+fn policy_page_with_merge_capabilities(merge: bool, squash: bool, rebase: bool) -> Value {
+    let mut page = policy_page("MERGEABLE", "CLEAN", None, (false, None));
+    let repository = page.pointer_mut("/data/repository").assert_value();
+    repository["mergeCommitAllowed"] = json!(merge);
+    repository["squashMergeAllowed"] = json!(squash);
+    repository["rebaseMergeAllowed"] = json!(rebase);
+    page
+}
+
 fn classify_conclusion(conclusion: &str, merge_state: &str) -> PolicySnapshot {
     classify(policy_page(
         "MERGEABLE",
@@ -341,12 +350,31 @@ fn repository_merge_capabilities_select_an_allowed_method() {
         ((false, false, true), MergeMethod::Rebase),
     ];
     for ((merge, squash, rebase), expected) in cases {
-        let mut page = policy_page("MERGEABLE", "CLEAN", None, (false, None));
-        let repository = page.pointer_mut("/data/repository").assert_value();
-        repository["mergeCommitAllowed"] = json!(merge);
-        repository["squashMergeAllowed"] = json!(squash);
-        repository["rebaseMergeAllowed"] = json!(rebase);
+        let page = policy_page_with_merge_capabilities(merge, squash, rebase);
         assert_eq!(classify(page).merge_method, Some(expected));
+    }
+}
+
+#[test]
+fn authoritative_merge_revision_is_preserved_for_every_merge_method() {
+    for (merge, squash, rebase) in [
+        (true, false, false),
+        (false, true, false),
+        (false, false, true),
+    ] {
+        let mut page = policy_page_with_merge_capabilities(merge, squash, rebase);
+        let repository = page.pointer_mut("/data/repository").assert_value();
+        let pull_request = repository.pointer_mut("/pullRequest").assert_value();
+        pull_request["state"] = json!("MERGED");
+        pull_request["merged"] = json!(true);
+        pull_request["mergeCommit"] = json!({"oid":"cccccccccccccccccccccccccccccccccccccccc"});
+
+        assert_eq!(
+            classify(page).state,
+            GitHubReviewState::Merged {
+                merge_revision: "cccccccccccccccccccccccccccccccccccccccc".to_owned()
+            }
+        );
     }
 }
 

--- a/zeroshot/src/native_v2_delivery/github/wire.rs
+++ b/zeroshot/src/native_v2_delivery/github/wire.rs
@@ -101,6 +101,18 @@ pub(super) fn require_review_head(
     Ok(())
 }
 
+pub(super) fn reference_revision(
+    wire: GitReferenceWire,
+    branch: &str,
+) -> Result<String, GitHubAuthorityError> {
+    let valid_identity = wire.reference == format!("refs/heads/{branch}")
+        && wire.object.kind == "commit"
+        && valid_revision(&wire.object.sha);
+    valid_identity
+        .then_some(wire.object.sha)
+        .ok_or(GitHubAuthorityError::Rejected)
+}
+
 #[cfg(test)]
 #[path = "wire/tests.rs"]
 mod tests;

--- a/zeroshot/src/native_v2_delivery/github/wire/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/wire/tests.rs
@@ -57,3 +57,28 @@ fn stale_reference_head_is_retryable_but_changed_reference_is_rejected() {
         Err(GitHubAuthorityError::Rejected)
     );
 }
+
+#[test]
+fn target_reference_requires_the_exact_branch_and_commit_revision() {
+    let valid = json!({
+        "ref": "refs/heads/main",
+        "object": {
+            "sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "type": "commit"
+        }
+    });
+    assert_eq!(
+        reference_revision(serde_json::from_value(valid.clone()).assert_value(), "main")
+            .assert_value(),
+        "cccccccccccccccccccccccccccccccccccccccc"
+    );
+
+    for pointer in ["/ref", "/object/sha", "/object/type"] {
+        let mut changed = valid.clone();
+        *changed.pointer_mut(pointer).assert_value() = json!("invalid");
+        assert_eq!(
+            reference_revision(serde_json::from_value(changed).assert_value(), "main"),
+            Err(GitHubAuthorityError::Rejected)
+        );
+    }
+}

--- a/zeroshot/src/native_v2_delivery/tests.rs
+++ b/zeroshot/src/native_v2_delivery/tests.rs
@@ -18,12 +18,14 @@ use crate::full_v1_reducer::{
     ReductionInput, StructuralOccurrence,
 };
 use crate::native_v2_admission::NativeV2Admission;
-use crate::native_v2_candidate::test_support::{TestGitRepository, full_graph, git, success_node};
+use crate::native_v2_candidate::test_support::{
+    TestGitRepository, full_graph, git, git_output, success_node,
+};
 use crate::native_v2_contract::{
     self, CodexProvider, DeclaredConnections, DeclaredEnvironment, ExecutionRef, NodeInvocation,
     NodeRuntimeBinding, RunSize, RunSubmission, RunTitle, RuntimePlan, SourceBranchId,
-    SourceRepositoryId, SourceRevisionId, ResolvedSource, GIT_DELIVERY_MERGE_WORKER_REF,
-    GIT_DELIVERY_PR_WORKER_REF,
+    SourceRepositoryId, SourceRevisionId, ResolvedSource, GIT_DELIVERY_MERGE_V2_WORKER_REF,
+    GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF,
 };
 use crate::native_v2_runner::{
     DriverControl, DriverInvocation, NativeNodeRunner, NodeDriver, NodeRunRequest, NodeRunner,
@@ -63,6 +65,12 @@ async fn no_ci_can_merge_but_only_after_authoritative_confirmation() {
     assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 1);
 }
 
+#[tokio::test]
+async fn legacy_merge_worker_retains_the_v1_receipt_contract() {
+    let authority = successful_delivery(DeliveryMode::MergeV1, DELIVERY_MERGED_LABEL, 3).await;
+    assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 1);
+}
+
 async fn successful_delivery(
     mode: DeliveryMode,
     expected_label: &str,
@@ -73,6 +81,23 @@ async fn successful_delivery(
     let outcome = run_delivery(&repo, authority.clone(), attempts, mode).await;
     let output = assert_delivery_signal(&outcome, expected_label);
     assert_receipt_match(output, mode, &repo, true);
+    match mode {
+        DeliveryMode::PullRequest => {
+            assert_eq!(output.pointer("/version"), Some(&json!("v1")));
+            assert!(output.pointer("/mergeRevision").is_none());
+        }
+        DeliveryMode::MergeV1 => {
+            assert_eq!(output.pointer("/version"), Some(&json!("v1")));
+            assert!(output.pointer("/mergeRevision").is_none());
+        }
+        DeliveryMode::Merge => {
+            assert_eq!(output.pointer("/version"), Some(&json!("v2")));
+            assert_eq!(
+                output.pointer("/mergeRevision"),
+                Some(&json!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
+            );
+        }
+    }
     authority
 }
 
@@ -95,6 +120,20 @@ async fn observed_conflict_is_a_routable_non_receipt_result() {
     let output = assert_delivery_signal(&outcome, DELIVERY_CONFLICT_LABEL);
     assert_receipt_match(output, DeliveryMode::Merge, &repo, false);
     assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        authority.conflict_materializations.load(Ordering::SeqCst),
+        1
+    );
+    assert_eq!(output.pointer("/version"), Some(&json!("v2")));
+    assert_eq!(output.pointer("/mergeRevision"), Some(&json!("")));
+    let target_revision = git_output(&repo.remote, &["rev-parse", "refs/heads/main"]);
+    assert_eq!(
+        git_output(&repo.workspace, &["rev-parse", "MERGE_HEAD"]),
+        target_revision
+    );
+    assert!(outcome_diagnostic(&outcome).contains(&format!(
+        "targetRevision={target_revision}; conflictedPaths=[\"result.txt\"]"
+    )));
 }
 
 #[tokio::test]
@@ -107,6 +146,78 @@ async fn merge_api_conflict_is_not_collapsed_into_infrastructure_failure() {
     let outcome = run_delivery(&repo, authority.clone(), 2, DeliveryMode::Merge).await;
     assert_delivery_signal(&outcome, DELIVERY_CONFLICT_LABEL);
     assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        authority.conflict_materializations.load(Ordering::SeqCst),
+        1
+    );
+}
+
+#[tokio::test]
+async fn stale_conflict_observation_is_reobserved_without_repair_or_failure() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(
+        repo.remote.clone(),
+        Script::StaleConflictThenMerges,
+    ));
+
+    let outcome = run_delivery(&repo, authority.clone(), 3, DeliveryMode::Merge).await;
+
+    let output = assert_delivery_signal(&outcome, DELIVERY_MERGED_LABEL);
+    assert_receipt_match(output, DeliveryMode::Merge, &repo, true);
+    assert_eq!(authority.inspections.load(Ordering::SeqCst), 3);
+    assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        authority.conflict_materializations.load(Ordering::SeqCst),
+        1
+    );
+    assert_eq!(
+        git_output(
+            &repo.workspace,
+            &["status", "--porcelain=v1", "--untracked-files=all"]
+        ),
+        ""
+    );
+}
+
+#[test]
+fn merge_success_receipts_require_the_exact_authoritative_revision() {
+    let target = DeliveryTarget::new(
+        "acme/project",
+        "main",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+    .assert_value();
+    let mut receipt = json!({
+        "version":"v2",
+        "mode":"merge",
+        "outcome":"merged",
+        "repository":"acme/project",
+        "targetBranch":"main",
+        "headRevision":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "mergeRevision":"cccccccccccccccccccccccccccccccccccccccc",
+        "pullRequestId":"17"
+    });
+    assert!(is_matching_success_receipt(
+        &receipt,
+        DeliveryMode::Merge,
+        &target
+    ));
+
+    receipt["mergeRevision"] = json!("");
+    assert!(!is_matching_success_receipt(
+        &receipt,
+        DeliveryMode::Merge,
+        &target
+    ));
+    receipt
+        .as_object_mut()
+        .assert_value()
+        .remove("mergeRevision");
+    assert!(!is_matching_success_receipt(
+        &receipt,
+        DeliveryMode::Merge,
+        &target
+    ));
 }
 
 #[tokio::test]
@@ -269,10 +380,7 @@ async fn exact_merge_retry_rediscovers_the_same_review_and_receipt() {
 
     assert_eq!(first, second);
     assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 1);
-    let reviews = authority
-        .reviews
-        .lock()
-        .assert_value_with("review request lock");
+    let reviews = authority.review_requests();
     assert_eq!(reviews.len(), 2);
     assert_eq!(reviews.assert_at(0), reviews.assert_at(1));
 }
@@ -292,13 +400,7 @@ async fn rewritten_history_is_rejected_before_push() {
         WorkerOutcome::declared_failure(WorkerErrorCode::Crash)
     );
     assert!(!authority.pushed.load(Ordering::SeqCst));
-    assert!(
-        authority
-            .reviews
-            .lock()
-            .assert_value_with("review request lock")
-            .is_empty()
-    );
+    assert!(authority.review_requests().is_empty());
 }
 
 #[tokio::test]
@@ -486,14 +588,15 @@ fn target(repo: &TempRepo) -> DeliveryTarget {
 fn worker_ref(mode: DeliveryMode) -> &'static str {
     match mode {
         DeliveryMode::PullRequest => GIT_DELIVERY_PR_WORKER_REF,
-        DeliveryMode::Merge => GIT_DELIVERY_MERGE_WORKER_REF,
+        DeliveryMode::MergeV1 => GIT_DELIVERY_MERGE_WORKER_REF,
+        DeliveryMode::Merge => GIT_DELIVERY_MERGE_V2_WORKER_REF,
     }
 }
 
 fn delivery_node(mode: DeliveryMode) -> Value {
     let labels: &[&str] = match mode {
         DeliveryMode::PullRequest => &[DELIVERY_OPENED_LABEL],
-        DeliveryMode::Merge => &[
+        DeliveryMode::MergeV1 | DeliveryMode::Merge => &[
             DELIVERY_MERGED_LABEL,
             DELIVERY_CONFLICT_LABEL,
             DELIVERY_CI_FAILED_LABEL,
@@ -529,6 +632,16 @@ fn assert_delivery_signal<'a>(outcome: &'a WorkerOutcome, expected: &str) -> &'a
     assert!(diagnostic.pointer("/message").is_some_and(Value::is_string));
     assert!(artifacts.is_empty());
     output
+}
+
+fn outcome_diagnostic(outcome: &WorkerOutcome) -> &str {
+    match outcome {
+        WorkerOutcome::Verifier { diagnostic, .. } => diagnostic
+            .pointer("/message")
+            .and_then(Value::as_str)
+            .assert_value_with("delivery diagnostic message"),
+        _ => panic!("delivery must return a verifier result"),
+    }
 }
 
 fn assert_receipt_match(output: &Value, mode: DeliveryMode, repo: &TempRepo, expected: bool) {

--- a/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use async_trait::async_trait;
@@ -27,6 +27,8 @@ pub(super) enum Script {
     ProtectedBranch,
     ReviewSyncRace,
     CiFailsThenMerges,
+    ConflictThenMerges,
+    StaleConflictThenMerges,
     NeverConfirmsMerge,
     CredentialExpires,
     ReviewSyncCredentialExpires,
@@ -43,6 +45,7 @@ pub(super) struct FakeGitHub {
     pub(super) inspections: AtomicUsize,
     pub(super) reviews: Mutex<Vec<GitHubReviewRequest>>,
     pub(super) review_sync_attempts: AtomicUsize,
+    pub(super) conflict_materializations: AtomicUsize,
 }
 
 impl FakeGitHub {
@@ -58,6 +61,7 @@ impl FakeGitHub {
             inspections: AtomicUsize::new(0),
             reviews: Mutex::new(Vec::new()),
             review_sync_attempts: AtomicUsize::new(0),
+            conflict_materializations: AtomicUsize::new(0),
         }
     }
 
@@ -68,6 +72,9 @@ impl FakeGitHub {
             Script::RegistrationRace => self.registration_race_state(inspection),
             Script::MultipleRegistrationWaves => self.multiple_registration_waves_state(inspection),
             Script::CiFailsThenMerges => self.ci_repair_state(inspection),
+            Script::ConflictThenMerges | Script::StaleConflictThenMerges => {
+                self.conflict_repair_state()
+            }
             _ => self.static_review_state(),
         }
     }
@@ -109,6 +116,14 @@ impl FakeGitHub {
         }
     }
 
+    fn conflict_repair_state(&self) -> GitHubReviewState {
+        if self.conflict_materializations.load(Ordering::SeqCst) == 0 {
+            GitHubReviewState::Conflict
+        } else {
+            self.no_ci_state()
+        }
+    }
+
     fn registration_race_state(&self, inspection: usize) -> GitHubReviewState {
         if self.merge_requested.load(Ordering::SeqCst) {
             merged_review()
@@ -146,12 +161,45 @@ impl FakeGitHub {
             Script::CredentialExpires | Script::ReviewSyncCredentialExpires
         )
     }
+
+    pub(super) fn review_requests(&self) -> MutexGuard<'_, Vec<GitHubReviewRequest>> {
+        self.reviews.lock().assert_value_with("review request lock")
+    }
 }
 
 pub(super) fn delivery_harness(script: Script) -> (TempRepo, Arc<FakeGitHub>) {
     let repo = TempRepo::delivery();
     let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), script));
     (repo, authority)
+}
+
+fn advance_conflicting_target(remote: &Path) {
+    let root = remote.parent().assert_value();
+    let target = root.join("conflicting-target");
+    git(
+        root,
+        &[
+            "clone",
+            remote.to_str().assert_value(),
+            target.to_str().assert_value(),
+        ],
+    );
+    fs::write(target.join("result.txt"), "target\n").assert_value();
+    git(&target, &["add", "result.txt"]);
+    git(
+        &target,
+        &[
+            "-c",
+            "user.name=Target",
+            "-c",
+            "user.email=target@example.invalid",
+            "commit",
+            "--no-verify",
+            "--message",
+            "advance target",
+        ],
+    );
+    git(&target, &["push", "origin", "main"]);
 }
 
 fn merged_review() -> GitHubReviewState {
@@ -367,6 +415,76 @@ impl GitHubDeliveryAuthority for FakeGitHub {
             return Err(GitHubAuthorityError::Unavailable);
         }
         Ok(())
+    }
+
+    async fn materialize_merge_conflict(
+        &self,
+        request: &GitHubConflictRequest,
+        credential: GitHubCredential<'_>,
+    ) -> Result<GitHubConflictOutcome, GitHubAuthorityError> {
+        assert_eq!(credential.expose(), "test-token");
+        self.conflict_materializations
+            .fetch_add(1, Ordering::SeqCst);
+        if matches!(self.script, Script::StaleConflictThenMerges) {
+            return Ok(GitHubConflictOutcome::ObservationChanged);
+        }
+        advance_conflicting_target(&self.remote);
+        let target_revision = git_output(&self.remote, &["rev-parse", "refs/heads/main"]);
+        let fetch = std::process::Command::new("/usr/bin/git")
+            .arg("-C")
+            .arg(&request.workspace)
+            .args(["fetch", "--no-tags", "--quiet"])
+            .arg(&self.remote)
+            .arg(&target_revision)
+            .status()
+            .assert_value();
+        if !fetch.success() {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        let merge = std::process::Command::new("/usr/bin/git")
+            .arg("-C")
+            .arg(&request.workspace)
+            .args([
+                "-c",
+                "rerere.enabled=false",
+                "-c",
+                "user.name=Zeroshot",
+                "-c",
+                "user.email=delivery@zeroshot.invalid",
+                "merge",
+                "--no-commit",
+                "--no-ff",
+                "--no-edit",
+                &target_revision,
+            ])
+            .status()
+            .assert_value();
+        if merge.code() != Some(1) {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        let paths = std::process::Command::new("/usr/bin/git")
+            .arg("-C")
+            .arg(&request.workspace)
+            .args(["diff", "--name-only", "--diff-filter=U", "-z"])
+            .output()
+            .assert_value();
+        if !paths.status.success() {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        let conflicted_paths = String::from_utf8(paths.stdout)
+            .assert_value()
+            .split_terminator('\0')
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        if conflicted_paths.is_empty() {
+            return Err(GitHubAuthorityError::Rejected);
+        }
+        Ok(GitHubConflictOutcome::Materialized(
+            GitHubConflictMaterialization {
+                target_revision,
+                conflicted_paths,
+            },
+        ))
     }
 }
 

--- a/zeroshot/src/native_v2_delivery/tests/routing.rs
+++ b/zeroshot/src/native_v2_delivery/tests/routing.rs
@@ -1,5 +1,6 @@
 use super::*;
 use openengine_cluster_protocol::GraphSpec;
+use openengine_cluster_testkit::assertions::JsonAt;
 
 #[test]
 fn hosted_delivery_polling_has_no_work_duration_limit() {
@@ -63,6 +64,10 @@ impl NodeDriver for DeliveryLoopLane {
         }
         assert_eq!(invocation.node.reference.node.as_str(), "repair");
         let repair = self.repairs.fetch_add(1, Ordering::SeqCst) + 1;
+        let conflicted = self.workspace.join("result.txt");
+        if fs::read_to_string(&conflicted).is_ok_and(|contents| contents.contains("<<<<<<<")) {
+            fs::write(&conflicted, "resolved\n").map_err(|_| NodeRunnerError::Driver)?;
+        }
         fs::write(
             self.workspace.join("repair.txt"),
             format!("repair {repair}\n"),
@@ -106,13 +111,15 @@ async fn create_delivery_run(
     (run_id, ledger, environments)
 }
 
-#[tokio::test]
-async fn ci_failure_repairs_then_authoritatively_merges_in_one_supervised_run() {
-    let repo = TempRepo::delivery();
-    let authority = Arc::new(FakeGitHub::new(
-        repo.remote.clone(),
-        Script::CiFailsThenMerges,
-    ));
+async fn drive_repair_loop(
+    repo: &TempRepo,
+    authority: Arc<FakeGitHub>,
+) -> (
+    TerminalResult,
+    Arc<DeliveryLoopLane>,
+    RunId,
+    Arc<FakeRunLedger>,
+) {
     let admitted = admitted_routing_graph(&repo.base).await;
     let delivery = Arc::new(NativeV2DeliveryAdapter::new(
         NativeV2DeliveryConfig {
@@ -121,7 +128,7 @@ async fn ci_failure_repairs_then_authoritatively_merges_in_one_supervised_run() 
             target: DeliveryTarget::new("acme/project", "main", repo.base.clone()).assert_value(),
             poll: DeliveryPollPolicy::new(3, Duration::ZERO).assert_value(),
         },
-        authority.clone(),
+        authority,
     ));
     let lane = Arc::new(DeliveryLoopLane {
         delivery,
@@ -137,15 +144,37 @@ async fn ci_failure_repairs_then_authoritatively_merges_in_one_supervised_run() 
         .drive()
         .await
         .assert_value_with("drive delivery loop");
+    (terminal, lane, run_id, ledger)
+}
 
-    assert_eq!(
-        terminal,
-        TerminalResult::Succeeded {
-            output: Value::Null
-        }
-    );
+fn assert_successful_repair_loop(
+    terminal: TerminalResult,
+    repo: &TempRepo,
+    lane: &DeliveryLoopLane,
+    authority: &FakeGitHub,
+) {
+    let TerminalResult::Succeeded { output } = terminal else {
+        panic!("delivery repair loop must succeed");
+    };
+    assert!(is_matching_success_receipt(
+        &output,
+        DeliveryMode::Merge,
+        &target(repo)
+    ));
     assert_eq!(lane.repairs.load(Ordering::SeqCst), 1);
     assert_eq!(authority.merge_requests.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn ci_failure_repairs_then_authoritatively_merges_in_one_supervised_run() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(
+        repo.remote.clone(),
+        Script::CiFailsThenMerges,
+    ));
+    let (terminal, lane, run_id, ledger) = drive_repair_loop(&repo, authority.clone()).await;
+
+    assert_successful_repair_loop(terminal, &repo, &lane, &authority);
     assert_eq!(authority.inspections.load(Ordering::SeqCst), 3);
     let stored = ledger.get(&run_id).await.assert_value().assert_value();
     let execution_nodes = stored
@@ -170,6 +199,40 @@ async fn ci_failure_repairs_then_authoritatively_merges_in_one_supervised_run() 
     );
 }
 
+#[tokio::test]
+async fn materialized_conflict_repairs_and_retries_the_same_run_branch() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(
+        repo.remote.clone(),
+        Script::ConflictThenMerges,
+    ));
+    let (terminal, lane, _, _) = drive_repair_loop(&repo, authority.clone()).await;
+
+    assert_successful_repair_loop(terminal, &repo, &lane, &authority);
+    assert_eq!(
+        authority.conflict_materializations.load(Ordering::SeqCst),
+        1
+    );
+    let reviews = authority.review_requests();
+    assert_eq!(reviews.len(), 2);
+    assert_eq!(reviews[0].head_branch, reviews[1].head_branch);
+    assert_ne!(reviews[0].head_revision, reviews[1].head_revision);
+    assert_eq!(
+        git_output(
+            &repo.remote,
+            &[
+                "rev-parse",
+                &format!("refs/heads/{}", reviews[1].head_branch)
+            ]
+        ),
+        reviews[1].head_revision
+    );
+    assert_eq!(
+        fs::read_to_string(repo.workspace.join("result.txt")).assert_value(),
+        "resolved\n"
+    );
+}
+
 pub(super) async fn assert_ci_failure_routes_an_authored_worker_loop(
     base_revision: &str,
     outcome: WorkerOutcome,
@@ -182,7 +245,7 @@ pub(super) async fn assert_ci_failure_routes_an_authored_worker_loop(
     let delivery = settled_execution((1, 1), "deliver", (0, 1), outcome);
     let after_failure = FullV1Reducer::native_v2(&verified)
         .reduce(ReductionInput {
-            initial_input: &Value::Null,
+            initial_input: &routing_initial_input(base_revision),
             executions: std::slice::from_ref(&delivery),
             next_node_instance: 2,
             next_execution: 2,
@@ -204,7 +267,7 @@ pub(super) async fn assert_ci_failure_routes_an_authored_worker_loop(
     );
     let next_iteration = FullV1Reducer::native_v2(&verified)
         .reduce(ReductionInput {
-            initial_input: &Value::Null,
+            initial_input: &routing_initial_input(base_revision),
             executions: &[delivery, repair],
             next_node_instance: 3,
             next_execution: 3,
@@ -241,7 +304,7 @@ async fn admitted_routing_graph(base_revision: &str) -> crate::native_v2_contrac
         .admit(RunSubmission {
             title: RunTitle::new("Delivery routing test").assert_value(),
             graph,
-            initial_input: Value::Null,
+            initial_input: routing_initial_input(base_revision),
             runtime: RuntimePlan::Codex {
                 provider: crate::native_v2_contract::CodexProvider::OpenAi,
                 size: RunSize::Medium,
@@ -262,49 +325,103 @@ async fn admitted_routing_graph(base_revision: &str) -> crate::native_v2_contrac
 }
 
 fn routing_graph() -> GraphSpec {
-    let delivery = delivery_node(DeliveryMode::Merge);
-    full_graph(vec![
-        json!({
-            "kind":"loop","name":"delivery_loop","state":{"kind":"null"},
-                    "body":{
-                        "kind":"seq","name":"delivery_attempt","state":{"kind":"null"},
-                        "children":[
-                            delivery,
-                            {
-                                "kind":"choice","name":"delivery_route","state":{"kind":"null"},
-                                "branches":[{
-                                    "when":{
-                                        "kind":"in",
-                                        "value":{"name":"deliver","source":"signal","field":"delivery"},
-                                        "labels":["ci_failed"]
-                                    },
-                                    "node":{
-                                        "kind":"step","name":"repair","worker":"agent.repair@1",
-                                        "instructions":"Repair the failed delivery.",
-                                        "input":{"kind":"null"},"output":{"kind":"null"},
-                                        "inputBindings":Value::Array(Vec::new()),
-                                        "writeBindings":Value::Array(Vec::new()),
-                                        "timeoutMs":1000,"attempts":1
-                                    }
-                                }],
-                                "otherwise":{
-                                    "kind":"succeed","name":"merged",
-                                    "output":{"kind":"null"},"bindings":[]
-                                },
-                                "promotedStatePaths":[]
-                            }
-                        ],
-                        "promotedStatePaths":[]
-                    },
-                    "until":{
-                        "kind":"in",
-                        "value":{"name":"deliver","source":"signal","field":"delivery"},
-                        "labels":["merged"]
-                    },
-            "maxIterations":3,"promotedStatePaths":[]
-        }),
-        success_node(),
-    ])
+    let state = serde_json::to_value(delivery_result_schema(DeliveryMode::Merge).assert_value())
+        .assert_value();
+    let fields = state
+        .pointer("/fields")
+        .and_then(Value::as_object)
+        .map(|fields| fields.keys().cloned().collect::<Vec<_>>())
+        .assert_value();
+    let promoted = fields
+        .iter()
+        .map(|field| json!([field]))
+        .collect::<Vec<_>>();
+    let terminal_bindings = fields
+        .iter()
+        .map(|field| {
+            json!({
+                "target":[field],
+                "value":{"source":"state","path":[field]}
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut delivery = delivery_node(DeliveryMode::Merge);
+    *delivery.assert_key_mut("writeBindings") = Value::Array(
+        fields
+            .iter()
+            .map(|field| {
+                let value = json!({"node":"deliver","channel":"out","path":[field]});
+                json!({
+                    "target":[field],
+                    "value":value
+                })
+            })
+            .collect(),
+    );
+    let repair = json!({
+        "kind":"step","name":"repair","worker":"agent.repair@1",
+        "instructions":"Repair the failed delivery.",
+        "input":{"kind":"null"},"output":{"kind":"null"},
+        "inputBindings":[],"writeBindings":[],"timeoutMs":1000,"attempts":1
+    });
+    let delivery_route = json!({
+        "kind":"choice","name":"delivery_route","state":state.clone(),
+        "branches":[{
+            "when":{
+                "kind":"in",
+                "value":{"name":"deliver","source":"signal","field":"delivery"},
+                "labels":["ci_failed","conflict"]
+            },
+            "node":repair
+        }],
+        "otherwise":{
+            "kind":"succeed","name":"merged","output":state.clone(),
+            "bindings":terminal_bindings.clone()
+        },
+        "promotedStatePaths":[]
+    });
+    let delivery_loop = json!({
+        "kind":"loop","name":"delivery_loop","state":state.clone(),
+        "body":{
+            "kind":"seq","name":"delivery_attempt","state":state.clone(),
+            "children":[delivery,delivery_route],
+            "promotedStatePaths":promoted.clone()
+        },
+        "until":{
+            "kind":"in",
+            "value":{"name":"deliver","source":"signal","field":"delivery"},
+            "labels":["merged"]
+        },
+        "maxIterations":3,"promotedStatePaths":promoted
+    });
+    let done = json!({
+        "kind":"succeed","name":"done","output":state.clone(),
+        "bindings":terminal_bindings
+    });
+    serde_json::from_value(json!({
+        "profile":"openengine.graph.full/v1",
+        "initialInput":state.clone(),
+        "policy":{"policy":"policy.native-v2@1","default":"deny"},
+        "root":{
+            "kind":"seq","name":"root","state":state,
+            "children":[delivery_loop,done],
+            "promotedStatePaths":[]
+        }
+    }))
+    .assert_value()
+}
+
+fn routing_initial_input(base_revision: &str) -> Value {
+    Value::Object(serde_json::Map::from_iter([
+        ("version".to_owned(), json!("v2")),
+        ("mode".to_owned(), json!("merge")),
+        ("outcome".to_owned(), json!("conflict")),
+        ("repository".to_owned(), json!("acme/project")),
+        ("targetBranch".to_owned(), json!("main")),
+        ("headRevision".to_owned(), json!(base_revision)),
+        ("mergeRevision".to_owned(), json!("")),
+        ("pullRequestId".to_owned(), json!("pending")),
+    ]))
 }
 
 fn settled_execution(

--- a/zeroshot/src/native_v2_supervisor.rs
+++ b/zeroshot/src/native_v2_supervisor.rs
@@ -330,8 +330,10 @@ fn enforce_delivery_terminal(
     snapshot: &RunSnapshot,
     terminal: TerminalResult,
 ) -> Result<TerminalResult, NativeV2SupervisorError> {
+    let requires_delivery_receipt =
+        policy == DeliveryPolicy::Required || sole_delivery_node(admitted).is_some();
     let accepted = match &terminal {
-        TerminalResult::Succeeded { output } if policy == DeliveryPolicy::Required => {
+        TerminalResult::Succeeded { output } if requires_delivery_receipt => {
             has_required_delivery_receipt(admitted, snapshot, output)
         }
         TerminalResult::Succeeded { .. } | TerminalResult::Failed { .. } => true,

--- a/zeroshot/src/native_v2_supervisor/tests/delivery_gate.rs
+++ b/zeroshot/src/native_v2_supervisor/tests/delivery_gate.rs
@@ -104,12 +104,13 @@ async fn admitted_without_delivery() -> AdmittedRun {
 
 fn delivery_receipt() -> Value {
     json!({
-        "version": "v1",
+        "version": "v2",
         "mode": "merge",
         "outcome": "merged",
         "repository": "acme/project",
         "targetBranch": "main",
         "headRevision": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "mergeRevision": "cccccccccccccccccccccccccccccccccccccccc",
         "pullRequestId": "17"
     })
 }
@@ -254,6 +255,46 @@ async fn required_success_needs_exact_terminal_receipt_from_last_completed_write
             &admitted,
             &no_durable_delivery,
             TerminalResult::Succeeded { output: receipt },
+        )
+        .assert_value(),
+        delivery_unconfirmed()
+    );
+}
+
+#[tokio::test]
+async fn optional_policy_still_requires_a_receipt_when_delivery_is_present() {
+    let admitted = admitted_with_delivery().await;
+    let receipt = delivery_receipt();
+    let snapshot = snapshot(
+        &admitted,
+        [
+            ("worker", worker_outcome()),
+            ("deliver", delivery_outcome(receipt.clone())),
+            ("verify", verifier_outcome()),
+        ],
+    );
+    let accepted = TerminalResult::Succeeded {
+        output: json!({"delivery": receipt}),
+    };
+
+    assert_eq!(
+        enforce_delivery_terminal(
+            DeliveryPolicy::Optional,
+            &admitted,
+            &snapshot,
+            accepted.clone(),
+        )
+        .assert_value(),
+        accepted
+    );
+    assert_eq!(
+        enforce_delivery_terminal(
+            DeliveryPolicy::Optional,
+            &admitted,
+            &snapshot,
+            TerminalResult::Succeeded {
+                output: Value::Null,
+            },
         )
         .assert_value(),
         delivery_unconfirmed()

--- a/zeroshot/src/native_v2_target.rs
+++ b/zeroshot/src/native_v2_target.rs
@@ -13,11 +13,11 @@ use thiserror::Error;
 use zeroshot_engine::native_v2_cli::oecp::{BoxedSubscription, TargetConnector};
 use zeroshot_engine::native_v2_cli::{
     CliRunForceResult, CliRunListResult, CliRunStatusResult, CliRunWatchEventNotification,
-    NativeV2CliError, PreparedRunRequest, TargetAdd,
+    NativeV2CliError, PreparedMergePlanRequest, PreparedRunRequest, TargetAdd,
 };
 use openengine_cluster_protocol::{
     ConnectionDeleteRequest, ConnectionDeleteResult, ConnectionListRequest, ConnectionListResult,
-    ConnectionMutationResult, ConnectionSetRequest,
+    ConnectionMutationResult, ConnectionSetRequest, MergePlan, MergePlanId, MergePlanSubmitRequest,
 };
 use openengine_cluster_protocol::{
     RunForceParams, RunListParams, RunLogEventNotification, RunLogsParams, RunStatusParams,
@@ -259,6 +259,59 @@ where
         let target = self.target(name)?;
         self.authority
             .profile_default(&target, request)
+            .await
+            .map_err(cli_authority_error)
+    }
+
+    async fn merge_plan_submit(
+        &self,
+        name: &str,
+        request: PreparedMergePlanRequest,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        let target = self.target(name)?;
+        if matches!(target.access, TargetAccess::Direct) {
+            return Err(NativeV2CliError::Target(
+                "direct target does not support hosted merge plans".to_owned(),
+            ));
+        }
+        self.authority
+            .merge_plan_submit(
+                &target,
+                &MergePlanSubmitRequest {
+                    submission_key: request.submission_key,
+                    title: request.title,
+                    expires_at: request.expires_at,
+                    source: request.source,
+                    profile: request.profile,
+                    runs: request.runs,
+                    connections: request.connections,
+                    github_token: request.github_token,
+                },
+            )
+            .await
+            .map_err(cli_authority_error)
+    }
+
+    async fn merge_plan_status(
+        &self,
+        name: &str,
+        plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        let target = self.target(name)?;
+        self.authority
+            .merge_plan_status(&target, &plan_id)
+            .await
+            .map_err(cli_authority_error)
+    }
+
+    async fn merge_plan_force(
+        &self,
+        name: &str,
+        plan_id: MergePlanId,
+    ) -> Result<MergePlan, NativeV2CliError> {
+        let target = self.target(name)?;
+        self.authority
+            .merge_plan_force(&target, &plan_id)
             .await
             .map_err(cli_authority_error)
     }

--- a/zeroshot/src/native_v2_target/authority.rs
+++ b/zeroshot/src/native_v2_target/authority.rs
@@ -3,6 +3,7 @@ use openengine_cluster_protocol::{
     ConnectionDeleteRequest, ConnectionDeleteResult, ConnectionListRequest, ConnectionListResult,
     ConnectionMutationResult, ConnectionSetRequest,
 };
+use openengine_cluster_protocol::{MergePlan, MergePlanId, MergePlanSubmitRequest};
 use openengine_cluster_protocol::{
     RunForceParams, RunListParams, RunLogEventNotification, RunLogsParams, RunStatusParams,
     RunSubmitResult, RunWatchParams, TargetOecpSessionRequest, TargetRunRequest,
@@ -91,6 +92,27 @@ pub trait TargetControlAuthority: Send + Sync {
     ) -> Result<RunSubmitResult, TargetAuthorityError> {
         Err(TargetAuthorityError::new("profile runs are unavailable"))
     }
+    async fn merge_plan_submit(
+        &self,
+        _target: &TargetRecord,
+        _request: &MergePlanSubmitRequest,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        merge_plan_unavailable()
+    }
+    async fn merge_plan_status(
+        &self,
+        _target: &TargetRecord,
+        _plan_id: &MergePlanId,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        merge_plan_unavailable()
+    }
+    async fn merge_plan_force(
+        &self,
+        _target: &TargetRecord,
+        _plan_id: &MergePlanId,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        merge_plan_unavailable()
+    }
     async fn hosted_run_list(
         &self,
         target: &TargetRecord,
@@ -116,6 +138,12 @@ pub trait TargetControlAuthority: Send + Sync {
         target: &TargetRecord,
         params: RunForceParams,
     ) -> Result<CliRunForceResult, TargetAuthorityError>;
+}
+
+fn merge_plan_unavailable<T>() -> Result<T, TargetAuthorityError> {
+    Err(TargetAuthorityError::new(
+        "hosted merge plans are unavailable",
+    ))
 }
 
 fn profile_unavailable<T>() -> Result<T, TargetAuthorityError> {

--- a/zeroshot/src/native_v2_target/authority_error.rs
+++ b/zeroshot/src/native_v2_target/authority_error.rs
@@ -48,6 +48,15 @@ impl TargetAuthorityError {
         }
     }
 
+    pub(super) fn is_http_auth_rejection(&self) -> bool {
+        self.remote
+            .as_ref()
+            .and_then(|remote| remote.details.as_ref())
+            .and_then(|details| details.get("httpStatus"))
+            .and_then(serde_json::Value::as_u64)
+            .is_some_and(|status| matches!(status, 401 | 403))
+    }
+
     pub(super) fn into_cli(self) -> NativeV2CliError {
         if self.disconnected {
             NativeV2CliError::Disconnected

--- a/zeroshot/src/native_v2_target/controller_authority.rs
+++ b/zeroshot/src/native_v2_target/controller_authority.rs
@@ -16,9 +16,9 @@ use zeroshot_engine::native_v2_target_authority::{DISCOVERY_PATH, TargetDiscover
 
 use self::contract::{
     build_auth_descriptor, build_controller_descriptor, validate_metadata_routes,
-    ControllerDescriptor, DeviceCodeWire, DevicePoll, HostedAuthDescriptor, OAuthErrorWire,
-    OAuthMetadataWire, TargetSessionWire, TokenWire, authority_error, parse_origin, read_json,
-    read_success_json, require_response_route, validate_device_code, validate_secret,
+    ControllerDescriptor, DeviceCodeWire, DevicePoll, HostedAuthDescriptor, MergePlansDescriptor,
+    OAuthErrorWire, OAuthMetadataWire, TargetSessionWire, TokenWire, authority_error, parse_origin,
+    read_json, read_success_json, require_response_route, validate_device_code, validate_secret,
     validate_token,
 };
 use self::credentials::{
@@ -31,12 +31,25 @@ use super::{TargetAccess, TargetAuthorityError, TargetRecord};
 const DEVICE_GRANT: &str = "urn:ietf:params:oauth:grant-type:device_code";
 const SESSION_KIND: &str = "openengine.target-session/v1";
 const DEVICE_LABEL: &str = "zeroshot-cli";
+const ACCESS_TOKEN_EXPIRY_SKEW: Duration = Duration::from_secs(30);
 
 struct HostedLogin<'a> {
     target_id: &'a str,
     device_token: &'a str,
     auth: &'a HostedAuthDescriptor,
     audience: &'a str,
+}
+
+struct IssuedAccessToken {
+    value: String,
+    reusable_until: Instant,
+}
+
+struct CachedMergePlanAccess {
+    target: TargetRecord,
+    routes: MergePlansDescriptor,
+    access_token: String,
+    reusable_until: Instant,
 }
 
 /// One named-target HTTP authority. Hosted access retains the existing OAuth refresh-family flow;
@@ -48,6 +61,7 @@ pub struct TargetHttpControlAuthority {
     credentials: Arc<dyn TargetCredentialStore>,
     notifier: Arc<dyn DeviceCodeNotifier>,
     refresh_lock_directory: PathBuf,
+    merge_plan_access: Arc<tokio::sync::Mutex<Option<CachedMergePlanAccess>>>,
 }
 
 impl TargetHttpControlAuthority {
@@ -79,6 +93,7 @@ impl TargetHttpControlAuthority {
             credentials,
             notifier: Arc::new(StderrDeviceCodeNotifier),
             refresh_lock_directory,
+            merge_plan_access: Arc::new(tokio::sync::Mutex::new(None)),
         })
     }
 
@@ -100,6 +115,7 @@ impl TargetHttpControlAuthority {
             credentials,
             notifier,
             refresh_lock_directory,
+            merge_plan_access: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 
@@ -257,6 +273,15 @@ impl TargetHttpControlAuthority {
         auth: &HostedAuthDescriptor,
         audience: &str,
     ) -> Result<String, TargetAuthorityError> {
+        Ok(self.issue_access_token(target, auth, audience).await?.value)
+    }
+
+    async fn issue_access_token(
+        &self,
+        target: &TargetRecord,
+        auth: &HostedAuthDescriptor,
+        audience: &str,
+    ) -> Result<IssuedAccessToken, TargetAuthorityError> {
         let _refresh_guard = self.lock_refresh_family(&target.id).await?;
         let refresh_token = self
             .credentials
@@ -264,6 +289,7 @@ impl TargetHttpControlAuthority {
             .await?
             .ok_or_else(|| authority_error("target login required"))?;
         validate_secret(&refresh_token, "stored refresh token")?;
+        let issued_at = Instant::now();
         let token: TokenWire = self
             .post_form_json(
                 &auth.token_endpoint,
@@ -281,7 +307,12 @@ impl TargetHttpControlAuthority {
         self.credentials
             .set(&target.id, &token.refresh_token)
             .await?;
-        Ok(token.access_token)
+        let reusable_for =
+            Duration::from_secs(token.expires_in).saturating_sub(ACCESS_TOKEN_EXPIRY_SKEW);
+        Ok(IssuedAccessToken {
+            value: token.access_token,
+            reusable_until: issued_at + reusable_for,
+        })
     }
 
     async fn verify_session(

--- a/zeroshot/src/native_v2_target/controller_authority/connections.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/connections.rs
@@ -39,8 +39,7 @@ impl TargetHttpControlAuthority {
             .header(ACCEPT, "application/json")
             .header(CACHE_CONTROL, "no-store")
             .json(&request);
-        self.hosted_json(builder, &routes.list, "connection list")
-            .await
+        self.hosted_json(builder, "connection list", None).await
     }
 
     pub(super) async fn connection_set(
@@ -54,8 +53,7 @@ impl TargetHttpControlAuthority {
             .header(ACCEPT, "application/json")
             .header(CACHE_CONTROL, "no-store")
             .json(&request);
-        self.hosted_json(builder, &routes.set, "connection set")
-            .await
+        self.hosted_json(builder, "connection set", None).await
     }
 
     pub(super) async fn connection_delete(
@@ -69,7 +67,6 @@ impl TargetHttpControlAuthority {
             .header(ACCEPT, "application/json")
             .header(CACHE_CONTROL, "no-store")
             .json(&request);
-        self.hosted_json(builder, &routes.delete, "connection delete")
-            .await
+        self.hosted_json(builder, "connection delete", None).await
     }
 }

--- a/zeroshot/src/native_v2_target/controller_authority/contract.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/contract.rs
@@ -10,9 +10,9 @@ mod hosted_runs;
 mod http_error;
 mod profiles;
 
-use hosted_runs::build_hosted_runs_descriptor;
-pub(super) use hosted_runs::HostedRunsDescriptor;
-pub(super) use http_error::{http_error, read_success_json};
+use hosted_runs::{build_hosted_runs_descriptor, build_merge_plans_descriptor};
+pub(super) use hosted_runs::{HostedRunsDescriptor, MergePlansDescriptor};
+pub(super) use http_error::{http_error, read_success_json, read_success_json_with_limit};
 use connections::build_connections_descriptor;
 pub(super) use connections::ConnectionsDescriptor;
 use profiles::build_profiles_descriptor;
@@ -40,6 +40,7 @@ pub(super) struct HostedAuthDescriptor {
     pub(super) device_grant_type: String,
     pub(super) session_endpoint: Url,
     pub(super) hosted_runs: HostedRunsDescriptor,
+    pub(super) merge_plans: Option<MergePlansDescriptor>,
     pub(super) connections: Option<ConnectionsDescriptor>,
     pub(super) run_profiles: Option<RunProfilesDescriptor>,
 }
@@ -217,12 +218,20 @@ pub(super) fn require_response_route(
 }
 
 pub(super) async fn read_json<T: DeserializeOwned>(
+    response: reqwest::Response,
+    operation: &'static str,
+) -> Result<T, TargetAuthorityError> {
+    read_json_with_limit(response, operation, MAX_RESPONSE_BYTES).await
+}
+
+pub(super) async fn read_json_with_limit<T: DeserializeOwned>(
     mut response: reqwest::Response,
     operation: &'static str,
+    maximum_bytes: usize,
 ) -> Result<T, TargetAuthorityError> {
     if response
         .content_length()
-        .is_some_and(|length| length > MAX_RESPONSE_BYTES as u64)
+        .is_some_and(|length| length > maximum_bytes as u64)
     {
         return Err(authority_error(format!(
             "{operation} response is too large"
@@ -232,7 +241,7 @@ pub(super) async fn read_json<T: DeserializeOwned>(
     while let Some(chunk) = response.chunk().await.map_err(|_| {
         TargetAuthorityError::disconnected(format!("{operation} response read failed"))
     })? {
-        if bytes.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+        if bytes.len().saturating_add(chunk.len()) > maximum_bytes {
             return Err(authority_error(format!(
                 "{operation} response is too large"
             )));
@@ -276,8 +285,7 @@ pub(super) fn build_auth_descriptor(
         .as_ref()
         .ok_or_else(|| authority_error("hosted target discovery is incompatible"))?;
     let hosted_runs = build_hosted_runs_descriptor(origin, &wire.extensions)?;
-    let connections = build_connections_descriptor(origin, &wire.extensions)?;
-    let run_profiles = build_profiles_descriptor(origin, &wire.extensions)?;
+    let capabilities = build_optional_capabilities(origin, &wire.extensions)?;
     let (metadata_url, device_authorization_endpoint, token_endpoint, revocation_endpoint) =
         oauth_routes(origin, oauth)?;
     Ok(HostedAuthDescriptor {
@@ -289,8 +297,26 @@ pub(super) fn build_auth_descriptor(
         device_grant_type: oauth.device_grant_type.clone(),
         session_endpoint: same_origin_path(origin, &session.route_template)?,
         hosted_runs,
-        connections,
-        run_profiles,
+        merge_plans: capabilities.merge_plans,
+        connections: capabilities.connections,
+        run_profiles: capabilities.run_profiles,
+    })
+}
+
+struct OptionalCapabilities {
+    merge_plans: Option<MergePlansDescriptor>,
+    connections: Option<ConnectionsDescriptor>,
+    run_profiles: Option<RunProfilesDescriptor>,
+}
+
+fn build_optional_capabilities(
+    origin: &Url,
+    extensions: &openengine_cluster_protocol::TargetDiscoveryExtensions,
+) -> Result<OptionalCapabilities, TargetAuthorityError> {
+    Ok(OptionalCapabilities {
+        merge_plans: build_merge_plans_descriptor(origin, extensions)?,
+        connections: build_connections_descriptor(origin, extensions)?,
+        run_profiles: build_profiles_descriptor(origin, extensions)?,
     })
 }
 

--- a/zeroshot/src/native_v2_target/controller_authority/contract/hosted_runs.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/contract/hosted_runs.rs
@@ -2,6 +2,10 @@ use openengine_cluster_protocol::{Cursor, ExecutionRef, RunId};
 use reqwest::Url;
 use openengine_cluster_protocol::TargetDiscoveryExtensions;
 
+#[path = "hosted_runs/merge_plans.rs"]
+mod merge_plans;
+pub(crate) use merge_plans::{MergePlansDescriptor, build_merge_plans_descriptor};
+
 use super::{authority_error, same_origin_url, valid_literal_route_segment};
 use crate::native_v2_target::TargetAuthorityError;
 

--- a/zeroshot/src/native_v2_target/controller_authority/contract/hosted_runs/merge_plans.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/contract/hosted_runs/merge_plans.rs
@@ -1,0 +1,122 @@
+use openengine_cluster_protocol::{MERGE_PLANS_KIND, MergePlanId, TargetDiscoveryExtensions};
+use reqwest::Url;
+
+use super::validate_route_template;
+use crate::native_v2_target::controller_authority::contract::{
+    authority_error, capability_base_url, valid_literal_route_segment,
+};
+use crate::native_v2_target::TargetAuthorityError;
+
+#[derive(Clone)]
+pub(crate) struct MergePlansDescriptor {
+    base_url: Url,
+    create: MergePlanRoute,
+    status: MergePlanRoute,
+    force: MergePlanRoute,
+}
+
+#[derive(Clone)]
+struct MergePlanRoute {
+    segments: Vec<MergePlanRouteSegment>,
+}
+
+#[derive(Clone)]
+enum MergePlanRouteSegment {
+    Literal(String),
+    PlanId,
+}
+
+impl MergePlansDescriptor {
+    pub(in super::super::super) fn create_url(&self) -> Result<Url, TargetAuthorityError> {
+        self.create.expand(&self.base_url, None)
+    }
+
+    pub(in super::super::super) fn status_url(
+        &self,
+        plan_id: &MergePlanId,
+    ) -> Result<Url, TargetAuthorityError> {
+        self.status.expand(&self.base_url, Some(plan_id))
+    }
+
+    pub(in super::super::super) fn force_url(
+        &self,
+        plan_id: &MergePlanId,
+    ) -> Result<Url, TargetAuthorityError> {
+        self.force.expand(&self.base_url, Some(plan_id))
+    }
+}
+
+impl MergePlanRoute {
+    fn expand(
+        &self,
+        base_url: &Url,
+        plan_id: Option<&MergePlanId>,
+    ) -> Result<Url, TargetAuthorityError> {
+        let mut url = base_url.clone();
+        let mut path = url
+            .path_segments_mut()
+            .map_err(|_| authority_error("merge-plan base URL is invalid"))?;
+        path.pop_if_empty();
+        for segment in &self.segments {
+            match segment {
+                MergePlanRouteSegment::Literal(value) => path.push(value),
+                MergePlanRouteSegment::PlanId => path.push(
+                    plan_id
+                        .ok_or_else(|| authority_error("merge-plan route is incomplete"))?
+                        .as_str(),
+                ),
+            };
+        }
+        drop(path);
+        Ok(url)
+    }
+}
+
+pub(crate) fn build_merge_plans_descriptor(
+    origin: &Url,
+    extensions: &TargetDiscoveryExtensions,
+) -> Result<Option<MergePlansDescriptor>, TargetAuthorityError> {
+    let Some(wire) = &extensions.merge_plans else {
+        return Ok(None);
+    };
+    if wire.kind != MERGE_PLANS_KIND {
+        return Err(authority_error("merge-plan discovery is incompatible"));
+    }
+    let base_url = capability_base_url(origin, &wire.base_url)?;
+    Ok(Some(MergePlansDescriptor {
+        base_url,
+        create: compile_route(&wire.route_templates.create, false)?,
+        status: compile_route(&wire.route_templates.status, true)?,
+        force: compile_route(&wire.route_templates.force, true)?,
+    }))
+}
+
+fn compile_route(
+    value: &str,
+    requires_plan_id: bool,
+) -> Result<MergePlanRoute, TargetAuthorityError> {
+    validate_route_template(value)?;
+    let mut found_plan_id = false;
+    let mut segments = Vec::new();
+    for segment in value.split('/').skip(1) {
+        if segment == "{plan_id}" {
+            if found_plan_id {
+                return Err(unsupported_variables());
+            }
+            found_plan_id = true;
+            segments.push(MergePlanRouteSegment::PlanId);
+        } else if valid_literal_route_segment(segment) {
+            segments.push(MergePlanRouteSegment::Literal(segment.to_owned()));
+        } else {
+            return Err(authority_error("merge-plan route template is invalid"));
+        }
+    }
+    if found_plan_id != requires_plan_id {
+        return Err(unsupported_variables());
+    }
+    Ok(MergePlanRoute { segments })
+}
+
+fn unsupported_variables() -> TargetAuthorityError {
+    authority_error("merge-plan route template declares unsupported variables")
+}

--- a/zeroshot/src/native_v2_target/controller_authority/contract/http_error.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/contract/http_error.rs
@@ -3,7 +3,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{Map, Value, json};
 use openengine_cluster_protocol::TargetHttpProblem;
 
-use super::{read_json, require_response_route};
+use super::{read_json, read_json_with_limit, require_response_route};
 use crate::native_v2_target::TargetAuthorityError;
 
 pub(in crate::native_v2_target::controller_authority) async fn read_success_json<
@@ -13,11 +13,22 @@ pub(in crate::native_v2_target::controller_authority) async fn read_success_json
     expected: &Url,
     operation: &'static str,
 ) -> Result<T, TargetAuthorityError> {
+    read_success_json_with_limit(response, expected, operation, super::MAX_RESPONSE_BYTES).await
+}
+
+pub(in crate::native_v2_target::controller_authority) async fn read_success_json_with_limit<
+    T: DeserializeOwned,
+>(
+    response: reqwest::Response,
+    expected: &Url,
+    operation: &'static str,
+    maximum_bytes: usize,
+) -> Result<T, TargetAuthorityError> {
     require_response_route(&response, expected)?;
     if !response.status().is_success() {
         return Err(http_error(response, operation).await);
     }
-    read_json(response, operation).await
+    read_json_with_limit(response, operation, maximum_bytes).await
 }
 
 pub(in crate::native_v2_target::controller_authority) async fn http_error(

--- a/zeroshot/src/native_v2_target/controller_authority/control.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/control.rs
@@ -173,6 +173,30 @@ impl TargetControlAuthority for TargetHttpControlAuthority {
         TargetHttpControlAuthority::profile_run(self, target, request).await
     }
 
+    async fn merge_plan_submit(
+        &self,
+        target: &TargetRecord,
+        request: &openengine_cluster_protocol::MergePlanSubmitRequest,
+    ) -> Result<openengine_cluster_protocol::MergePlan, TargetAuthorityError> {
+        TargetHttpControlAuthority::merge_plan_submit(self, target, request).await
+    }
+
+    async fn merge_plan_status(
+        &self,
+        target: &TargetRecord,
+        plan_id: &openengine_cluster_protocol::MergePlanId,
+    ) -> Result<openengine_cluster_protocol::MergePlan, TargetAuthorityError> {
+        TargetHttpControlAuthority::merge_plan_status(self, target, plan_id).await
+    }
+
+    async fn merge_plan_force(
+        &self,
+        target: &TargetRecord,
+        plan_id: &openengine_cluster_protocol::MergePlanId,
+    ) -> Result<openengine_cluster_protocol::MergePlan, TargetAuthorityError> {
+        TargetHttpControlAuthority::merge_plan_force(self, target, plan_id).await
+    }
+
     async fn hosted_run_list(
         &self,
         target: &TargetRecord,

--- a/zeroshot/src/native_v2_target/controller_authority/hosted_runs.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/hosted_runs.rs
@@ -7,7 +7,10 @@ use reqwest::header::{ACCEPT, CACHE_CONTROL, CONTENT_TYPE};
 use reqwest::{RequestBuilder, Response, Url};
 use serde::de::DeserializeOwned;
 
-use super::contract::{HostedRunsDescriptor, http_error, read_success_json, require_response_route};
+use super::contract::{
+    HostedRunsDescriptor, MergePlansDescriptor, authority_error, http_error, read_success_json,
+    read_success_json_with_limit, require_response_route,
+};
 use super::TargetHttpControlAuthority;
 use zeroshot_engine::native_v2_cli::oecp::BoxedSubscription;
 use zeroshot_engine::native_v2_cli::{
@@ -18,6 +21,9 @@ use crate::native_v2_target::{TargetAccess, TargetAuthorityError, TargetRecord};
 
 const NDJSON_MEDIA_TYPE: &str = "application/x-ndjson";
 const MAX_STREAM_FRAME_BYTES: usize = 64 * 1024;
+
+#[path = "hosted_runs/merge_plans_http.rs"]
+mod merge_plans_http;
 
 struct HostedRunSubscription<E> {
     response: Response,
@@ -127,13 +133,34 @@ impl TargetHttpControlAuthority {
     pub(super) async fn hosted_json<T: DeserializeOwned>(
         &self,
         request: RequestBuilder,
-        url: &Url,
         operation: &'static str,
+        maximum_bytes: Option<usize>,
     ) -> Result<T, TargetAuthorityError> {
-        let response = request.send().await.map_err(|_| {
+        let request = request.build().map_err(|_| {
             TargetAuthorityError::disconnected(format!("{operation} request failed"))
         })?;
-        read_success_json(response, url, operation).await
+        let expected = request.url().clone();
+        let response = self.client.execute(request).await.map_err(|_| {
+            TargetAuthorityError::disconnected(format!("{operation} request failed"))
+        })?;
+        if let Some(maximum_bytes) = maximum_bytes {
+            read_success_json_with_limit(response, &expected, operation, maximum_bytes).await
+        } else {
+            read_success_json(response, &expected, operation).await
+        }
+    }
+
+    pub(super) async fn hosted_get_json<T: DeserializeOwned>(
+        &self,
+        url: Url,
+        access: &str,
+        operation: &'static str,
+    ) -> Result<T, TargetAuthorityError> {
+        let request = self
+            .authorized(self.client.get(url.clone()), access)?
+            .header(ACCEPT, "application/json")
+            .header(CACHE_CONTROL, "no-store");
+        self.hosted_json(request, operation, None).await
     }
 
     async fn hosted_stream<E>(
@@ -170,11 +197,7 @@ impl TargetHttpControlAuthority {
     ) -> Result<CliRunListResult, TargetAuthorityError> {
         let (routes, access) = self.require_hosted_run_access(target).await?;
         let url = routes.list_url()?;
-        let request = self
-            .authorized(self.client.get(url.clone()), &access)?
-            .header(ACCEPT, "application/json")
-            .header(CACHE_CONTROL, "no-store");
-        self.hosted_json(request, &url, "hosted run list").await
+        self.hosted_get_json(url, &access, "hosted run list").await
     }
 
     pub(super) async fn hosted_run_status(
@@ -184,11 +207,8 @@ impl TargetHttpControlAuthority {
     ) -> Result<CliRunStatusResult, TargetAuthorityError> {
         let (routes, access) = self.require_hosted_run_access(target).await?;
         let url = routes.status_url(&params.run_id)?;
-        let request = self
-            .authorized(self.client.get(url.clone()), &access)?
-            .header(ACCEPT, "application/json")
-            .header(CACHE_CONTROL, "no-store");
-        self.hosted_json(request, &url, "hosted run status").await
+        self.hosted_get_json(url, &access, "hosted run status")
+            .await
     }
 
     pub(super) async fn hosted_run_watch(
@@ -227,7 +247,7 @@ impl TargetHttpControlAuthority {
             .header(ACCEPT, "application/json")
             .header(CONTENT_TYPE, "application/json")
             .body("{}");
-        self.hosted_json(request, &url, "hosted run force").await
+        self.hosted_json(request, "hosted run force", None).await
     }
 }
 

--- a/zeroshot/src/native_v2_target/controller_authority/hosted_runs/merge_plans_http.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/hosted_runs/merge_plans_http.rs
@@ -1,0 +1,150 @@
+use std::time::Instant;
+
+use openengine_cluster_protocol::{MergePlan, MergePlanId, MergePlanSubmitRequest};
+use reqwest::header::ACCEPT;
+
+use super::{
+    CACHE_CONTROL, MergePlansDescriptor, TargetAccess, TargetAuthorityError,
+    TargetHttpControlAuthority, TargetRecord, authority_error,
+};
+use super::super::CachedMergePlanAccess;
+
+const MAX_MERGE_PLAN_RESPONSE_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Copy)]
+enum MergePlanHttpOperation<'a> {
+    Submit(&'a MergePlanSubmitRequest),
+    Status(&'a MergePlanId),
+    Force(&'a MergePlanId),
+}
+
+impl TargetHttpControlAuthority {
+    async fn require_merge_plan_access(
+        &self,
+        target: &TargetRecord,
+    ) -> Result<(MergePlansDescriptor, String), TargetAuthorityError> {
+        if matches!(target.access, TargetAccess::Direct) {
+            return Err(authority_error(
+                "direct target does not support hosted merge plans",
+            ));
+        }
+        let mut cached = self.merge_plan_access.lock().await;
+        if let Some(access) = cached.as_ref()
+            && access.target == *target
+            && Instant::now() < access.reusable_until
+        {
+            return Ok((access.routes.clone(), access.access_token.clone()));
+        }
+        let (auth, controller) = self.descriptors(target).await?;
+        let routes = auth.merge_plans.clone().ok_or_else(|| {
+            authority_error("hosted target does not advertise zeroshot.merge-plans/v1")
+        })?;
+        let access = self
+            .issue_access_token(target, &auth, &controller.audience)
+            .await?;
+        *cached = Some(CachedMergePlanAccess {
+            target: target.clone(),
+            routes: routes.clone(),
+            access_token: access.value.clone(),
+            reusable_until: access.reusable_until,
+        });
+        Ok((routes, access.value))
+    }
+
+    async fn invalidate_merge_plan_access(&self, target: &TargetRecord, access_token: &str) {
+        let mut cached = self.merge_plan_access.lock().await;
+        if cached
+            .as_ref()
+            .is_some_and(|access| access.target == *target && access.access_token == access_token)
+        {
+            *cached = None;
+        }
+    }
+
+    async fn execute_merge_plan_operation(
+        &self,
+        routes: &MergePlansDescriptor,
+        access: &str,
+        operation: MergePlanHttpOperation<'_>,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        let (request, label) = match operation {
+            MergePlanHttpOperation::Submit(body) => {
+                let url = routes.create_url()?;
+                let request = self
+                    .authorized(self.client.post(url), access)?
+                    .header(CACHE_CONTROL, "no-store")
+                    .json(body);
+                (request, "merge-plan submission")
+            }
+            MergePlanHttpOperation::Status(plan_id) => {
+                let url = routes.status_url(plan_id)?;
+                let request = self
+                    .authorized(self.client.get(url), access)?
+                    .header(ACCEPT, "application/json")
+                    .header(CACHE_CONTROL, "no-store");
+                (request, "merge-plan status")
+            }
+            MergePlanHttpOperation::Force(plan_id) => {
+                let url = routes.force_url(plan_id)?;
+                let request = self
+                    .authorized(self.client.post(url), access)?
+                    .header(CACHE_CONTROL, "no-store")
+                    .json(&serde_json::json!({}));
+                (request, "merge-plan force-stop")
+            }
+        };
+        self.hosted_json(request, label, Some(MAX_MERGE_PLAN_RESPONSE_BYTES))
+            .await
+    }
+
+    async fn execute_merge_plan_with_access(
+        &self,
+        target: &TargetRecord,
+        operation: MergePlanHttpOperation<'_>,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        let mut retried = false;
+        loop {
+            let (routes, access) = self.require_merge_plan_access(target).await?;
+            match self
+                .execute_merge_plan_operation(&routes, &access, operation)
+                .await
+            {
+                Err(error) if error.is_http_auth_rejection() => {
+                    self.invalidate_merge_plan_access(target, &access).await;
+                    if retried {
+                        return Err(error);
+                    }
+                    retried = true;
+                }
+                result => return result,
+            }
+        }
+    }
+
+    pub(in super::super) async fn merge_plan_submit(
+        &self,
+        target: &TargetRecord,
+        body: &MergePlanSubmitRequest,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        self.execute_merge_plan_with_access(target, MergePlanHttpOperation::Submit(body))
+            .await
+    }
+
+    pub(in super::super) async fn merge_plan_status(
+        &self,
+        target: &TargetRecord,
+        plan_id: &MergePlanId,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        self.execute_merge_plan_with_access(target, MergePlanHttpOperation::Status(plan_id))
+            .await
+    }
+
+    pub(in super::super) async fn merge_plan_force(
+        &self,
+        target: &TargetRecord,
+        plan_id: &MergePlanId,
+    ) -> Result<MergePlan, TargetAuthorityError> {
+        self.execute_merge_plan_with_access(target, MergePlanHttpOperation::Force(plan_id))
+            .await
+    }
+}

--- a/zeroshot/src/native_v2_target/controller_authority/profiles.rs
+++ b/zeroshot/src/native_v2_target/controller_authority/profiles.rs
@@ -79,7 +79,7 @@ impl TargetHttpControlAuthority {
             .header(ACCEPT, "application/json")
             .header(CACHE_CONTROL, "no-store")
             .json(input);
-        self.hosted_json(builder, &url, operation.label()).await
+        self.hosted_json(builder, operation.label(), None).await
     }
 
     pub(super) async fn profile_list(

--- a/zeroshot/src/native_v2_target/tests/hosted_authority.rs
+++ b/zeroshot/src/native_v2_target/tests/hosted_authority.rs
@@ -17,6 +17,8 @@ pub(super) use connections::test_authority;
 #[path = "hosted_authority/direct.rs"]
 mod direct;
 pub(super) use direct::{spawn_direct_target_authority, spawn_rejecting_direct_target_authority};
+#[path = "hosted_authority/merge_plans.rs"]
+mod merge_plans;
 #[path = "hosted_authority/problem_errors.rs"]
 mod problem_errors;
 
@@ -44,12 +46,17 @@ pub(super) struct CapturedHttpRequest {
     pub(super) body: String,
 }
 
-pub(super) async fn spawn_target_authority(
-    request_count: usize,
-) -> (String, tokio::task::JoinHandle<Vec<CapturedHttpRequest>>) {
+pub(super) async fn bind_target_authority() -> (TcpListener, std::net::SocketAddr, String) {
     let listener = TcpListener::bind("127.0.0.1:0").await.assert_value();
     let address = listener.local_addr().assert_value();
     let origin = format!("http://{address}");
+    (listener, address, origin)
+}
+
+pub(super) async fn spawn_target_authority(
+    request_count: usize,
+) -> (String, tokio::task::JoinHandle<Vec<CapturedHttpRequest>>) {
+    let (listener, address, origin) = bind_target_authority().await;
     let server_origin = origin.clone();
     let server = tokio::spawn(serve_target_authority(
         listener,
@@ -240,6 +247,15 @@ fn hosted_discovery(origin: &str) -> String {
                 "kind": "zeroshot.hosted-runs/v1",
                 "base_url": origin,
                 "route_templates": hosted_run_routes()
+            },
+            "merge_plans": {
+                "kind": "zeroshot.merge-plans/v1",
+                "baseUrl": origin,
+                "routeTemplates": {
+                    "create": "/native-v2/merge-plans",
+                    "status": "/native-v2/merge-plans/{plan_id}",
+                    "force": "/native-v2/merge-plans/{plan_id}/force"
+                }
             },
             "connections": {
                 "kind": "zeroshot.connections/v1",

--- a/zeroshot/src/native_v2_target/tests/hosted_authority/merge_plans.rs
+++ b/zeroshot/src/native_v2_target/tests/hosted_authority/merge_plans.rs
@@ -1,0 +1,314 @@
+use openengine_cluster_protocol::MergePlanId;
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
+use serde_json::{Value, json};
+
+use super::{
+    CapturedHttpRequest, bind_target_authority, hosted_discovery, oauth_metadata,
+    read_http_request, test_authority, token_response, write_http_response_with_status,
+};
+use super::super::fixtures::{TempRoot, hosted_target, temp_root};
+use super::super::super::controller_authority::{TargetCredentialStore, TargetHttpControlAuthority};
+use super::super::super::{TargetControlAuthority, TargetRecord};
+
+const DEFAULT_RESPONSE_LIMIT: usize = 64 * 1024;
+const MERGE_PLAN_RESPONSE_LIMIT: usize = 1024 * 1024;
+
+#[tokio::test]
+async fn merge_plan_polling_reuses_discovery_routes_and_access_token() {
+    let body = merge_plan_body(dense_runs());
+    let harness = merge_plan_harness(vec![body.clone(), body]).await;
+
+    let plan_id = MergePlanId::new("plan-1");
+    harness
+        .authority
+        .merge_plan_status(&harness.target, &plan_id)
+        .await
+        .assert_value();
+    harness
+        .authority
+        .merge_plan_status(&harness.target, &plan_id)
+        .await
+        .assert_value();
+
+    let requests = harness.server.await.assert_value();
+    assert_eq!(
+        request_count(&requests, "GET", "/.well-known/zeroshot-native-v2"),
+        1
+    );
+    assert_eq!(request_count(&requests, "GET", "/oauth/metadata"), 1);
+    assert_eq!(request_count(&requests, "POST", "/oauth/token"), 1);
+    assert_eq!(request_count(&requests, "GET", "/session"), 1);
+    assert_eq!(
+        request_count(&requests, "GET", "/native-v2/merge-plans/plan-1"),
+        2
+    );
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.path == "/native-v2/merge-plans/plan-1")
+            .map(|request| request.authorization.as_deref())
+            .collect::<Vec<_>>(),
+        vec![Some("Bearer access-1"), Some("Bearer access-1")]
+    );
+}
+
+#[tokio::test]
+async fn merge_plan_auth_rejection_refreshes_and_retries_once() {
+    let body = merge_plan_body(vec![merge_plan_run("build", Vec::new(), None)]);
+    for rejection in ["401 Unauthorized", "403 Forbidden"] {
+        let harness = merge_plan_harness_with_responses(
+            vec![(rejection, auth_rejection_body()), ("200 OK", body.clone())],
+            2,
+        )
+        .await;
+
+        harness
+            .authority
+            .merge_plan_status(&harness.target, &MergePlanId::new("plan-1"))
+            .await
+            .assert_value();
+
+        let requests = harness.server.await.assert_value();
+        assert_eq!(
+            request_count(&requests, "GET", "/.well-known/zeroshot-native-v2"),
+            2
+        );
+        assert_eq!(request_count(&requests, "POST", "/oauth/token"), 2);
+        assert_eq!(
+            merge_plan_authorizations(&requests),
+            ["Bearer access-1", "Bearer access-2"]
+        );
+        let refreshes = refresh_token_bodies(&requests);
+        assert!(refreshes[0].contains("refresh_token=refresh-0"));
+        assert!(refreshes[1].contains("refresh_token=refresh-1"));
+    }
+}
+
+#[tokio::test]
+async fn merge_plan_auth_retry_is_bounded_and_leaves_rejected_retry_uncached() {
+    let body = merge_plan_body(vec![merge_plan_run("build", Vec::new(), None)]);
+    let harness = merge_plan_harness_with_responses(
+        vec![
+            ("401 Unauthorized", auth_rejection_body()),
+            ("403 Forbidden", auth_rejection_body()),
+            ("200 OK", body),
+        ],
+        3,
+    )
+    .await;
+    let plan_id = MergePlanId::new("plan-1");
+
+    let error = harness
+        .authority
+        .merge_plan_status(&harness.target, &plan_id)
+        .await
+        .assert_error();
+    assert_eq!(
+        error.to_string(),
+        "merge-plan status request was rejected: access token rejected"
+    );
+    harness
+        .authority
+        .merge_plan_status(&harness.target, &plan_id)
+        .await
+        .assert_value();
+
+    let requests = harness.server.await.assert_value();
+    assert_eq!(request_count(&requests, "POST", "/oauth/token"), 3);
+    assert_eq!(
+        merge_plan_authorizations(&requests),
+        ["Bearer access-1", "Bearer access-2", "Bearer access-3"]
+    );
+}
+
+#[tokio::test]
+async fn merge_plan_status_accepts_a_maximal_dense_dag_above_the_default_limit() {
+    let body = merge_plan_body(dense_runs());
+    assert!(body.len() > DEFAULT_RESPONSE_LIMIT);
+    assert!(body.len() <= MERGE_PLAN_RESPONSE_LIMIT);
+    let harness = merge_plan_harness(vec![body]).await;
+
+    let plan = harness
+        .authority
+        .merge_plan_status(&harness.target, &MergePlanId::new("plan-1"))
+        .await
+        .assert_value();
+
+    assert_eq!(plan.runs.len(), 64);
+    harness.server.await.assert_value();
+}
+
+#[tokio::test]
+async fn merge_plan_status_rejects_a_response_above_its_dedicated_limit() {
+    let body = merge_plan_body(vec![merge_plan_run(
+        "oversized",
+        Vec::new(),
+        Some("x".repeat(MERGE_PLAN_RESPONSE_LIMIT)),
+    )]);
+    assert!(body.len() > MERGE_PLAN_RESPONSE_LIMIT);
+    let harness = merge_plan_harness(vec![body]).await;
+
+    let error = harness
+        .authority
+        .merge_plan_status(&harness.target, &MergePlanId::new("plan-1"))
+        .await
+        .assert_error();
+
+    assert_eq!(error.to_string(), "merge-plan status response is too large");
+    harness.server.await.assert_value();
+}
+
+struct MergePlanHarness {
+    _root: TempRoot,
+    authority: TargetHttpControlAuthority,
+    target: TargetRecord,
+    server: tokio::task::JoinHandle<Vec<CapturedHttpRequest>>,
+}
+
+async fn merge_plan_harness(responses: Vec<String>) -> MergePlanHarness {
+    merge_plan_harness_with_responses(
+        responses.into_iter().map(|body| ("200 OK", body)).collect(),
+        1,
+    )
+    .await
+}
+
+async fn merge_plan_harness_with_responses(
+    responses: Vec<(&'static str, String)>,
+    access_rounds: usize,
+) -> MergePlanHarness {
+    let (origin, server) = spawn_merge_plan_authority(responses, access_rounds).await;
+    let root = temp_root();
+    let (credentials, authority) = test_authority(&root);
+    let target = hosted_target("prod", origin);
+    credentials
+        .set(&target.id, "refresh-0")
+        .await
+        .assert_value();
+    MergePlanHarness {
+        _root: root,
+        authority,
+        target,
+        server,
+    }
+}
+
+async fn spawn_merge_plan_authority(
+    responses: Vec<(&'static str, String)>,
+    access_rounds: usize,
+) -> (String, tokio::task::JoinHandle<Vec<CapturedHttpRequest>>) {
+    let (listener, _, origin) = bind_target_authority().await;
+    let server_origin = origin.clone();
+    let server = tokio::spawn(async move {
+        let mut captured = Vec::new();
+        let mut token_index = 0_u8;
+        let request_count = responses.len() + access_rounds * 4;
+        let mut responses = responses.into_iter();
+        for _ in 0..request_count {
+            let (mut stream, request) = accept_merge_plan_request(&listener).await;
+            let (status, body) = match (request.method.as_str(), request.path.as_str()) {
+                ("GET", "/.well-known/zeroshot-native-v2") => {
+                    ("200 OK", hosted_discovery(&server_origin))
+                }
+                ("GET", "/oauth/metadata") => ("200 OK", oauth_metadata(&server_origin)),
+                ("POST", "/oauth/token") => ("200 OK", token_response(&mut token_index)),
+                ("GET", "/session") => (
+                    "200 OK",
+                    json!({
+                        "kind": "openengine.target-session/v1",
+                        "organization_id": "organization-1",
+                    })
+                    .to_string(),
+                ),
+                ("GET", path) if path.starts_with("/native-v2/merge-plans/") => {
+                    responses.next().assert_value()
+                }
+                unexpected => None::<(&str, String)>
+                    .assert_value_with(&format!("unexpected authority request: {unexpected:?}")),
+            };
+            write_http_response_with_status(&mut stream, status, &body).await;
+            captured.push(request);
+        }
+        captured
+    });
+    (origin, server)
+}
+
+async fn accept_merge_plan_request(
+    listener: &tokio::net::TcpListener,
+) -> (tokio::net::TcpStream, CapturedHttpRequest) {
+    let (mut stream, _) = listener.accept().await.assert_value();
+    let request = read_http_request(&mut stream).await;
+    (stream, request)
+}
+
+fn dense_runs() -> Vec<Value> {
+    let names = (0..64)
+        .map(|index| format!("n{index:02}-{}", "x".repeat(60)))
+        .collect::<Vec<_>>();
+    names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| merge_plan_run(name, names.get(..index).assert_value().to_vec(), None))
+        .collect()
+}
+
+fn merge_plan_run(name: &str, needs: Vec<String>, waiting_reason: Option<String>) -> Value {
+    json!({
+        "name": name,
+        "runId": format!("run-{name}"),
+        "state": "blocked",
+        "needs": needs,
+        "sourceRevision": null,
+        "readyAt": null,
+        "queueExpiresAt": null,
+        "terminalAt": null,
+        "waitingReason": waiting_reason,
+        "errorCode": null
+    })
+}
+
+fn merge_plan_body(runs: Vec<Value>) -> String {
+    json!({
+        "planId": "plan-1",
+        "title": "Dense merge plan",
+        "state": "queued",
+        "repository": "open-engine/zeroshot",
+        "branch": "main",
+        "submittedAt": "2026-09-10T00:00:00Z",
+        "expiresAt": "2026-09-11T00:00:00Z",
+        "runs": runs
+    })
+    .to_string()
+}
+
+fn auth_rejection_body() -> String {
+    json!({
+        "code": "unauthorized",
+        "message": "access token rejected"
+    })
+    .to_string()
+}
+
+fn merge_plan_authorizations(requests: &[CapturedHttpRequest]) -> Vec<&str> {
+    requests
+        .iter()
+        .filter(|request| request.path == "/native-v2/merge-plans/plan-1")
+        .filter_map(|request| request.authorization.as_deref())
+        .collect()
+}
+
+fn refresh_token_bodies(requests: &[CapturedHttpRequest]) -> Vec<&str> {
+    requests
+        .iter()
+        .filter(|request| request.path == "/oauth/token")
+        .map(|request| request.body.as_str())
+        .collect()
+}
+
+fn request_count(requests: &[CapturedHttpRequest], method: &str, path: &str) -> usize {
+    requests
+        .iter()
+        .filter(|request| request.method == method && request.path == path)
+        .count()
+}

--- a/zeroshot/src/native_v2_templates.rs
+++ b/zeroshot/src/native_v2_templates.rs
@@ -9,7 +9,7 @@ use openengine_cluster_protocol::{
     WorkerErrorCode, WorkerRef, WriteBinding,
 };
 
-use crate::native_v2_contract::{GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF};
+use crate::native_v2_contract::{GIT_DELIVERY_MERGE_V2_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF};
 use crate::native_v2_delivery::contract::{
     delivery_diagnostic_schema, delivery_result_schema, delivery_signal_labels,
 };
@@ -509,7 +509,8 @@ fn delivery_mode(delivery: TemplateDelivery) -> Option<DeliveryMode> {
 fn delivery_worker(mode: DeliveryMode) -> &'static str {
     match mode {
         DeliveryMode::PullRequest => GIT_DELIVERY_PR_WORKER_REF,
-        DeliveryMode::Merge => GIT_DELIVERY_MERGE_WORKER_REF,
+        DeliveryMode::Merge => GIT_DELIVERY_MERGE_V2_WORKER_REF,
+        DeliveryMode::MergeV1 => unreachable!("built-in templates never author merge@1"),
     }
 }
 

--- a/zeroshot/src/native_v2_templates/tests/support.rs
+++ b/zeroshot/src/native_v2_templates/tests/support.rs
@@ -239,19 +239,34 @@ pub(super) fn settled_delivery_with_diagnostic(
 }
 
 pub(super) fn delivery_receipt(mode: DeliveryMode, outcome: &str) -> serde_json::Value {
-    let mode = match mode {
-        DeliveryMode::PullRequest => "pr",
-        DeliveryMode::Merge => "merge",
+    let (version, mode, merge_revision) = match mode {
+        DeliveryMode::PullRequest => ("v1", "pr", None),
+        DeliveryMode::MergeV1 => ("v1", "merge", None),
+        DeliveryMode::Merge => (
+            "v2",
+            "merge",
+            Some(
+                if outcome == crate::native_v2_delivery::DELIVERY_MERGED_LABEL {
+                    "c".repeat(40)
+                } else {
+                    String::new()
+                },
+            ),
+        ),
     };
-    json!({
-        "version":"v1",
+    let mut receipt = json!({
+        "version":version,
         "mode":mode,
         "outcome":outcome,
         "repository":"acme/project",
         "targetBranch":"main",
         "headRevision":"b".repeat(40),
         "pullRequestId":"17"
-    })
+    });
+    if let Some(merge_revision) = merge_revision {
+        receipt["mergeRevision"] = json!(merge_revision);
+    }
+    receipt
 }
 
 pub(super) struct SettledExecutionSpec<'a> {

--- a/zeroshot/tests/native_v2_cli_loopback/fixtures.rs
+++ b/zeroshot/tests/native_v2_cli_loopback/fixtures.rs
@@ -111,7 +111,7 @@ fn pr_delivery_graph(timeout_ms: u64, worker_errors_are_terminal: bool) -> serde
         "kind":"succeed",
         "name":"done",
         "output":delivery_result_schema("pr"),
-        "bindings":delivery_terminal_bindings()
+        "bindings":delivery_terminal_bindings("pr")
     });
     let children = if worker_errors_are_terminal {
         vec![
@@ -157,12 +157,12 @@ fn pr_delivery_graph(timeout_ms: u64, worker_errors_are_terminal: bool) -> serde
 
 fn merge_delivery_graph() -> serde_json::Value {
     let state = delivery_state_schema("merge");
-    let promoted = delivery_field_paths();
+    let promoted = delivery_field_paths("merge");
     let root = json!({"kind":"seq","name":"root","state":state,"children":[
             {"kind":"loop","name":"delivery_loop","state":state,
              "body":{"kind":"seq","name":"delivery_attempt","state":state,"children":[
                 delivery_node(
-                    "builtin.git-delivery.merge@1",
+                    "builtin.git-delivery.merge@2",
                     json!(["merged","conflict","ci_failed"]),
                     10_000,
                     "merge"
@@ -178,7 +178,7 @@ fn merge_delivery_graph() -> serde_json::Value {
                 }],
                 "otherwise":{"kind":"succeed","name":"merged",
                     "output":delivery_result_schema("merge"),
-                    "bindings":delivery_terminal_bindings()},
+                    "bindings":delivery_terminal_bindings("merge")},
                 "promotedStatePaths":[]}
              ],"promotedStatePaths":promoted},
              "until":{"kind":"in","value":{
@@ -186,7 +186,7 @@ fn merge_delivery_graph() -> serde_json::Value {
              },"labels":["merged"]},
              "maxIterations":3,"promotedStatePaths":promoted},
             {"kind":"succeed","name":"done","output":delivery_result_schema("merge"),
-                "bindings":delivery_terminal_bindings()}
+                "bindings":delivery_terminal_bindings("merge")}
         ],"promotedStatePaths":[]});
     native_v2_graph(state, root)
 }
@@ -212,7 +212,7 @@ pub(crate) fn delivery_node(
     json!({
         "kind":"verifier","name":"deliver","worker":worker,
         "input":{"kind":"null"},"output":delivery_result_schema(mode),
-        "inputBindings":[],"writeBindings":delivery_write_bindings(),
+        "inputBindings":[],"writeBindings":delivery_write_bindings(mode),
         "timeoutMs":timeout_ms,"attempts":1,
         "signals":{"delivery":labels},"diagnostic":{
             "kind":"record","fields":{
@@ -223,16 +223,16 @@ pub(crate) fn delivery_node(
 }
 
 pub(crate) fn delivery_result_schema(mode: &str) -> serde_json::Value {
-    let outcomes = match mode {
-        "pr" => Some(json!(["opened"])),
-        "merge" => Some(json!(["merged", "conflict", "ci_failed"])),
+    let (version, outcomes) = match mode {
+        "pr" => Some(("v1", json!(["opened"]))),
+        "merge" => Some(("v2", json!(["merged", "conflict", "ci_failed"]))),
         _ => None,
     }
     .assert_value_with("fixture delivery mode is closed");
-    json!({
+    let mut schema = json!({
         "kind":"record",
         "fields":{
-            "version":{"type":{"kind":"enum","values":["v1"]},"required":true},
+            "version":{"type":{"kind":"enum","values":[version]},"required":true},
             "mode":{"type":{"kind":"enum","values":[mode]},"required":true},
             "outcome":{"type":{"kind":"enum","values":outcomes},"required":true},
             "repository":{"type":{"kind":"string"},"required":true},
@@ -240,7 +240,18 @@ pub(crate) fn delivery_result_schema(mode: &str) -> serde_json::Value {
             "headRevision":{"type":{"kind":"string"},"required":true},
             "pullRequestId":{"type":{"kind":"string"},"required":true}
         }
-    })
+    });
+    if mode == "merge" {
+        schema
+            .assert_key_mut("fields")
+            .as_object_mut()
+            .assert_value_with("delivery schema fields")
+            .insert(
+                "mergeRevision".to_owned(),
+                json!({"type":{"kind":"string"},"required":true}),
+            );
+    }
+    schema
 }
 
 pub(crate) fn delivery_state_schema(mode: &str) -> serde_json::Value {
@@ -257,46 +268,63 @@ pub(crate) fn delivery_state_schema(mode: &str) -> serde_json::Value {
 }
 
 pub(crate) fn delivery_initial_input(instruction: &str, mode: &str) -> serde_json::Value {
-    let outcome = match mode {
-        "pr" => Some("opened"),
-        "merge" => Some("conflict"),
+    let (version, outcome) = match mode {
+        "pr" => Some(("v1", "opened")),
+        "merge" => Some(("v2", "conflict")),
         _ => None,
     }
     .assert_value_with("fixture delivery mode is closed");
-    json!({
+    let mut input = json!({
         "instruction":instruction,
-        "version":"v1",
+        "version":version,
         "mode":mode,
         "outcome":outcome,
         "repository":"placeholder/repository",
         "targetBranch":"main",
         "headRevision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "pullRequestId":"pending"
-    })
+    });
+    if mode == "merge" {
+        input["mergeRevision"] = json!("");
+    }
+    input
 }
 
-fn delivery_fields() -> [&'static str; 7] {
-    [
-        "version",
-        "mode",
-        "outcome",
-        "repository",
-        "targetBranch",
-        "headRevision",
-        "pullRequestId",
-    ]
+fn delivery_fields(mode: &str) -> &'static [&'static str] {
+    match mode {
+        "pr" => &[
+            "version",
+            "mode",
+            "outcome",
+            "repository",
+            "targetBranch",
+            "headRevision",
+            "pullRequestId",
+        ],
+        "merge" => &[
+            "version",
+            "mode",
+            "outcome",
+            "repository",
+            "targetBranch",
+            "headRevision",
+            "mergeRevision",
+            "pullRequestId",
+        ],
+        _ => panic!("fixture delivery mode is closed"),
+    }
 }
 
-pub(crate) fn delivery_field_paths() -> Vec<serde_json::Value> {
-    delivery_fields()
-        .into_iter()
+pub(crate) fn delivery_field_paths(mode: &str) -> Vec<serde_json::Value> {
+    delivery_fields(mode)
+        .iter()
         .map(|field| json!([field]))
         .collect()
 }
 
-fn delivery_write_bindings() -> Vec<serde_json::Value> {
-    delivery_fields()
-        .into_iter()
+fn delivery_write_bindings(mode: &str) -> Vec<serde_json::Value> {
+    delivery_fields(mode)
+        .iter()
         .map(|field| {
             json!({
                 "value":{"node":"deliver","channel":"out","path":[field]},
@@ -306,9 +334,9 @@ fn delivery_write_bindings() -> Vec<serde_json::Value> {
         .collect()
 }
 
-pub(crate) fn delivery_terminal_bindings() -> Vec<serde_json::Value> {
-    delivery_fields()
-        .into_iter()
+pub(crate) fn delivery_terminal_bindings(mode: &str) -> Vec<serde_json::Value> {
+    delivery_fields(mode)
+        .iter()
         .map(|field| {
             json!({
                 "target":[field],

--- a/zeroshot/tests/native_v2_cli_loopback/live.rs
+++ b/zeroshot/tests/native_v2_cli_loopback/live.rs
@@ -197,13 +197,13 @@ fn verifier_node(name: &str) -> serde_json::Value {
 fn terminal_node(name: &str, mode: &str) -> serde_json::Value {
     json!({
         "kind":"succeed","name":name,"output":delivery_result_schema(mode),
-        "bindings":delivery_terminal_bindings()
+        "bindings":delivery_terminal_bindings(mode)
     })
 }
 
 fn merge_delivery_node() -> serde_json::Value {
     delivery_node(
-        "builtin.git-delivery.merge@1",
+        "builtin.git-delivery.merge@2",
         json!(["merged", "conflict", "ci_failed"]),
         LIVE_TIMEOUT_MS,
         "merge",
@@ -238,7 +238,7 @@ fn complex_merge_graph() -> serde_json::Value {
 
 fn ci_repair_graph() -> serde_json::Value {
     let state = ci_repair_state_schema();
-    let promoted = delivery_field_paths();
+    let promoted = delivery_field_paths("merge");
     let route = json!({
         "kind":"choice","name":"delivery_route","state":state,"branches":[{
             "when":delivery_guard(json!(["ci_failed","conflict"])),


### PR DESCRIPTION
## Summary

Adds the shared hosted merge-plan protocol, structured CLI and Python SDK clients, and the trusted merge-delivery primitives required for DAG nodes to resolve and merge sequentially.

Conflict delivery now fetches the exact current target revision in the trusted lane, verifies a genuine unresolved Git merge, and hands that workspace state back to the same run without exposing the GitHub credential. Merge success receipts are v2 and include GitHub’s authoritative merged revision; PR receipts remain v1.

## Changes Made

- add strict `zeroshot.merge-plan/v1` request/status/discovery contracts
- add `zeroshot plan validate|submit|status|watch|force-stop`
- add typed async Python merge-plan APIs, projections, errors, docs, and example
- add verified real-conflict materialization and stale-observation cleanup
- preserve merge-only authoritative receipt semantics with `mergeRevision`

## Testing

- `cargo test --locked -p zeroshot --lib --quiet` (474 passed)
- focused real-Git conflict tests (3 passed)
- protocol merge-plan tests (2 passed)
- `cargo check -p zeroshot --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- generated CLI docs check
- Python Ruff lint/format, pydoclint, strict mypy, pytest (31 passed)
- `python -m mkdocs build --strict`
- Opcore Verify: 52/52 changed source files covered; no diagnostics

## Checklist

- [x] Tests pass
- [x] Documentation updated
- [x] Follows commit guidelines