### PR TITLE
docs: extend merge plan queue deadline to seven days

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,8 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 - Hosted merge plans are atomic, immutable, merge-only DAGs over one explicit repository, branch,
   and profile. The target resolves each node's exact revision only after its dependencies succeed;
   plans have static inputs, no cross-node dataflow, and no retry-in-place. Agent runtime bindings
-  cannot declare `GH_TOKEN`; the sole merge-delivery binding owns the GitHub write credential.
+  cannot declare `GH_TOKEN`; the sole merge-delivery binding owns the GitHub write credential. A
+  node's queue deadline is the earlier of plan expiry and seven days after readiness.
 - Read-only safe commands include `zeroshot list`, `zeroshot status`, and `zeroshot logs`.
 - Destructive commands such as `zeroshot force-stop` require explicit user intent.
 

--- a/docs/guides/python-sdk.md
+++ b/docs/guides/python-sdk.md
@@ -118,10 +118,10 @@ async def submit_release_plan() -> None:
 Submission is atomic, and every node receives a stable run ID. `needs` gates readiness only; plan
 nodes have no output interpolation or shared mutable input. After dependencies merge, Cloud
 materializes the node against an exact source revision. When materialization completes, `readyAt`
-is set and the node gets a queue window of up to 24 hours, bounded by plan expiry. A merge conflict
-is repaired by the conflicting run itself in the same checkout and delivery loop. A descendant
-cannot repair a failed predecessor; it ends as `dependency_failed`. The v1 API has no aggregate
-event stream, so `MergePlan.watch()` polls and yields changed snapshots.
+is set and the node's queue deadline is the earlier of plan expiry and seven days after `readyAt`.
+A merge conflict is repaired by the conflicting run itself in the same checkout and delivery loop.
+A descendant cannot repair a failed predecessor; it ends as `dependency_failed`. The v1 API has no
+aggregate event stream, so `MergePlan.watch()` polls and yields changed snapshots.
 
 ## Pass exact protocol documents
 

--- a/docs/zeroshot-cli.html
+++ b/docs/zeroshot-cli.html
@@ -530,8 +530,8 @@ Every run uses the same source and profile. The profile must contain exactly one
 pull-request delivery is rejected. Agent bindings must not declare `GH_TOKEN`; only the Git delivery
 binding may declare it. `needs` gates readiness but does not pass output between runs.
 Cloud assigns every run ID atomically at submission. After a node&#39;s dependencies succeed, Cloud
-materializes it against an exact source revision. Completion starts a queue window of up to 24
-hours, bounded by `expiresAt`.
+materializes it against an exact source revision. Once materialization completes, `readyAt` is set
+and the node&#39;s queue deadline is the earlier of `expiresAt` and seven days after `readyAt`.
 `expiresAt` must be in the future and no more than
 seven days away. Plans cannot be edited or retried in place.</code></pre></section>
 <section id="zeroshot-plan-validate"><h4><code>zeroshot plan validate</code></h4>

--- a/docs/zeroshot-cli.md
+++ b/docs/zeroshot-cli.md
@@ -564,8 +564,8 @@ Every run uses the same source and profile. The profile must contain exactly one
 pull-request delivery is rejected. Agent bindings must not declare `GH_TOKEN`; only the Git delivery
 binding may declare it. `needs` gates readiness but does not pass output between runs.
 Cloud assigns every run ID atomically at submission. After a node's dependencies succeed, Cloud
-materializes it against an exact source revision. Completion starts a queue window of up to 24
-hours, bounded by `expiresAt`.
+materializes it against an exact source revision. Once materialization completes, `readyAt` is set
+and the node's queue deadline is the earlier of `expiresAt` and seven days after `readyAt`.
 `expiresAt` must be in the future and no more than
 seven days away. Plans cannot be edited or retried in place.
 ```

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -117,10 +117,11 @@ async def run_plan() -> None:
 Plan input is static JSON. A dependency controls when a node may start; it doesn't copy output into
 another node. Run IDs are assigned once during atomic submission. After dependencies merge, Cloud
 materializes a node against an exact source revision. When materialization completes, `readyAt` is
-set and the node gets a queue window of up to 24 hours, bounded by plan expiry. A merge conflict is
-repaired by the conflicting run itself in the same checkout and delivery loop. A descendant cannot
-repair a failed predecessor; it ends as `dependency_failed`. `MergePlan.watch()` polls the aggregate
-Cloud status and emits changed snapshots because the v1 plan API has no streaming endpoint.
+set and the node's queue deadline is the earlier of plan expiry and seven days after `readyAt`. A
+merge conflict is repaired by the conflicting run itself in the same checkout and delivery loop. A
+descendant cannot repair a failed predecessor; it ends as `dependency_failed`. `MergePlan.watch()`
+polls the aggregate Cloud status and emits changed snapshots because the v1 plan API has no
+streaming endpoint.
 
 ## Exact graph and runtime control
 

--- a/sdks/python/src/zeroshot/plans.py
+++ b/sdks/python/src/zeroshot/plans.py
@@ -87,8 +87,8 @@ class MergePlanRunStatus:
         needs: Stable symbolic dependency names.
         source_revision: Exact source revision once the node materializes.
         ready_at: RFC 3339 time when source materialization completed and the node became ready.
-        queue_expires_at: RFC 3339 per-node queue deadline, up to 24 hours after readiness and
-            bounded by the plan deadline.
+        queue_expires_at: RFC 3339 per-node queue deadline, set to the earlier of the plan deadline
+            and seven days after readiness.
         terminal_at: RFC 3339 terminal time.
         waiting_reason: Stable explanation while queued or blocked, when supplied.
         error_code: Stable terminal error category, including dependency_failed.

--- a/zeroshot/src/native_v2_cli/parser.rs
+++ b/zeroshot/src/native_v2_cli/parser.rs
@@ -112,8 +112,8 @@ Every run uses the same source and profile. The profile must contain exactly one
 pull-request delivery is rejected. Agent bindings must not declare `GH_TOKEN`; only the Git delivery
 binding may declare it. `needs` gates readiness but does not pass output between runs.
 Cloud assigns every run ID atomically at submission. After a node's dependencies succeed, Cloud
-materializes it against an exact source revision. Completion starts a queue window of up to 24
-hours, bounded by `expiresAt`.
+materializes it against an exact source revision. Once materialization completes, `readyAt` is set
+and the node's queue deadline is the earlier of `expiresAt` and seven days after `readyAt`.
 `expiresAt` must be in the future and no more than
 seven days away. Plans cannot be edited or retried in place."#)]
 enum PlanCommand {

--- a/zeroshot/tests/native_v2_cli_help.rs
+++ b/zeroshot/tests/native_v2_cli_help.rs
@@ -214,6 +214,19 @@ fn help_explains_delivery_authentication_and_local_run_safety() {
 }
 
 #[test]
+fn help_explains_the_seven_day_plan_queue_deadline() {
+    let plan = successful_stdout(&["plan", "--help"]);
+    assert_prose(
+        &plan,
+        &[
+            "queue deadline is the earlier of `expiresat` and seven days after `readyat`",
+            "`expiresat` must be in the future and no more than seven days away",
+        ],
+    );
+    assert!(!normalized(&plan).contains("24 hours"));
+}
+
+#[test]
 fn help_and_version_aliases_remain_available() {
     for arguments in [
         [].as_slice(),


### PR DESCRIPTION
## Summary

- document the seven-day ready-queue deadline for hosted merge-plan nodes
- update CLI help, generated CLI reference, and Python SDK documentation
- add CLI help regression coverage for the deadline contract

## Validation

- `cargo run --locked -p zeroshot --example generate_cli_docs -- --check`
- `cargo test --locked -p zeroshot --test native_v2_cli_help`
- Python SDK: Ruff, formatting, MyPy, pydoclint, and 38/38 pytest tests
- `opcore-zero check --repo . --staged --json` (clean, 3/3 source files covered)
- `opcore-zero sense --repo . --staged --json` (no findings; partial because two files are unsupported)
