### PR TITLE
fix(cli): prefill device login and include the cloud target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   maintain model catalogs, or validate provider availability. Admission may reject only known
   incompatible harness/provider pairs.
 - Runtime selection requires caller-authored `harness`, `provider`, and `model` values.
+- The local target registry initializes `cloud` at `https://api.cloud.zeroshot.sh` with a persistent hosted device identity.
 - Named targets store only endpoint, access mode, and login identity. Named runs resolve repository, branch, exact remote revision, and worktree dirtiness client-side from the invoking Git worktree plus per-run overrides; target records never bind repositories.
 - Portable worker bindings resolve through the generic `WorkerRegistry` boundary. External binding
   protocol, version, and profile values are bounded opaque strings; the protocol crate must not

--- a/README.md
+++ b/README.md
@@ -106,7 +106,15 @@ isolation, builds, and HTTPS.
 
 ### Zeroshot Cloud: close the laptop
 
-Use the same CLI against a managed target with a shared team queue and durable run history.
+Use the built-in `cloud` target at `https://api.cloud.zeroshot.sh` for a shared team queue and
+durable run history:
+
+```bash
+zeroshot target login cloud
+```
+
+Open the printed link to sign in with the device code already filled in. Use `--target cloud` when
+submitting runs.
 
 ## Reference
 

--- a/docs/zeroshot-cli.html
+++ b/docs/zeroshot-cli.html
@@ -90,7 +90,9 @@ Options:
   -h, --help
           Print help (see a summary with &#39;-h&#39;)</code></pre></section>
 <section id="zeroshot-target"><h3><code>zeroshot target</code></h3>
-<pre><code>Manage named targets or serve a direct target
+<pre><code>Manage named targets or serve a direct target.
+
+The built-in `cloud` target points to https://api.cloud.zeroshot.sh. Run `zeroshot target login cloud` to sign in.
 
 Usage: zeroshot target &lt;COMMAND&gt;
 
@@ -102,7 +104,7 @@ Commands:
 
 Options:
   -h, --help
-          Print help</code></pre></section>
+          Print help (see a summary with &#39;-h&#39;)</code></pre></section>
 <section id="zeroshot-target-add"><h4><code>zeroshot target add</code></h4>
 <pre><code>Register a named target
 

--- a/docs/zeroshot-cli.md
+++ b/docs/zeroshot-cli.md
@@ -40,7 +40,9 @@ Options:
 ### `zeroshot target`
 
 ```text
-Manage named targets or serve a direct target
+Manage named targets or serve a direct target.
+
+The built-in `cloud` target points to https://api.cloud.zeroshot.sh. Run `zeroshot target login cloud` to sign in.
 
 Usage: zeroshot target <COMMAND>
 
@@ -52,7 +54,7 @@ Commands:
 
 Options:
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
 ```
 
 #### `zeroshot target add`

--- a/zeroshot/src/native_v2_cli/parser.rs
+++ b/zeroshot/src/native_v2_cli/parser.rs
@@ -26,6 +26,9 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 enum CliCommand {
     /// Manage named targets or serve a direct target.
+    ///
+    /// The built-in `cloud` target points to https://api.cloud.zeroshot.sh.
+    /// Run `zeroshot target login cloud` to sign in.
     Target {
         #[command(subcommand)]
         command: TargetCommand,

--- a/zeroshot/src/native_v2_target/controller_authority.rs
+++ b/zeroshot/src/native_v2_target/controller_authority.rs
@@ -190,7 +190,12 @@ impl TargetHttpControlAuthority {
             )
             .await?;
         validate_device_code(&code)?;
-        self.notifier.show(&code.verification_uri, &code.user_code);
+        self.notifier.show(
+            code.verification_uri_complete
+                .as_deref()
+                .unwrap_or(&code.verification_uri),
+            &code.user_code,
+        );
         let token = self
             .poll_for_token(DevicePoll {
                 device_token: request.device_token,

--- a/zeroshot/src/native_v2_target/registry.rs
+++ b/zeroshot/src/native_v2_target/registry.rs
@@ -6,7 +6,8 @@ use std::path::{Path, PathBuf};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 
-use super::contract::{normalize_origin, validate_target_name};
+use super::contract::{normalize_origin, prepare_target, validate_target_name};
+use super::TargetAdd;
 use super::{TargetAccess, TargetConnectorError, TargetRecord};
 
 const REGISTRY_VERSION: u32 = 5;
@@ -41,10 +42,9 @@ impl FileTargetRegistry {
         create_private_directory(parent)?;
         let lock = open_lock(&self.path.with_extension("lock"))?;
         lock_registry(&lock, true)?;
-        let mut state = read_registry(&self.path)?;
-        let migrate = state.version == LEGACY_REGISTRY_VERSION;
+        let (mut state, initialized) = initialize_registry(&self.path)?;
         let result = operation(&mut state)?;
-        if mutate || migrate {
+        if mutate || initialized {
             state.version = REGISTRY_VERSION;
             write_registry(&self.path, &state)?;
         }
@@ -111,6 +111,21 @@ pub(super) fn lock_registry(lock: &File, exclusive: bool) -> Result<(), TargetCo
     } else {
         FileExt::lock_shared(lock).map_err(TargetConnectorError::RegistryIo)
     }
+}
+
+fn initialize_registry(path: &Path) -> Result<(RegistryState, bool), TargetConnectorError> {
+    let mut state = read_registry(path)?;
+    let missing_cloud = !state.targets.contains_key("cloud");
+    let initialized = state.version == LEGACY_REGISTRY_VERSION || missing_cloud;
+    if missing_cloud {
+        let cloud = prepare_target(TargetAdd {
+            name: "cloud".to_owned(),
+            url: "https://api.cloud.zeroshot.sh".to_owned(),
+            direct: false,
+        })?;
+        state.targets.insert(cloud.name.clone(), cloud);
+    }
+    Ok((state, initialized))
 }
 
 fn read_registry(path: &Path) -> Result<RegistryState, TargetConnectorError> {

--- a/zeroshot/src/native_v2_target/tests/authentication.rs
+++ b/zeroshot/src/native_v2_target/tests/authentication.rs
@@ -4,11 +4,54 @@ use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
 
 use super::super::controller_authority::credentials::{
     refresh_lock_is_held,
-    test_support::{MemoryDeviceCodeNotifier, UnavailableCredentialStore},
+    test_support::{MemoryCredentialStore, MemoryDeviceCodeNotifier, UnavailableCredentialStore},
 };
 use super::super::*;
 use super::fixtures::{hosted_target, temp_root};
-use super::hosted_authority::{LoginBlockingCredentialStore, spawn_target_authority};
+use super::hosted_authority::{
+    LoginBlockingCredentialStore, spawn_target_authority, spawn_target_authority_with_complete_uri,
+};
+
+#[tokio::test]
+async fn login_displays_the_validated_complete_uri_or_plain_fallback() {
+    for (complete_uri, expected_path) in [
+        (None, Some("/activate")),
+        (
+            Some("{origin}/activate?user_code=ABCD-EFGH"),
+            Some("/activate?user_code=ABCD-EFGH"),
+        ),
+        (
+            Some("https://other.example/activate?user_code=ABCD-EFGH"),
+            None,
+        ),
+        (Some("{origin}/activate?user_code=ABCD-EFGH#fragment"), None),
+    ] {
+        let root = temp_root();
+        let request_count = if expected_path.is_some() { 5 } else { 3 };
+        let (origin, server) =
+            spawn_target_authority_with_complete_uri(request_count, complete_uri).await;
+        let notifier = Arc::new(MemoryDeviceCodeNotifier::default());
+        let authority = TargetHttpControlAuthority::with_dependencies(
+            Arc::new(MemoryCredentialStore::default()),
+            notifier.clone(),
+            root.path("refresh-locks"),
+        );
+        let result = authority
+            .login(&hosted_target("local", origin.clone()))
+            .await;
+        if let Some(path) = expected_path {
+            result.assert_value();
+            assert_eq!(
+                notifier.values(),
+                vec![(format!("{origin}{path}"), "ABCD-EFGH".to_owned())]
+            );
+        } else {
+            assert!(result.is_err());
+            assert!(notifier.values().is_empty());
+        }
+        assert_eq!(server.await.assert_value().len(), request_count);
+    }
+}
 
 #[tokio::test]
 async fn login_preflights_credential_persistence_before_requesting_a_device_code() {

--- a/zeroshot/src/native_v2_target/tests/hosted_authority.rs
+++ b/zeroshot/src/native_v2_target/tests/hosted_authority.rs
@@ -56,13 +56,20 @@ pub(super) async fn bind_target_authority() -> (TcpListener, std::net::SocketAdd
 pub(super) async fn spawn_target_authority(
     request_count: usize,
 ) -> (String, tokio::task::JoinHandle<Vec<CapturedHttpRequest>>) {
+    spawn_target_authority_with_complete_uri(request_count, None).await
+}
+
+pub(super) async fn spawn_target_authority_with_complete_uri(
+    request_count: usize,
+    complete_uri: Option<&str>,
+) -> (String, tokio::task::JoinHandle<Vec<CapturedHttpRequest>>) {
     let (listener, address, origin) = bind_target_authority().await;
-    let server_origin = origin.clone();
+    let complete_uri = complete_uri.map(|uri| uri.replace("{origin}", &origin));
     let server = tokio::spawn(serve_target_authority(
         listener,
         request_count,
-        server_origin,
         address,
+        complete_uri,
     ));
     (origin, server)
 }
@@ -70,19 +77,36 @@ pub(super) async fn spawn_target_authority(
 async fn serve_target_authority(
     listener: TcpListener,
     request_count: usize,
-    origin: String,
     address: std::net::SocketAddr,
+    complete_uri: Option<String>,
 ) -> Vec<CapturedHttpRequest> {
+    let origin = format!("http://{address}");
     let mut captured = Vec::new();
     let mut token_index = 0_u8;
     for _ in 0..request_count {
         let (mut stream, _) = listener.accept().await.assert_value();
         let request = read_http_request(&mut stream).await;
         let body = authority_response(&request, &origin, address, &mut token_index);
+        let body = device_complete_uri(&request, body, complete_uri.as_deref());
         write_http_response(&mut stream, &body).await;
         captured.push(request);
     }
     captured
+}
+
+fn device_complete_uri(
+    request: &CapturedHttpRequest,
+    body: String,
+    complete_uri: Option<&str>,
+) -> String {
+    if request.path == "/oauth/device" {
+        if let Some(uri) = complete_uri {
+            let mut value: serde_json::Value = serde_json::from_str(&body).assert_value();
+            value["verification_uri_complete"] = json!(uri);
+            return value.to_string();
+        }
+    }
+    body
 }
 
 fn authority_response(

--- a/zeroshot/src/native_v2_target/tests/integration.rs
+++ b/zeroshot/src/native_v2_target/tests/integration.rs
@@ -19,6 +19,26 @@ type ServerRequest = tokio_tungstenite::tungstenite::handshake::server::Request;
 type ServerResponse = tokio_tungstenite::tungstenite::handshake::server::Response;
 
 #[test]
+fn file_registry_initializes_cloud_with_a_stable_hosted_identity() {
+    let root = temp_root();
+    let path = root.path("config/targets.json");
+    let cloud = FileTargetRegistry::new(path.clone())
+        .get("cloud")
+        .assert_value();
+    assert_eq!(cloud.name, "cloud");
+    assert_eq!(cloud.origin, "https://api.cloud.zeroshot.sh");
+    assert!(matches!(cloud.access, TargetAccess::Hosted { .. }));
+    assert_eq!(
+        FileTargetRegistry::new(path).get("cloud").assert_value(),
+        cloud
+    );
+    assert!(matches!(
+        FileTargetRegistry::new(root.path("other/targets.json")).get("unknown"),
+        Err(TargetConnectorError::NotFound(_))
+    ));
+}
+
+#[test]
 fn file_registry_round_trips_named_targets_without_credentials() {
     let root = temp_root();
     let path = root.path("config/targets.json");
@@ -48,9 +68,12 @@ fn file_registry_round_trips_direct_access_without_a_device_credential() {
     };
     registry.insert(direct.clone()).assert_value();
     assert_eq!(registry.get("vm").assert_value(), direct);
-    let stored = std::fs::read_to_string(path).assert_value();
-    assert!(stored.contains(r#""mode": "direct""#));
-    assert!(!stored.contains("deviceToken"));
+    let stored: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).assert_value()).assert_value();
+    assert_eq!(
+        stored["targets"]["vm"]["access"],
+        serde_json::json!({"mode": "direct"})
+    );
 }
 
 #[test]


### PR DESCRIPTION
Target login now prints the server-provided device URL with the user code included. The local registry initializes a hosted `cloud` target at `https://api.cloud.zeroshot.sh`, so a fresh installation can run `zeroshot target login cloud` without adding a target first. CLI help and the README describe that command.

Validation: 40 CLI binary tests and 17 CLI parser tests passed; Clippy for all Zeroshot targets, Rust formatting, and generated CLI documentation checks passed. Opcore Zero Verify passed; Sense found no introduced findings but reports partial Rust interface/dependency coverage.

A locally built CLI also reached production through the built-in target and printed the issued code in the URL. Chromium followed that URL through the expected 303 redirect to the sign-in page at `/device`.
