### PR TITLE
fix(release): allow independent documentation recovery

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,20 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Immutable version in vX.Y.Z form; omit to publish dev documentation.
+        required: false
+        type: string
+      release_commit:
+        description: Exact source commit from main; omit to use current main.
+        required: false
+        type: string
+      stable:
+        description: Point the stable alias and site root at the supplied release version.
+        required: false
+        default: false
+        type: boolean
   workflow_call:
     inputs:
       version:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,6 +122,13 @@ jobs:
               echo "::error::$DOCS_VERSION does not resolve to $SOURCE_COMMIT"
               exit 1
             }
+            if [[ "$UPDATE_STABLE" == "true" ]]; then
+              latest_tag="$(git tag --list 'v[0-9]*' --sort=-version:refname | head -n 1)"
+              [[ "$DOCS_VERSION" == "$latest_tag" ]] || {
+                echo "::error::stable documentation must use the newest release $latest_tag"
+                exit 1
+              }
+            fi
           fi
 
       - name: Setup Python 3.12

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -97,3 +97,7 @@ interactive publish; do not create a second package name or temporary compatibil
 Release jobs are designed to verify already-published immutable artifacts before completing missing
 steps. Recovery must use the same version, tag, and source commit. Never overwrite a different npm
 tarball, GitHub asset, Python wheel, image source label, or tag target.
+
+To recover documentation independently, dispatch **Publish versioned documentation** with
+`version: vX.Y.Z`, the release's exact `release_commit`, and `stable: true` only when it is the
+newest canonical release. Omitting the version and commit publishes current `main` to `dev/`.


### PR DESCRIPTION
Expose the existing version, source commit, and stable-alias inputs on manual documentation dispatch. This lets operators recover versioned documentation after a separate publishing step fails. Omitted inputs publish current main to dev; stable updates require the newest canonical release. Existing source provenance and immutable-version checks still apply.

Validation: Rust formatting, repository lint, and all 28 tooling tests passed. Executed the provenance script with four cases: current release to stable, older release without stable, dev publication, and rejection of an older stable release. Opcore Zero reported no introduced findings with partial coverage.
