### PR TITLE
fix: keep merge-plan GitHub credentials on delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,8 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   from public run status and logs.
 - Hosted merge plans are atomic, immutable, merge-only DAGs over one explicit repository, branch,
   and profile. The target resolves each node's exact revision only after its dependencies succeed;
-  plans have static inputs, no cross-node dataflow, and no retry-in-place.
+  plans have static inputs, no cross-node dataflow, and no retry-in-place. Agent runtime bindings
+  cannot declare `GH_TOKEN`; the sole merge-delivery binding owns the GitHub write credential.
 - Read-only safe commands include `zeroshot list`, `zeroshot status`, and `zeroshot logs`.
 - Destructive commands such as `zeroshot force-stop` require explicit user intent.
 

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -80,7 +80,8 @@ async def run_direct(runtime: UniformRuntime) -> None:
 
 Log in with the CLI first, then pass that target's local name to `HostedTarget`. A plan uses one
 explicit repository and branch plus one hosted profile. The profile must contain exactly one
-`builtin.git-delivery.merge@2` node.
+`builtin.git-delivery.merge@2` node. Agent bindings must not declare `GH_TOKEN`; only the Git
+delivery binding may declare it.
 
 ```python
 from datetime import UTC, datetime, timedelta

--- a/docs/zeroshot-cli.html
+++ b/docs/zeroshot-cli.html
@@ -527,7 +527,8 @@ The JSON manifest is strict and self-contained:
   }
 
 Every run uses the same source and profile. The profile must contain exactly one `builtin.git-delivery.merge@2` node;
-pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
+pull-request delivery is rejected. Agent bindings must not declare `GH_TOKEN`; only the Git delivery
+binding may declare it. `needs` gates readiness but does not pass output between runs.
 Cloud assigns every run ID atomically at submission. After a node&#39;s dependencies succeed, Cloud
 materializes it against an exact source revision. Completion starts a queue window of up to 24
 hours, bounded by `expiresAt`.

--- a/docs/zeroshot-cli.md
+++ b/docs/zeroshot-cli.md
@@ -561,7 +561,8 @@ The JSON manifest is strict and self-contained:
   }
 
 Every run uses the same source and profile. The profile must contain exactly one `builtin.git-delivery.merge@2` node;
-pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
+pull-request delivery is rejected. Agent bindings must not declare `GH_TOKEN`; only the Git delivery
+binding may declare it. `needs` gates readiness but does not pass output between runs.
 Cloud assigns every run ID atomically at submission. After a node's dependencies succeed, Cloud
 materializes it against an exact source revision. Completion starts a queue window of up to 24
 hours, bounded by `expiresAt`.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -79,7 +79,8 @@ Docker is a deployment of `DirectTarget`, not a separate client or target type.
 
 `HostedTarget` reuses a named target and login from the CLI. Merge plans are immutable DAGs over one
 repository, branch, and hosted profile. That profile must contain exactly one
-`builtin.git-delivery.merge@2` node; pull-request delivery isn't accepted for plans.
+`builtin.git-delivery.merge@2` node; pull-request delivery isn't accepted for plans. Agent bindings
+must not declare `GH_TOKEN`; only the Git delivery binding may declare it.
 
 ```python
 from datetime import UTC, datetime, timedelta

--- a/sdks/python/src/zeroshot/plans.py
+++ b/sdks/python/src/zeroshot/plans.py
@@ -45,7 +45,8 @@ class MergePlanRequest:
         title: Human-readable immutable plan title.
         repository: Source repository in owner/name form, shared by every node.
         branch: Source branch shared by every node.
-        profile: Hosted profile selector in user:name or org:name form.
+        profile: Hosted profile selector in user:name or org:name form. Agent bindings cannot
+            declare GH_TOKEN; only the Git delivery binding can declare it.
         expires_at: RFC 3339 deadline for the whole plan, at most seven days in the future.
         runs: Node names mapped to static inputs and symbolic dependencies.
         submission_key: Stable idempotency key; None generates one before native validation.

--- a/zeroshot/src/native_v2_admission.rs
+++ b/zeroshot/src/native_v2_admission.rs
@@ -24,6 +24,7 @@ use crate::native_v2_contract::{
     AdmittedRun, GIT_DELIVERY_MERGE_V2_WORKER_REF, NodeRuntimeBinding, RunSubmission,
     RunSubmissionIntent, RuntimePlan,
 };
+use crate::native_v2_delivery::GITHUB_TOKEN_ENV;
 use openengine_cluster_protocol::MAX_DECLARED_ENVIRONMENT_NAMES;
 
 /// Host policy for graph-visible Git delivery.
@@ -68,6 +69,8 @@ pub enum NativeV2AdmissionError {
     },
     #[error("merge plans require exactly one graph-visible Git merge delivery node")]
     MergeDeliveryRequired,
+    #[error("merge-plan agent node {node} must not declare GH_TOKEN")]
+    MergePlanAgentGitHubToken { node: NodeName },
     #[error(
         "run declares {found} unique environment names; maximum is {MAX_DECLARED_ENVIRONMENT_NAMES}"
     )]
@@ -131,6 +134,17 @@ impl NativeV2Admission {
             .any(|declaration| declaration.worker.as_str() == GIT_DELIVERY_MERGE_V2_WORKER_REF);
         if !has_merge {
             return Err(NativeV2AdmissionError::MergeDeliveryRequired);
+        }
+        if let Some(node) = runtime.nodes().iter().find_map(|(node, binding)| {
+            let NodeRuntimeBinding::Agent { connections, .. } = binding else {
+                return None;
+            };
+            connections
+                .environment_names()
+                .any(|name| name.as_str() == GITHUB_TOKEN_ENV)
+                .then_some(node.clone())
+        }) {
+            return Err(NativeV2AdmissionError::MergePlanAgentGitHubToken { node });
         }
         Ok(())
     }

--- a/zeroshot/src/native_v2_admission/tests.rs
+++ b/zeroshot/src/native_v2_admission/tests.rs
@@ -4,7 +4,7 @@ use crate::native_v2_contract::{
     EnvironmentVariableName, GIT_DELIVERY_MERGE_V2_WORKER_REF, GIT_DELIVERY_MERGE_WORKER_REF,
     GIT_DELIVERY_PR_WORKER_REF, ResolvedSource, RunSize, RunTitle, SessionScope,
 };
-use crate::native_v2_delivery::DeliveryMode;
+use crate::native_v2_delivery::{DeliveryMode, GITHUB_TOKEN_ENV};
 use crate::native_v2_delivery::contract::{delivery_result_schema, delivery_signal_labels};
 use openengine_cluster_protocol::{IdempotencyKey, ReasoningEffort};
 use serde_json::{json, Value};

--- a/zeroshot/src/native_v2_admission/tests/delivery.rs
+++ b/zeroshot/src/native_v2_admission/tests/delivery.rs
@@ -138,6 +138,66 @@ async fn merge_profile_validation_rejects_pull_request_delivery() {
 }
 
 #[tokio::test]
+async fn merge_profile_keeps_github_credentials_on_delivery_nodes() {
+    let merge_graph = graph(vec![
+        null_step("worker", "worker.change@1"),
+        delivery_verifier("deliver", DeliveryMode::Merge),
+        succeed("done"),
+    ]);
+    let agent_token = submission(
+        merge_graph.clone(),
+        BTreeMap::from([
+            (
+                named("worker"),
+                binding_with_environment([GITHUB_TOKEN_ENV.to_owned()]),
+            ),
+            (named("deliver"), delivery_binding()),
+        ]),
+    );
+
+    NativeV2Admission
+        .validate_profile(
+            &agent_token.graph,
+            &agent_token.runtime,
+            DeliveryPolicy::Required,
+        )
+        .await
+        .assert_value_with("ordinary hosted runs may explicitly bind GitHub to an agent");
+    assert_eq!(
+        NativeV2Admission
+            .validate_merge_profile(&agent_token.graph, &agent_token.runtime)
+            .await,
+        Err(NativeV2AdmissionError::MergePlanAgentGitHubToken {
+            node: named("worker"),
+        })
+    );
+
+    let delivery_token = submission(
+        merge_graph,
+        BTreeMap::from([
+            (named("worker"), binding("claude-sonnet-5", None)),
+            (
+                named("deliver"),
+                NodeRuntimeBinding::GitDelivery {
+                    connections: DeclaredConnections::single(
+                        "github-alias",
+                        DeclaredEnvironment::new([
+                            EnvironmentVariableName::new(GITHUB_TOKEN_ENV).assert_value()
+                        ])
+                        .assert_value(),
+                    )
+                    .assert_value(),
+                },
+            ),
+        ]),
+    );
+    NativeV2Admission
+        .validate_merge_profile(&delivery_token.graph, &delivery_token.runtime)
+        .await
+        .assert_value_with("merge plans keep GitHub credentials on Git delivery");
+}
+
+#[tokio::test]
 async fn legacy_merge_worker_remains_admissible_but_is_not_a_merge_plan_profile() {
     let legacy_graph = graph(vec![
         delivery_verifier("deliver", DeliveryMode::MergeV1),

--- a/zeroshot/src/native_v2_cli/diagnostic.rs
+++ b/zeroshot/src/native_v2_cli/diagnostic.rs
@@ -5,6 +5,7 @@ use serde_json::{Map, Value, json};
 
 use super::NativeV2CliError;
 use crate::native_v2_admission::NativeV2AdmissionError;
+use crate::native_v2_delivery::GITHUB_TOKEN_ENV;
 use crate::native_v2_supervisor::RunEnvironmentError;
 
 pub const ERROR_FORMAT_ENV: &str = "ZEROSHOT_ERROR_FORMAT";
@@ -182,6 +183,7 @@ fn admission_code(source: &NativeV2AdmissionError) -> &'static str {
         NativeV2AdmissionError::InitialInput(_) => "input.type_mismatch",
         NativeV2AdmissionError::MissingRuntimeBinding { .. } => "runtime.missing_binding",
         NativeV2AdmissionError::UnexpectedRuntimeBinding { .. } => "runtime.unexpected_binding",
+        NativeV2AdmissionError::MergePlanAgentGitHubToken { .. } => "runtime.invalid_environment",
         NativeV2AdmissionError::UnsupportedGraphProfile => "graph.unsupported_profile",
         _ => "request.invalid",
     }
@@ -197,7 +199,8 @@ fn admission_node(source: &NativeV2AdmissionError) -> Option<String> {
         | NativeV2AdmissionError::DeliveryMustBeVerifier { node }
         | NativeV2AdmissionError::UnsupportedDeliveryWorker { node, .. }
         | NativeV2AdmissionError::DeliveryWorkerRequiresBinding { node, .. }
-        | NativeV2AdmissionError::InvalidDeliveryContract { node, .. } => Some(node.to_string()),
+        | NativeV2AdmissionError::InvalidDeliveryContract { node, .. }
+        | NativeV2AdmissionError::MergePlanAgentGitHubToken { node } => Some(node.to_string()),
         _ => None,
     }
 }
@@ -206,6 +209,9 @@ fn admission_details(source: &NativeV2AdmissionError) -> Value {
     match source {
         NativeV2AdmissionError::DeliveryNodeCount { found, .. } => json!({"found": found}),
         NativeV2AdmissionError::DeclaredEnvironmentTooLarge { found } => json!({"found": found}),
+        NativeV2AdmissionError::MergePlanAgentGitHubToken { .. } => {
+            json!({"environment": GITHUB_TOKEN_ENV})
+        }
         _ => json!({}),
     }
 }
@@ -321,6 +327,21 @@ mod tests {
         assert_eq!(value.assert_key("code"), "runtime.missing_binding");
         assert_eq!(value.assert_key("node"), "worker");
         assert_eq!(value.assert_key("details"), &json!({}));
+    }
+
+    #[test]
+    fn merge_plan_agent_token_diagnostic_names_the_credential_boundary() {
+        let error =
+            NativeV2CliError::InvalidRun(NativeV2AdmissionError::MergePlanAgentGitHubToken {
+                node: NodeName::new("worker").assert_value(),
+            });
+        let value = serde_json::to_value(error.diagnostic()).assert_value();
+        assert_eq!(value.assert_key("code"), "runtime.invalid_environment");
+        assert_eq!(value.assert_key("node"), "worker");
+        assert_eq!(
+            value.assert_key("details"),
+            &json!({"environment": GITHUB_TOKEN_ENV})
+        );
     }
 
     #[test]

--- a/zeroshot/src/native_v2_cli/parser.rs
+++ b/zeroshot/src/native_v2_cli/parser.rs
@@ -109,7 +109,8 @@ The JSON manifest is strict and self-contained:
   }
 
 Every run uses the same source and profile. The profile must contain exactly one `builtin.git-delivery.merge@2` node;
-pull-request delivery is rejected. `needs` gates readiness but does not pass output between runs.
+pull-request delivery is rejected. Agent bindings must not declare `GH_TOKEN`; only the Git delivery
+binding may declare it. `needs` gates readiness but does not pass output between runs.
 Cloud assigns every run ID atomically at submission. After a node's dependencies succeed, Cloud
 materializes it against an exact source revision. Completion starts a queue window of up to 24
 hours, bounded by `expiresAt`.


### PR DESCRIPTION
## Summary
- reject merge-plan profiles that expose `GH_TOKEN` to agent nodes
- keep ordinary hosted-run admission unchanged and allow the credential on the merge delivery node
- surface a precise CLI diagnostic and document the credential boundary

## Validation
- `cargo test -p zeroshot --lib native_v2` (450 passed)
- `cargo clippy -p zeroshot --all-targets -- -D warnings`
- Python SDK ruff, mypy, and pytest (38 passed)
- generated CLI reference check
- Opcore Zero Verify clean; Sense partial with no findings (2 unsupported files)