### PR TITLE
fix: pin conflict repair commit identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,9 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   queues, branch freshness advances only through an authorized compare-and-swap response. A
   reported conflict is routable only after the trusted lane fetches the exact current target and
   leaves a verified nonempty Git merge conflict in the workspace; repair agents receive no GitHub
-  credential. Merge receipts preserve GitHub's authoritative merged revision.
+  credential, and the trusted lane pins their repository-local commit identity to
+  `Zeroshot <delivery@zeroshot.invalid>` before handoff. Merge receipts preserve GitHub's
+  authoritative merged revision.
 - Delivery-enabled software-change templates make the acceptance verifier the sole author of the
   current change title and description after every review pass. Git delivery uses that manifest for
   commits and reviews, refreshes only its marker-delimited body section while preserving surrounding

--- a/zeroshot/src/native_v2_delivery/github/conflict.rs
+++ b/zeroshot/src/native_v2_delivery/github/conflict.rs
@@ -99,10 +99,25 @@ async fn require_commit(
     bounded_status(command, context.authority.config.api_deadline).await
 }
 
+async fn configure_delivery_identity(
+    context: ConflictContext<'_>,
+) -> Result<(), GitHubAuthorityError> {
+    for (key, value) in [
+        ("user.name", "Zeroshot"),
+        ("user.email", "delivery@zeroshot.invalid"),
+    ] {
+        let mut command = local_git_command(&context.authority.config, &context.request.workspace);
+        command.args(["config", "--local", "--replace-all", key, value]);
+        bounded_status(command, context.authority.config.api_deadline).await?;
+    }
+    Ok(())
+}
+
 async fn merge_target(
     context: ConflictContext<'_>,
     target_revision: &str,
 ) -> Result<i32, GitHubAuthorityError> {
+    configure_delivery_identity(context).await?;
     let mut command = local_git_command(&context.authority.config, &context.request.workspace);
     command.args([
         "-c",

--- a/zeroshot/src/native_v2_delivery/github/conflict/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/conflict/tests.rs
@@ -113,6 +113,62 @@ async fn authenticated_target_fetch_leaves_exact_conflict_for_repair() {
 }
 
 #[tokio::test]
+async fn conflict_handoff_pins_repair_commit_to_delivery_identity() {
+    let fixture = ConflictFixture::new("result.txt");
+    git(
+        &fixture.repository.workspace,
+        &["config", "--local", "user.name", "Codex"],
+    );
+    git(
+        &fixture.repository.workspace,
+        &["config", "--local", "user.email", "codex@openai.com"],
+    );
+
+    let outcome = fixture
+        .authority
+        .materialize_merge_conflict(&fixture.request, GitHubCredential("test-token"))
+        .await
+        .assert_value();
+    assert!(matches!(outcome, GitHubConflictOutcome::Materialized(_)));
+
+    fs::write(
+        fixture.repository.workspace.join("result.txt"),
+        "resolved\n",
+    )
+    .assert_value();
+    git(&fixture.repository.workspace, &["add", "--all"]);
+    git(
+        &fixture.repository.workspace,
+        &["commit", "--no-verify", "--message", "repair conflict"],
+    );
+
+    assert_eq!(
+        git_output(
+            &fixture.repository.workspace,
+            &["show", "--no-patch", "--format=%an <%ae>"]
+        ),
+        "Zeroshot <delivery@zeroshot.invalid>"
+    );
+    assert_eq!(
+        git_output(
+            &fixture.repository.workspace,
+            &["show", "--no-patch", "--format=%cn <%ce>"]
+        ),
+        "Zeroshot <delivery@zeroshot.invalid>"
+    );
+    assert_eq!(
+        git_output(
+            &fixture.repository.workspace,
+            &["show", "--no-patch", "--format=%P"]
+        ),
+        format!(
+            "{} {}",
+            fixture.request.review.head_revision, fixture.target_revision
+        )
+    );
+}
+
+#[tokio::test]
 async fn stale_conflict_observation_restores_the_review_head_for_reobservation() {
     let fixture = ConflictFixture::new("target.txt");
 


### PR DESCRIPTION
## Summary

Pin the repository-local Git author and committer identity before handing a real merge conflict to the repair agent. This prevents repair commits from inheriting the harness identity while keeping GitHub credentials confined to trusted delivery.

## Changes Made

- configure the canonical Zeroshot identity before conflict-repair handoff
- exercise a real conflicted merge and verify its author, committer, and two parents

## Testing

- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings

## Checklist

- [x] Tests pass
- [x] Documentation updated if needed
- [x] Follows commit guidelines