### PR TITLE
fix: clarify merge plan queue semantics

### DIFF
--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -80,7 +80,7 @@ async def run_direct(runtime: UniformRuntime) -> None:
 
 Log in with the CLI first, then pass that target's local name to `HostedTarget`. A plan uses one
 explicit repository and branch plus one hosted profile. The profile must contain exactly one
-merge-delivery node.
+`builtin.git-delivery.merge@2` node.
 
 ```python
 from datetime import UTC, datetime, timedelta
@@ -99,7 +99,7 @@ async def submit_release_plan() -> None:
             "backend": MergePlanRun(input={"task": "Update the API."}),
             "frontend": MergePlanRun(input={"task": "Update the client."}),
             "integrate": MergePlanRun(
-                input={"task": "Resolve conflicts and run the release tests."},
+                input={"task": "Verify the combined changes and run the release tests."},
                 needs=("backend", "frontend"),
             ),
         },
@@ -115,9 +115,12 @@ async def submit_release_plan() -> None:
 ```
 
 Submission is atomic, and every node receives a stable run ID. `needs` gates readiness only; plan
-nodes have no output interpolation or shared mutable input. Cloud resolves a node's exact source
-revision after its dependencies merge, then starts that node's 24-hour queue deadline. The v1 API
-has no aggregate event stream, so `MergePlan.watch()` polls and yields changed snapshots.
+nodes have no output interpolation or shared mutable input. After dependencies merge, Cloud
+materializes the node against an exact source revision. When materialization completes, `readyAt`
+is set and the node gets a queue window of up to 24 hours, bounded by plan expiry. A merge conflict
+is repaired by the conflicting run itself in the same checkout and delivery loop. A descendant
+cannot repair a failed predecessor; it ends as `dependency_failed`. The v1 API has no aggregate
+event stream, so `MergePlan.watch()` polls and yields changed snapshots.
 
 ## Pass exact protocol documents
 

--- a/docs/zeroshot-cli.html
+++ b/docs/zeroshot-cli.html
@@ -526,10 +526,12 @@ The JSON manifest is strict and self-contained:
     }
   }
 
-Every run uses the same source and profile. The profile must contain exactly one merge-delivery node;
+Every run uses the same source and profile. The profile must contain exactly one `builtin.git-delivery.merge@2` node;
 pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
-Cloud assigns all run IDs atomically, resolves each exact source revision only when that run becomes
-ready, and starts its 24-hour queue deadline then. `expiresAt` must be in the future and no more than
+Cloud assigns every run ID atomically at submission. After a node&#39;s dependencies succeed, Cloud
+materializes it against an exact source revision. Completion starts a queue window of up to 24
+hours, bounded by `expiresAt`.
+`expiresAt` must be in the future and no more than
 seven days away. Plans cannot be edited or retried in place.</code></pre></section>
 <section id="zeroshot-plan-validate"><h4><code>zeroshot plan validate</code></h4>
 <pre><code>Validate a merge-plan manifest without contacting a target

--- a/docs/zeroshot-cli.md
+++ b/docs/zeroshot-cli.md
@@ -560,10 +560,12 @@ The JSON manifest is strict and self-contained:
     }
   }
 
-Every run uses the same source and profile. The profile must contain exactly one merge-delivery node;
+Every run uses the same source and profile. The profile must contain exactly one `builtin.git-delivery.merge@2` node;
 pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
-Cloud assigns all run IDs atomically, resolves each exact source revision only when that run becomes
-ready, and starts its 24-hour queue deadline then. `expiresAt` must be in the future and no more than
+Cloud assigns every run ID atomically at submission. After a node's dependencies succeed, Cloud
+materializes it against an exact source revision. Completion starts a queue window of up to 24
+hours, bounded by `expiresAt`.
+`expiresAt` must be in the future and no more than
 seven days away. Plans cannot be edited or retried in place.
 ```
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -78,8 +78,8 @@ async def run_direct(runtime: UniformRuntime) -> None:
 Docker is a deployment of `DirectTarget`, not a separate client or target type.
 
 `HostedTarget` reuses a named target and login from the CLI. Merge plans are immutable DAGs over one
-repository, branch, and hosted profile. That profile must contain exactly one merge-delivery node;
-pull-request delivery isn't accepted for plans.
+repository, branch, and hosted profile. That profile must contain exactly one
+`builtin.git-delivery.merge@2` node; pull-request delivery isn't accepted for plans.
 
 ```python
 from datetime import UTC, datetime, timedelta
@@ -98,7 +98,7 @@ async def run_plan() -> None:
             "backend": MergePlanRun(input={"task": "Update the API."}),
             "frontend": MergePlanRun(input={"task": "Update the client."}),
             "integrate": MergePlanRun(
-                input={"task": "Resolve conflicts and run the release tests."},
+                input={"task": "Verify the combined changes and run the release tests."},
                 needs=("backend", "frontend"),
             ),
         },
@@ -114,10 +114,12 @@ async def run_plan() -> None:
 ```
 
 Plan input is static JSON. A dependency controls when a node may start; it doesn't copy output into
-another node. Run IDs are assigned once during atomic submission, and each ready node resolves its
-source revision after its dependencies merge. Each node gets its own 24-hour queue deadline when it
-becomes ready. `MergePlan.watch()` polls the aggregate Cloud status and emits changed snapshots
-because the v1 plan API has no streaming endpoint.
+another node. Run IDs are assigned once during atomic submission. After dependencies merge, Cloud
+materializes a node against an exact source revision. When materialization completes, `readyAt` is
+set and the node gets a queue window of up to 24 hours, bounded by plan expiry. A merge conflict is
+repaired by the conflicting run itself in the same checkout and delivery loop. A descendant cannot
+repair a failed predecessor; it ends as `dependency_failed`. `MergePlan.watch()` polls the aggregate
+Cloud status and emits changed snapshots because the v1 plan API has no streaming endpoint.
 
 ## Exact graph and runtime control
 

--- a/sdks/python/examples/hosted_plan.py
+++ b/sdks/python/examples/hosted_plan.py
@@ -17,8 +17,9 @@ async def main() -> None:
         runs={
             "backend": MergePlanRun(input={"task": "Update the API."}),
             "frontend": MergePlanRun(input={"task": "Update the client."}),
+            # Predecessors repair their own delivery conflicts before this node can start.
             "integrate": MergePlanRun(
-                input={"task": "Resolve conflicts and run the release tests."},
+                input={"task": "Verify the combined changes and run the release tests."},
                 needs=("backend", "frontend"),
             ),
         },

--- a/sdks/python/src/zeroshot/client.py
+++ b/sdks/python/src/zeroshot/client.py
@@ -253,7 +253,9 @@ class Client:
             ProtocolError: If native output is malformed.
         """
         self._require_hosted_target()
-        submission_key = request.submission_key or _submission_key()
+        submission_key = (
+            request.submission_key if request.submission_key is not None else _submission_key()
+        )
         with tempfile.TemporaryDirectory(prefix="zeroshot-python-plan-") as directory:
             manifest = _write_json(Path(directory) / "plan.json", request.to_dict())
             await self._native(static=True).json(["plan", "validate", str(manifest)])

--- a/sdks/python/src/zeroshot/plans.py
+++ b/sdks/python/src/zeroshot/plans.py
@@ -85,8 +85,9 @@ class MergePlanRunStatus:
         state: Current materialization or run state.
         needs: Stable symbolic dependency names.
         source_revision: Exact source revision once the node materializes.
-        ready_at: RFC 3339 time at which all dependencies had succeeded.
-        queue_expires_at: RFC 3339 per-node queue deadline, set 24 hours after readiness.
+        ready_at: RFC 3339 time when source materialization completed and the node became ready.
+        queue_expires_at: RFC 3339 per-node queue deadline, up to 24 hours after readiness and
+            bounded by the plan deadline.
         terminal_at: RFC 3339 terminal time.
         waiting_reason: Stable explanation while queued or blocked, when supplied.
         error_code: Stable terminal error category, including dependency_failed.

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -287,7 +287,11 @@ def test_failed_result_has_opt_in_exception_projection() -> None:
     assert caught.value.result is result
 
 
-def test_hosted_plan_submission_uses_one_strict_manifest(fake_native: Path) -> None:
+@pytest.mark.parametrize("submission_key", ["release-1", ""])
+def test_hosted_plan_submission_uses_one_strict_manifest(
+    fake_native: Path,
+    submission_key: str,
+) -> None:
     request = MergePlanRequest(
         title="Release",
         repository="owner/repo",
@@ -298,7 +302,7 @@ def test_hosted_plan_submission_uses_one_strict_manifest(fake_native: Path) -> N
             "build": MergePlanRun(input={"task": "build"}),
             "integrate": MergePlanRun(input={"task": "integrate"}, needs=("build",)),
         },
-        submission_key="release-1",
+        submission_key=submission_key,
     )
 
     async def exercise() -> None:
@@ -326,7 +330,7 @@ def test_hosted_plan_submission_uses_one_strict_manifest(fake_native: Path) -> N
     assert all(item["plan"] == expected for item in invocations)
     submitted = invocations[1]["args"]
     assert submitted[submitted.index("--target") + 1] == "cloud"
-    assert submitted[submitted.index("--submission-key") + 1] == "release-1"
+    assert submitted[submitted.index("--submission-key") + 1] == submission_key
     assert "--detach" in submitted
 
 

--- a/zeroshot/src/native_v2_cli/parser.rs
+++ b/zeroshot/src/native_v2_cli/parser.rs
@@ -108,10 +108,12 @@ The JSON manifest is strict and self-contained:
     }
   }
 
-Every run uses the same source and profile. The profile must contain exactly one merge-delivery node;
+Every run uses the same source and profile. The profile must contain exactly one `builtin.git-delivery.merge@2` node;
 pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
-Cloud assigns all run IDs atomically, resolves each exact source revision only when that run becomes
-ready, and starts its 24-hour queue deadline then. `expiresAt` must be in the future and no more than
+Cloud assigns every run ID atomically at submission. After a node's dependencies succeed, Cloud
+materializes it against an exact source revision. Completion starts a queue window of up to 24
+hours, bounded by `expiresAt`.
+`expiresAt` must be in the future and no more than
 seven days away. Plans cannot be edited or retried in place."#)]
 enum PlanCommand {
     /// Validate a merge-plan manifest without contacting a target.


### PR DESCRIPTION
## Summary
- document queue readiness and the plan-expiry cap accurately
- make same-run merge-conflict repair explicit across CLI and Python examples
- preserve explicit Python submission keys, including empty values, for native validation
- name the required merge receipt v2 delivery profile precisely

## Verification
- cargo fmt --all -- --check
- cargo clippy --locked -p zeroshot --all-targets --all-features -- -D warnings
- cargo test --locked -p zeroshot --lib native_v2_cli (81 passed)
- generated CLI docs check
- Python ruff, format, mypy, and pytest (38 passed)
- Opcore Zero check clean; Sense partial only for two unsupported files, with no findings