### PR TITLE
feat(runtime): recover Git failures and ship native build toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,18 @@ jobs:
           docker run --rm --platform linux/amd64 --entrypoint codex zeroshot-target:ci --version
           docker run --rm --platform linux/amd64 --entrypoint claude zeroshot-target:ci --version
 
+      - name: Compile with the isolated runtime toolchains
+        run: |
+          docker run --rm --network none --read-only \
+            --tmpfs /tmp:rw,nosuid,nodev,size=64m,mode=1777 \
+            --tmpfs /work:rw,nosuid,nodev,exec,size=256m,mode=0700,uid=10001,gid=10001 \
+            --user 10001:10001 \
+            --mount "type=bind,src=${PWD}/docker/zeroshot-target/smoke-toolchains.sh,dst=/smoke.sh,readonly" \
+            --mount "type=bind,src=${PWD}/rust-toolchain.toml,dst=/rust-toolchain.toml,readonly" \
+            --entrypoint /usr/bin/env \
+            zeroshot-target:ci -i HOME=/work/home PATH=/usr/local/bin:/usr/bin:/bin \
+            /bin/sh /smoke.sh
+
   required:
     name: required
     if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,6 +377,18 @@ jobs:
             exit 1
           }
 
+      - name: Compile with the isolated runtime toolchains
+        run: |
+          docker run --rm --network none --read-only \
+            --tmpfs /tmp:rw,nosuid,nodev,size=64m,mode=1777 \
+            --tmpfs /work:rw,nosuid,nodev,exec,size=256m,mode=0700,uid=10001,gid=10001 \
+            --user 10001:10001 \
+            --mount "type=bind,src=${PWD}/docker/zeroshot-target/smoke-toolchains.sh,dst=/smoke.sh,readonly" \
+            --mount "type=bind,src=${PWD}/rust-toolchain.toml,dst=/rust-toolchain.toml,readonly" \
+            --entrypoint /usr/bin/env \
+            "$ZEROSHOT_IMAGE:$RELEASE_VERSION" -i HOME=/work/home PATH=/usr/local/bin:/usr/bin:/bin \
+            /bin/sh /smoke.sh
+
       - name: Save exact image publication input
         run: |
           mkdir -p image-artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 - Native-v2 retries only a settled `crash` outcome when the executable has another authored
   attempt. A provider session invalidated by that active execution becomes replaceable for the
   authorized retry; passive session loss and run closure remain permanent, fail-closed loss.
+- Hosted source checkout retries only its fresh platform-owned staging workspace, within one
+  allocation and one total deadline. Preserve the exact admitted revision before starting any
+  graph node; terminal Git details remain redacted and private operator diagnostics.
 - Contained provider sessions bound post-exit I/O draining by the command deadline and a ten-minute
   ceiling while still observing cancellation and cleanup.
 - Git delivery captures bounded, credential-redacted command/status/stdout/stderr diagnostics and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,11 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   so refreshing metadata cannot retain a stale issue reference. Reviews with an unowned closing
   reference in a legacy Zeroshot layout fail closed instead of rewriting ambiguous human text.
 
+- Target images ship one Rust toolchain baseline plus Node.js, Python and shared native build
+  tools. They expose Rust through the fixed runtime PATH without a shared writable Cargo cache;
+  explicit user toolchain settings and installations take precedence. Runtime toolchain smoke
+  tests compile native fixtures as an isolated user with a read-only root and fresh home.
+
 ## CLI and target contracts
 
 - CLI grammar/help comes from the derived Clap `Cli` tree and Rust doc comments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,13 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   authorized retry; passive session loss and run closure remain permanent, fail-closed loss.
 - Contained provider sessions bound post-exit I/O draining by the command deadline and a ten-minute
   ceiling while still observing cancellation and cleanup.
+- Git delivery captures bounded, credential-redacted command/status/stdout/stderr diagnostics and
+  routes unfamiliar failures to the existing delivery repair worker through `repair_required`.
+  Graphs opt in with that signal; stored older contracts still validate without it. Repair may run
+  before a PR exists, so only successful receipts require complete remote identity. Cancellation,
+  exhausted graph budgets, confirmed authentication refusal, and authority mismatches remain terminal.
+  Pending authorized head adoption survives repair and completes before staging or pushing resumes.
+  Delivery stages with `git add --all`; writing agents keep tooling outside the checkout.
 - GitHub delivery treats aggregate merge policy and required contexts as authority, waits through
   merge queues/deferrals, and succeeds only after observing the exact merged result. Outside merge
   queues, branch freshness advances only through an authorized compare-and-swap response. A
@@ -94,7 +101,7 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   caller-owned issue input.
 - GitHub review creation and rediscovery are shared by pull-request and merge delivery. They verify
   the exact pushed ref and head, retry bounded transient visibility or API failures, refresh a
-  dynamic credential once on HTTP 401/403 within the synchronization deadline and cancellation
+  dynamic credential once on HTTP 401 within the synchronization deadline and cancellation
   boundary, and fail closed on identity mismatch or static-token rejection. Verifier-authored pull
   request descriptions and source-issue closing references stay inside the generated body markers
   so refreshing metadata cannot retain a stale issue reference. Reviews with an unowned closing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,9 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   milliseconds and remain unchanged across durable replay.
 - Run close reserves and tombstones execution activity atomically. No late start, handle, or stream
   may surface after close returns.
+- Native-v2 retries only a settled `crash` outcome when the executable has another authored
+  attempt. A provider session invalidated by that active execution becomes replaceable for the
+  authorized retry; passive session loss and run closure remain permanent, fail-closed loss.
 - Contained provider sessions bound post-exit I/O draining by the command deadline and a ten-minute
   ceiling while still observing cancellation and cleanup.
 - GitHub delivery treats aggregate merge policy and required contexts as authority, waits through

--- a/docker/zeroshot-target/Dockerfile
+++ b/docker/zeroshot-target/Dockerfile
@@ -1,4 +1,10 @@
-FROM rust:1.97.0-trixie AS builder
+FROM rust:1.97.0-trixie AS rust-toolchain
+RUN rustup component add rustfmt clippy \
+    && mkdir -p /opt/rustup \
+    && cp -a /usr/local/rustup/. /opt/rustup/ \
+    && cp -a /usr/local/cargo/bin /opt/rustup/bin
+
+FROM rust-toolchain AS builder
 
 WORKDIR /src
 
@@ -8,10 +14,13 @@ COPY zeroshot ./zeroshot
 
 RUN cargo build --locked --release --package zeroshot --bin zeroshot
 
-FROM node:22-trixie-slim AS runtime
+FROM python:3.12.14-slim-trixie@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea AS python-runtime
+
+FROM node:24-trixie-slim AS tooling
 
 ARG CODEX_VERSION=0.148.0
 ARG CLAUDE_CODE_VERSION=2.1.237
+ARG NPM_VERSION=11.19.1
 ARG ZEROSHOT_VERSION=development
 ARG VCS_REF=unknown
 
@@ -23,18 +32,42 @@ LABEL org.opencontainers.image.source="https://github.com/the-open-engine/zerosh
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends \
         bash \
+        build-essential \
         ca-certificates \
         gh \
         git \
+        libbz2-1.0 \
+        libffi-dev \
+        libgdbm6t64 \
+        liblzma5 \
+        libncursesw6 \
+        libreadline8t64 \
+        libsqlite3-0 \
+        libssl-dev \
+        libuuid1 \
+        pkgconf \
         ripgrep \
     && git_version="$(git --version)" \
     && dpkg --compare-versions "${git_version#git version }" ge 2.47 \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install --global --no-audit --no-fund \
+COPY --from=python-runtime /usr/local /usr/local
+COPY --from=rust-toolchain /opt/rustup /opt/rustup
+COPY --chmod=0755 docker/zeroshot-target/rust-tool.sh /usr/local/libexec/zeroshot-rust-tool
+RUN for tool in cargo cargo-clippy cargo-fmt clippy-driver rustc rustdoc rustfmt rustup; do \
+        ln -s /usr/local/libexec/zeroshot-rust-tool "/usr/local/bin/$tool"; \
+    done \
+    && ldconfig
+
+RUN npm install --global --no-audit --no-fund "npm@${NPM_VERSION}" \
+    && npm install --global --no-audit --no-fund \
+        --strict-allow-scripts \
+        --allow-scripts=@anthropic-ai/claude-code \
         "@openai/codex@${CODEX_VERSION}" \
         "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
     && npm cache clean --force
+
+FROM tooling AS runtime
 
 COPY --from=builder /src/target/release/zeroshot /usr/local/bin/zeroshot
 COPY docker/zeroshot-target/entrypoint.sh /usr/local/bin/zeroshot-target-entrypoint

--- a/docker/zeroshot-target/README.md
+++ b/docker/zeroshot-target/README.md
@@ -3,6 +3,15 @@
 `ghcr.io/the-open-engine/zeroshot-target` is the canonical self-hosted target server image. It
 contains the native `zeroshot` executable plus pinned Codex and Claude harness CLIs.
 
+Coding tools include Node.js 24 and npm, Python 3.12 with pip, venv and extension headers,
+Rust 1.97 with Cargo, rustfmt and Clippy, and C/C++ compilers, make, pkgconf, OpenSSL and
+libffi development files. CI compiles and executes native fixtures with these tools as an
+isolated user, with a read-only root filesystem, fresh home and no network.
+
+The image's Rust installation is read-only. Explicit `RUSTUP_HOME` settings and existing
+`~/.rustup` installations take precedence; Cargo caches stay in the agent's private home unless
+it specifies `CARGO_HOME`. Other compiler versions and project dependencies remain caller-owned.
+
 ## Run
 
 The image runs an unauthenticated direct target:

--- a/docker/zeroshot-target/rust-tool.sh
+++ b/docker/zeroshot-target/rust-tool.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+# Keep explicit or existing user installations authoritative; otherwise use the image baseline.
+if [ -z "${RUSTUP_HOME+x}" ] && [ ! -d "$HOME/.rustup" ]; then
+  export RUSTUP_HOME=/opt/rustup
+fi
+exec "/opt/rustup/bin/${0##*/}" "$@"

--- a/docker/zeroshot-target/smoke-toolchains.sh
+++ b/docker/zeroshot-target/smoke-toolchains.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+set -eu
+
+# Run in a read-only image with a fresh writable HOME, fixed PATH and no network.
+test "$(id -u)" -ne 0
+test "$PATH" = /usr/local/bin:/usr/bin:/bin
+test ! -w /usr/local/bin
+test ! -e "$HOME"
+mkdir -m 0700 "$HOME"
+work=$(mktemp -d "$HOME/toolchain-proof.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+cd "$work"
+
+mkdir native
+cat >native/probe.c <<'C'
+#include <ffi.h>
+#include <openssl/sha.h>
+
+int probe_value(void) {
+    ffi_cif cif;
+    unsigned char digest[SHA256_DIGEST_LENGTH];
+    return ffi_prep_cif(&cif, FFI_DEFAULT_ABI, 0, &ffi_type_sint, NULL) == FFI_OK &&
+           SHA256((const unsigned char *)"probe", 5, digest) != NULL ? 42 : 0;
+}
+C
+cat >native/Makefile <<'MAKE'
+all:
+	$(CC) -Wall -Wextra -Werror -fPIC $(shell pkg-config --cflags openssl libffi) -c probe.c -o $(OUT_DIR)/probe.o
+	$(AR) crs $(OUT_DIR)/libprobe.a $(OUT_DIR)/probe.o
+MAKE
+cat >cpp.cpp <<'CPP'
+#include <iostream>
+int main() { std::cout << 42 << std::endl; }
+CPP
+c++ -Wall -Wextra -Werror cpp.cpp -o cpp
+test "$(./cpp)" = 42
+
+cat >Cargo.toml <<'TOML'
+[package]
+name = "target-toolchain-proof"
+version = "0.1.0"
+edition = "2024"
+TOML
+cp /rust-toolchain.toml .
+cat >build.rs <<'RUST'
+use std::{env, process::Command};
+
+fn main() {
+    let output = env::var("OUT_DIR").unwrap();
+    assert!(Command::new("make").arg("-C").arg("native").status().unwrap().success());
+    println!("cargo:rustc-link-search=native={output}");
+    println!("cargo:rustc-link-lib=static=probe");
+    println!("cargo:rustc-link-lib=crypto");
+    println!("cargo:rustc-link-lib=ffi");
+}
+RUST
+mkdir src
+cat >src/main.rs <<'RUST'
+unsafe extern "C" {
+    fn probe_value() -> i32;
+}
+fn main() {
+    assert_eq!(unsafe { probe_value() }, 42);
+    println!("rust-native: 42");
+}
+RUST
+rustc --version | grep '^rustc 1\.97\.0 '
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --offline -- -D warnings
+cargo run --offline --quiet
+test "$(RUSTUP_HOME="$work/custom-rustup" rustup show home)" = "$work/custom-rustup"
+mkdir "$HOME/.rustup"
+test "$(rustup show home)" = "$HOME/.rustup"
+
+python3.12 -m venv "$work/venv"
+"$work/venv/bin/python" -m pip --version
+cat >probe.c <<'C'
+#include <Python.h>
+
+static PyObject *answer(PyObject *self, PyObject *args) {
+    (void)self;
+    (void)args;
+    return PyLong_FromLong(42);
+}
+static PyMethodDef methods[] = {{"answer", answer, METH_NOARGS, NULL}, {NULL, NULL, 0, NULL}};
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT, "probe", NULL, -1, methods, NULL, NULL, NULL, NULL
+};
+PyMODINIT_FUNC PyInit_probe(void) { return PyModule_Create(&module); }
+C
+cc -Wall -Wextra -Werror -shared -fPIC \
+  -I"$(python3.12 -c 'import sysconfig; print(sysconfig.get_path("include"))')" \
+  probe.c -o "probe$(python3.12-config --extension-suffix)"
+"$work/venv/bin/python" - <<'PYTHON'
+import ctypes, sqlite3, ssl, sys, probe
+assert sys.version_info[:2] == (3, 12)
+assert probe.answer() == 42
+print("python-native: 42")
+PYTHON
+
+mkdir node-addon
+cd node-addon
+cat >package.json <<'JSON'
+{
+  "name": "target-toolchain-proof",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "c++ -Wall -Wextra -Werror -shared -fPIC -I/usr/local/include/node addon.cpp -o addon.node",
+    "test": "node -e \"require('node:assert/strict').equal(require('./addon.node'), 42)\""
+  }
+}
+JSON
+cat >addon.cpp <<'CPP'
+#include <node_api.h>
+
+static napi_value initialize(napi_env env, napi_value exports) {
+    (void)exports;
+    napi_value result;
+    if (napi_create_int32(env, 42, &result) != napi_ok) return nullptr;
+    return result;
+}
+NAPI_MODULE(NODE_GYP_MODULE_NAME, initialize)
+CPP
+node -e "require('node:assert/strict').equal(process.versions.node.split('.')[0], '24')"
+npm install --offline --ignore-scripts --no-audit --no-fund
+npm run build
+npm test
+printf 'node-native: 42\n'

--- a/zeroshot/src/full_v1_reducer.rs
+++ b/zeroshot/src/full_v1_reducer.rs
@@ -18,12 +18,14 @@ pub use history::{
 use openengine_cluster_protocol::{
     ChoiceNode, ControlSelector, ControlSource, DataSelector, FieldPath, GraphNode, Guard, Join,
     EnumLabel, MapNode, NodeName, NodeOutputChannel, ParNode, PositiveInteger, TerminalResult,
-    WorkerOutcome, WorkerRef,
+    WorkerErrorCode, WorkerOutcome, WorkerRef,
 };
 use openengine_cluster_server::admission::VerifiedGraph;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
+
+const INITIAL_ATTEMPT: u64 = 1;
 
 #[derive(Clone, Debug)]
 pub struct ReductionInput<'a> {
@@ -105,7 +107,7 @@ pub struct FullV1Reducer<'a> {
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum ExecutionMode {
     LegacyAttempts,
-    NativeV2NoRetry,
+    NativeV2,
 }
 
 impl<'a> FullV1Reducer<'a> {
@@ -117,12 +119,12 @@ impl<'a> FullV1Reducer<'a> {
         }
     }
 
-    /// Native-v2 execution: every structural revisit is a fresh execution with attempt one.
+    /// Native-v2 execution: retries stay within a structural visit, while a revisit starts at one.
     #[must_use]
     pub const fn native_v2(graph: &'a VerifiedGraph) -> Self {
         Self {
             graph,
-            execution_mode: ExecutionMode::NativeV2NoRetry,
+            execution_mode: ExecutionMode::NativeV2,
         }
     }
 

--- a/zeroshot/src/full_v1_reducer/evaluation.rs
+++ b/zeroshot/src/full_v1_reducer/evaluation.rs
@@ -215,7 +215,10 @@ impl Engine<'_> {
         };
         let visit = *visit;
         let input = bind_payload(spec.input_bindings, &context.state, traversal.item)?;
-        if let Some(execution) = &visit.existing {
+        for execution in &visit.executions {
+            if execution.input != input {
+                return Err(ReducerError::InconsistentHistory);
+            }
             self.consumed_executions.insert(execution.execution);
         }
         mark_visit(
@@ -255,14 +258,28 @@ impl Engine<'_> {
         if execution.dispatch_position > traversal.cutoff {
             return Ok(Status::Pending);
         }
-        if execution.input != input {
-            return Err(ReducerError::InconsistentHistory);
-        }
         let DurableExecutionState::Settled { position, outcome } = &execution.state else {
             return Ok(Status::Pending);
         };
         if *position > traversal.cutoff {
             return Ok(Status::Pending);
+        }
+        if self.execution_mode == ExecutionMode::NativeV2
+            && matches!(
+                outcome,
+                WorkerOutcome::Error {
+                    code: WorkerErrorCode::Crash,
+                    ..
+                }
+            )
+            && execution.attempt < spec.attempt_ceiling
+        {
+            return self.dispatch_retry(RetryDispatchRequest {
+                spec,
+                traversal,
+                execution,
+                input,
+            });
         }
         let writes_applied = self.apply_outcome(OutcomeApplication {
             spec: &spec,
@@ -294,7 +311,7 @@ impl Engine<'_> {
             .cloned()
             .collect::<Vec<_>>();
         let number = next_visit(spec.name, map_indices, &context.controls);
-        let (attempt, existing) = match self.execution_mode {
+        let (attempt, existing, executions) = match self.execution_mode {
             ExecutionMode::LegacyAttempts => {
                 matching.sort_by_key(|execution| execution.attempt);
                 let attempt =
@@ -306,20 +323,30 @@ impl Engine<'_> {
                     .iter()
                     .find(|execution| execution.attempt == attempt)
                     .cloned();
-                (attempt, existing)
+                let executions = existing.iter().cloned().collect();
+                (attempt, existing, executions)
             }
-            ExecutionMode::NativeV2NoRetry => {
+            ExecutionMode::NativeV2 => {
                 matching.sort_by_key(|execution| execution.dispatch_position);
-                let attempt =
-                    PositiveInteger::new(1).map_err(|_| ReducerError::InconsistentHistory)?;
-                let index =
-                    usize::try_from(number - 1).map_err(|_| ReducerError::IdentityOutOfRange)?;
-                (attempt, matching.get(index).cloned())
+                let executions = native_visit_executions(&matching, number);
+                let existing = executions.last().cloned();
+                let attempt = existing.as_ref().map_or_else(
+                    || {
+                        PositiveInteger::new(INITIAL_ATTEMPT)
+                            .expect("the initial attempt is positive")
+                    },
+                    |execution| execution.attempt,
+                );
+                if attempt > spec.attempt_ceiling {
+                    return Err(ReducerError::InconsistentHistory);
+                }
+                (attempt, existing, executions)
             }
         };
         Ok(VisitResolution::Ready(Box::new(ExecutableVisit {
             occurrence,
             matching,
+            executions,
             number,
             attempt,
             existing,
@@ -351,12 +378,7 @@ impl Engine<'_> {
                 allocated
             }
         };
-        let execution =
-            ExecutionId::new(self.next_execution).map_err(|_| ReducerError::IdentityOutOfRange)?;
-        self.next_execution = self
-            .next_execution
-            .checked_add(1)
-            .ok_or(ReducerError::IdentityOutOfRange)?;
+        let execution = self.allocate_execution()?;
         self.decisions.push(Decision::Dispatch {
             node_instance,
             execution,
@@ -366,6 +388,49 @@ impl Engine<'_> {
             input,
         });
         Ok(Status::Pending)
+    }
+
+    fn dispatch_retry(
+        &mut self,
+        request: RetryDispatchRequest<'_, '_>,
+    ) -> Result<Status, ReducerError> {
+        let RetryDispatchRequest {
+            spec,
+            traversal,
+            execution: previous,
+            input,
+        } = request;
+        if traversal.mode == EvalMode::Probe || traversal.cutoff != HistoryPosition::MAX {
+            return Ok(Status::Pending);
+        }
+        let attempt = previous
+            .attempt
+            .get()
+            .checked_add(1)
+            .ok_or(ReducerError::IdentityOutOfRange)
+            .and_then(|value| {
+                PositiveInteger::new(value).map_err(|_| ReducerError::IdentityOutOfRange)
+            })?;
+        let execution = self.allocate_execution()?;
+        self.decisions.push(Decision::Dispatch {
+            node_instance: previous.node_instance,
+            execution,
+            occurrence: previous.occurrence,
+            attempt,
+            worker: spec.worker.clone(),
+            input,
+        });
+        Ok(Status::Pending)
+    }
+
+    fn allocate_execution(&mut self) -> Result<ExecutionId, ReducerError> {
+        let execution =
+            ExecutionId::new(self.next_execution).map_err(|_| ReducerError::IdentityOutOfRange)?;
+        self.next_execution = self
+            .next_execution
+            .checked_add(1)
+            .ok_or(ReducerError::IdentityOutOfRange)?;
+        Ok(execution)
     }
 
     fn apply_outcome(
@@ -467,4 +532,20 @@ impl Engine<'_> {
         Ok(())
     }
     // Choice, parallel, and map evaluation live in the groups companion module.
+}
+
+fn native_visit_executions(
+    executions: &[DurableExecution],
+    requested_visit: u64,
+) -> Vec<DurableExecution> {
+    let mut visit = 0;
+    executions
+        .iter()
+        .filter_map(|execution| {
+            if execution.attempt.get() == 1 {
+                visit += 1;
+            }
+            (visit == requested_visit).then(|| execution.clone())
+        })
+        .collect()
 }

--- a/zeroshot/src/full_v1_reducer/evaluation/state.rs
+++ b/zeroshot/src/full_v1_reducer/evaluation/state.rs
@@ -43,6 +43,13 @@ pub(super) struct MissingDispatchRequest<'graph, 'traversal> {
     pub(super) traversal: Traversal<'traversal>,
 }
 
+pub(super) struct RetryDispatchRequest<'graph, 'traversal> {
+    pub(super) spec: ExecutableSpec<'graph>,
+    pub(super) traversal: Traversal<'traversal>,
+    pub(super) execution: DurableExecution,
+    pub(super) input: Value,
+}
+
 pub(super) struct OutcomeApplication<'request, 'graph> {
     pub(super) spec: &'request ExecutableSpec<'graph>,
     pub(super) context: &'request mut Context,
@@ -53,6 +60,7 @@ pub(super) struct OutcomeApplication<'request, 'graph> {
 pub(super) struct ExecutableVisit {
     pub(super) occurrence: StructuralOccurrence,
     pub(super) matching: Vec<DurableExecution>,
+    pub(super) executions: Vec<DurableExecution>,
     pub(super) number: u64,
     pub(super) attempt: PositiveInteger,
     pub(super) existing: Option<DurableExecution>,

--- a/zeroshot/src/full_v1_reducer/values.rs
+++ b/zeroshot/src/full_v1_reducer/values.rs
@@ -49,6 +49,8 @@ pub(super) fn validate_history_for_mode(
                 return Err(ReducerError::InconsistentHistory);
             }
         }
+    } else {
+        validate_native_attempt_lineage(executions)?;
     }
     Ok(())
 }
@@ -70,12 +72,9 @@ impl HistoryVisitIdentities {
             ExecutionMode::LegacyAttempts => self
                 .attempts
                 .insert((execution.occurrence.clone(), execution.attempt)),
-            ExecutionMode::NativeV2NoRetry => {
-                execution.attempt.get() == 1
-                    && self
-                        .visits
-                        .insert((execution.occurrence.clone(), execution.dispatch_position))
-            }
+            ExecutionMode::NativeV2 => self
+                .visits
+                .insert((execution.occurrence.clone(), execution.dispatch_position)),
         };
         if self.ids.insert(execution.execution) && valid_visit {
             Ok(())
@@ -83,6 +82,53 @@ impl HistoryVisitIdentities {
             Err(ReducerError::InconsistentHistory)
         }
     }
+}
+
+fn validate_native_attempt_lineage(executions: &[DurableExecution]) -> Result<(), ReducerError> {
+    let mut occurrences = BTreeMap::<StructuralOccurrence, Vec<&DurableExecution>>::new();
+    for execution in executions {
+        occurrences
+            .entry(execution.occurrence.clone())
+            .or_default()
+            .push(execution);
+    }
+    for occurrence_executions in occurrences.values_mut() {
+        occurrence_executions.sort_by_key(|execution| execution.dispatch_position);
+        let first = occurrence_executions[0];
+        if first.attempt.get() != INITIAL_ATTEMPT {
+            return Err(ReducerError::InconsistentHistory);
+        }
+        for pair in occurrence_executions.windows(2) {
+            let previous = pair[0];
+            let current = pair[1];
+            let follows_finalized_visit = matches!(
+                &previous.state,
+                DurableExecutionState::Settled { position, .. }
+                    | DurableExecutionState::Voided { position, .. }
+                    if *position < current.dispatch_position
+            );
+            let follows_failed_attempt = matches!(
+                &previous.state,
+                DurableExecutionState::Settled {
+                    position,
+                    outcome: WorkerOutcome::Error {
+                        code: WorkerErrorCode::Crash,
+                        ..
+                    },
+                } if *position < current.dispatch_position
+            ) && previous
+                .attempt
+                .get()
+                .checked_add(1)
+                .is_some_and(|attempt| attempt == current.attempt.get());
+            if (current.attempt.get() == 1 && !follows_finalized_visit)
+                || (current.attempt.get() != 1 && !follows_failed_attempt)
+            {
+                return Err(ReducerError::InconsistentHistory);
+            }
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn validate_instance_lineage(
@@ -363,4 +409,90 @@ pub(super) fn descendant_names(node: &GraphNode) -> BTreeSet<NodeName> {
     let mut depths = BTreeMap::new();
     collect_map_depths(node, 0, &mut depths);
     depths.into_keys().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use openengine_cluster_protocol::WorkerErrorCode;
+
+    use super::*;
+
+    const NODE_INSTANCE: u64 = 1;
+
+    fn execution(
+        execution: u64,
+        attempt: u64,
+        dispatch_position: u64,
+        state: DurableExecutionState,
+    ) -> DurableExecution {
+        DurableExecution {
+            dispatch_position: HistoryPosition::new(dispatch_position).expect("valid position"),
+            node_instance: NodeInstanceId::new(NODE_INSTANCE).expect("valid node instance"),
+            execution: ExecutionId::new(execution).expect("valid execution"),
+            occurrence: StructuralOccurrence {
+                node: "loop_work".parse().expect("valid node name"),
+                map_indices: Vec::new(),
+            },
+            attempt: PositiveInteger::new(attempt).expect("positive attempt"),
+            input: Value::Null,
+            state,
+        }
+    }
+
+    #[test]
+    fn native_history_accepts_fresh_visit_after_void_but_rejects_retry() {
+        let voided = execution(
+            1,
+            INITIAL_ATTEMPT,
+            1,
+            DurableExecutionState::Voided {
+                position: HistoryPosition::new(2).expect("valid position"),
+                reason: ExecutionVoidReason::ParallelJoin,
+            },
+        );
+        let fresh_visit = execution(2, INITIAL_ATTEMPT, 3, DurableExecutionState::Active);
+        assert_eq!(
+            validate_native_attempt_lineage(&[voided.clone(), fresh_visit]),
+            Ok(())
+        );
+
+        let invalid_retry = execution(2, INITIAL_ATTEMPT + 1, 3, DurableExecutionState::Active);
+        assert_eq!(
+            validate_native_attempt_lineage(&[voided, invalid_retry]),
+            Err(ReducerError::InconsistentHistory)
+        );
+    }
+
+    #[test]
+    fn native_history_accepts_retry_after_settled_crash() {
+        let failed = execution(
+            1,
+            INITIAL_ATTEMPT,
+            1,
+            DurableExecutionState::Settled {
+                position: HistoryPosition::new(2).expect("valid position"),
+                outcome: WorkerOutcome::declared_failure(WorkerErrorCode::Crash),
+            },
+        );
+        let retry = execution(2, INITIAL_ATTEMPT + 1, 3, DurableExecutionState::Active);
+        assert_eq!(validate_native_attempt_lineage(&[failed, retry]), Ok(()));
+    }
+
+    #[test]
+    fn native_history_rejects_retry_after_non_crash_error() {
+        let timed_out = execution(
+            1,
+            INITIAL_ATTEMPT,
+            1,
+            DurableExecutionState::Settled {
+                position: HistoryPosition::new(2).expect("valid position"),
+                outcome: WorkerOutcome::declared_failure(WorkerErrorCode::Timeout),
+            },
+        );
+        let retry = execution(2, INITIAL_ATTEMPT + 1, 3, DurableExecutionState::Active);
+        assert_eq!(
+            validate_native_attempt_lineage(&[timed_out, retry]),
+            Err(ReducerError::InconsistentHistory)
+        );
+    }
 }

--- a/zeroshot/src/native_v2_admission.rs
+++ b/zeroshot/src/native_v2_admission.rs
@@ -27,6 +27,8 @@ use crate::native_v2_contract::{
 use crate::native_v2_delivery::GITHUB_TOKEN_ENV;
 use openengine_cluster_protocol::MAX_DECLARED_ENVIRONMENT_NAMES;
 
+pub(crate) const MAX_AGENT_VERIFIER_ATTEMPTS: u64 = 2;
+
 /// Host policy for graph-visible Git delivery.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -44,7 +46,7 @@ pub enum NativeV2AdmissionError {
     UnsupportedGraphProfile,
     #[error("initial input does not match GraphSpec.initialInput: {0}")]
     InitialInput(#[from] PayloadValueError),
-    #[error("executable node {node} must use exactly one attempt, found {attempts}")]
+    #[error("executable node {node} uses unsupported native-v2 attempt count {attempts}")]
     Attempts { node: NodeName, attempts: u64 },
     #[error("runtime plan has no binding for executable node {node}")]
     MissingRuntimeBinding { node: NodeName },

--- a/zeroshot/src/native_v2_admission/tests.rs
+++ b/zeroshot/src/native_v2_admission/tests.rs
@@ -208,14 +208,43 @@ async fn rejects_non_full_profile_and_invalid_actual_input() {
 }
 
 #[tokio::test]
-async fn rejects_non_single_attempts_and_runtime_coverage_errors() {
+async fn bounds_attempts_and_rejects_runtime_coverage_errors() {
+    for attempts in 1..=MAX_AGENT_VERIFIER_ATTEMPTS + 1 {
+        let mut verifier = null_verifier("verify", "verify.work@1");
+        *verifier.get_mut("attempts").assert_value() = json!(attempts);
+        let verifier_graph = graph(vec![verifier, succeed("done")]);
+        let verifier_nodes = BTreeMap::from([(named("verify"), binding("claude-sonnet-5", None))]);
+        let admission = NativeV2Admission
+            .admit(submission(verifier_graph, verifier_nodes))
+            .await;
+        if attempts <= MAX_AGENT_VERIFIER_ATTEMPTS {
+            admission.assert_value();
+        } else {
+            assert!(matches!(
+                admission,
+                Err(NativeV2AdmissionError::Attempts { .. })
+            ));
+        }
+    }
+
     let mut value = null_step("work", "agent.work@1");
-    *value.get_mut("attempts").assert_value() = json!(2);
+    *value.get_mut("attempts").assert_value() = json!(MAX_AGENT_VERIFIER_ATTEMPTS);
     let attempts_graph = graph(vec![value, succeed("done")]);
     let nodes = BTreeMap::from([(named("work"), binding("claude-sonnet-5", None))]);
     assert!(matches!(
         NativeV2Admission
             .admit(submission(attempts_graph, nodes))
+            .await,
+        Err(NativeV2AdmissionError::Attempts { .. })
+    ));
+
+    let mut delivery = delivery_verifier("deliver", DeliveryMode::PullRequest);
+    *delivery.get_mut("attempts").assert_value() = json!(MAX_AGENT_VERIFIER_ATTEMPTS);
+    let delivery_graph = graph(vec![delivery, succeed("done")]);
+    let delivery_nodes = BTreeMap::from([(named("deliver"), delivery_binding())]);
+    assert!(matches!(
+        NativeV2Admission
+            .admit(submission(delivery_graph, delivery_nodes))
             .await,
         Err(NativeV2AdmissionError::Attempts { .. })
     ));

--- a/zeroshot/src/native_v2_admission/validation.rs
+++ b/zeroshot/src/native_v2_admission/validation.rs
@@ -5,7 +5,7 @@ use openengine_cluster_protocol::{
     WorkerContract, WorkerRef, MAX_DECLARED_ENVIRONMENT_NAMES, RUNTIME_WORKER_ERRORS,
 };
 
-use super::{DeliveryPolicy, NativeV2AdmissionError};
+use super::{DeliveryPolicy, NativeV2AdmissionError, MAX_AGENT_VERIFIER_ATTEMPTS};
 use crate::native_v2_contract::{
     AdmittedRun, NodeRuntimeBinding, GIT_DELIVERY_MERGE_V2_WORKER_REF,
     GIT_DELIVERY_MERGE_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF,
@@ -126,7 +126,12 @@ fn collect_declarations(node: &GraphNode, declarations: &mut Vec<ExecutableDecla
 }
 
 fn validate_attempts(declarations: &[ExecutableDeclaration]) -> Result<(), NativeV2AdmissionError> {
-    if let Some(declaration) = declarations.iter().find(|item| item.attempts != 1) {
+    if let Some(declaration) = declarations.iter().find(|item| {
+        item.attempts != 1
+            && !(item.kind == LeafKind::Verifier
+                && !is_git_delivery_worker(&item.worker)
+                && item.attempts <= MAX_AGENT_VERIFIER_ATTEMPTS)
+    }) {
         return Err(NativeV2AdmissionError::Attempts {
             node: declaration.name.clone(),
             attempts: declaration.attempts,

--- a/zeroshot/src/native_v2_candidate/test_support.rs
+++ b/zeroshot/src/native_v2_candidate/test_support.rs
@@ -13,9 +13,7 @@ use crate::native_v2_contract::{
     self, AdmittedRun, ExecutionId, ExecutionRef, NodeInstanceId, NodeInvocation,
     NodeRuntimeBinding, RunSubmission, GIT_DELIVERY_MERGE_V2_WORKER_REF,
 };
-use crate::native_v2_delivery::{
-    DELIVERY_CI_FAILED_LABEL, DELIVERY_CONFLICT_LABEL, DELIVERY_MERGED_LABEL, DeliveryMode,
-};
+use crate::native_v2_delivery::{DeliveryMode};
 use crate::native_v2_delivery::contract::delivery_result_schema;
 use crate::native_v2_runner::{NodeRunRequest, ResolvedEnvironment};
 
@@ -156,11 +154,8 @@ pub(crate) fn git_delivery_node() -> Value {
         "input":{"kind":"null"},"output":delivery_result_schema(DeliveryMode::Merge)
             .assert_value_with("delivery result schema"),
         "inputBindings":[],"writeBindings":[],"timeoutMs":1000,"attempts":1,
-        "signals":{"delivery":[
-            DELIVERY_MERGED_LABEL,
-            DELIVERY_CONFLICT_LABEL,
-            DELIVERY_CI_FAILED_LABEL
-        ]},
+        "signals":{"delivery":crate::native_v2_delivery::delivery_signal_labels(DeliveryMode::Merge)
+            .assert_value_with("delivery signals")},
         "diagnostic":crate::native_v2_delivery::delivery_diagnostic_schema()
             .assert_value_with("delivery diagnostic schema")
     })

--- a/zeroshot/src/native_v2_codex/tests/retry.rs
+++ b/zeroshot/src/native_v2_codex/tests/retry.rs
@@ -220,3 +220,25 @@ async fn clean_exit_incomplete_stream_preserves_stderr_and_retries() {
     assert!(!rendered.contains("execution failed without provider detail"));
     assert!(!rendered.contains("sentinel-secret"));
 }
+
+#[tokio::test]
+async fn exhausted_provider_failure_reopens_a_node_instance_session_for_retry() {
+    let directory = TestDirectory::new("codex-verifier-session-replacement");
+    let (admitted, runtime, state) =
+        codex_retry_runtime(&directory, SessionScope::NodeInstance).await;
+    let mut failed = start(&runtime, &admitted, 1, &retry_values(&state, true, false)).await;
+    assert_eq!(failed.completion().await, Err(NodeRunnerError::Driver));
+    assert!(
+        fs::read_to_string(state.with_extension("args.2"))
+            .assert_value()
+            .contains("arg=resume")
+    );
+
+    let retry = start(&runtime, &admitted, 2, &retry_values(&state, false, false)).await;
+    complete_verified_with_logs(retry).await;
+    assert!(
+        !fs::read_to_string(state.with_extension("args.2"))
+            .assert_value()
+            .contains("arg=resume")
+    );
+}

--- a/zeroshot/src/native_v2_delivery.rs
+++ b/zeroshot/src/native_v2_delivery.rs
@@ -7,6 +7,7 @@
 
 mod adapter;
 mod authority_error;
+pub(crate) mod command;
 pub(crate) mod contract;
 mod git;
 #[doc(hidden)]
@@ -16,6 +17,7 @@ mod review_head;
 #[cfg(test)]
 mod tests;
 
+pub use command::GitCommandFailure;
 pub use authority_error::{GitHubApiFailure, GitHubAuthorityError};
 pub use github::{GhCliAuthorityConfig, GhCliDeliveryAuthority};
 pub use review_head::{GitHubHeadSynchronization, GitHubHeadUpdateOutcome, GitHubMergeRequestOutcome};
@@ -45,7 +47,7 @@ use crate::native_v2_runner::{
     SessionFactory,
 };
 
-use self::git::{GitError, SystemGit};
+use self::git::SystemGit;
 use self::review_head::valid_head_update;
 
 pub const GITHUB_TOKEN_ENV: &str = "GH_TOKEN";
@@ -54,6 +56,7 @@ pub const DELIVERY_OPENED_LABEL: &str = "opened";
 pub const DELIVERY_MERGED_LABEL: &str = "merged";
 pub const DELIVERY_CONFLICT_LABEL: &str = "conflict";
 pub const DELIVERY_CI_FAILED_LABEL: &str = "ci_failed";
+pub const DELIVERY_REPAIR_REQUIRED_LABEL: &str = "repair_required";
 
 const DELIVERY_PR_RESULT_VERSION: &str = "v1";
 const DELIVERY_MERGE_RESULT_VERSION: &str = "v2";
@@ -424,6 +427,9 @@ fn valid_delivery_result(result: &DeliveryResult<'_>) -> bool {
 }
 
 fn valid_mode_outcome(mode: DeliveryMode, outcome: &str) -> bool {
+    if outcome == DELIVERY_REPAIR_REQUIRED_LABEL {
+        return true;
+    }
     match mode {
         DeliveryMode::PullRequest => outcome == DELIVERY_OPENED_LABEL,
         DeliveryMode::MergeV1 | DeliveryMode::Merge => matches!(
@@ -533,12 +539,10 @@ fn delivery_branch(run_id: &str) -> String {
     format!("zeroshot/v2-{suffix}")
 }
 
-async fn wait_for_poll(
-    control: &mut DriverControl,
-    interval: Duration,
-) -> Result<(), NodeRunnerError> {
+async fn wait_for_poll(control: &DriverControl, interval: Duration) -> Result<(), NodeRunnerError> {
+    let mut cancellation = control.cancellation();
     tokio::select! {
-        _ = control.cancelled() => Err(NodeRunnerError::Cancelled),
+        _ = cancellation.cancelled() => Err(NodeRunnerError::Cancelled),
         () = tokio::time::sleep(interval) => Ok(()),
     }
 }

--- a/zeroshot/src/native_v2_delivery/adapter.rs
+++ b/zeroshot/src/native_v2_delivery/adapter.rs
@@ -3,6 +3,7 @@ use super::*;
 mod conflict;
 mod head;
 mod input;
+mod recovery;
 mod review;
 mod sync;
 use input::delivery_input;
@@ -14,6 +15,7 @@ pub struct NativeV2DeliveryAdapter {
     authority: Arc<dyn GitHubDeliveryAuthority>,
     git: SystemGit,
     trusted_github_token: Option<Arc<str>>,
+    pending_head: Arc<std::sync::Mutex<Option<head::PendingHead>>>,
 }
 
 impl NativeV2DeliveryAdapter {
@@ -28,6 +30,7 @@ impl NativeV2DeliveryAdapter {
             authority,
             git,
             trusted_github_token: None,
+            pending_head: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -86,38 +89,37 @@ impl NodeDriver for NativeV2DeliveryAdapter {
         mut control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
         let (session, mut credentials, mode) = match self.authorize(&invocation) {
-            Ok(authority) => authority,
+            Ok(authorized) => authorized,
             Err(stop) => return stop.result(),
         };
-        if control.is_cancelled() {
-            return Err(NodeRunnerError::Cancelled);
+        ensure_active(&control)?;
+        let mut cancellation = control.cancellation();
+        let result = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(NodeRunnerError::Cancelled),
+            result = async {
+                let review = self.prepare_review(DeliveryPreparation {
+                    invocation: &invocation, session, credentials: &mut credentials, control: &control,
+                }).await?;
+                self.drive_review(ReviewDrive {
+                    mode, response: &invocation.response, review, credentials, control: &mut control,
+                }).await
+            } => result,
+        };
+        match result {
+            Ok(outcome) => Ok(outcome),
+            Err(DeliveryStop::Repair(failure)) => {
+                self.repair_outcome(&invocation, mode, failure).await
+            }
+            Err(stop) => stop.result(),
         }
-        let review = match self
-            .prepare_review(DeliveryPreparation {
-                invocation: &invocation,
-                session,
-                credentials: &mut credentials,
-                control: &control,
-            })
-            .await
-        {
-            Ok(review) => review,
-            Err(stop) => return stop.result(),
-        };
-        self.drive_review(ReviewDrive {
-            mode,
-            response: &invocation.response,
-            review,
-            credentials,
-            control: &mut control,
-        })
-        .await
     }
 }
 
 enum DeliveryStop {
     Runner(NodeRunnerError),
     Outcome(WorkerOutcome),
+    Repair(recovery::RepairFailure),
 }
 
 struct DeliveryPreparation<'a, 'environment> {
@@ -132,6 +134,7 @@ impl DeliveryStop {
         match self {
             Self::Runner(error) => Err(error),
             Self::Outcome(outcome) => Ok(outcome),
+            Self::Repair(_) => Ok(WorkerOutcome::declared_failure(WorkerErrorCode::Crash)),
         }
     }
 }
@@ -170,8 +173,11 @@ impl<'a> DeliveryCredentials<'a> {
         };
         let refreshed = crate::native_v2_runner::refresh_environment(environment)
             .await
-            .map_err(|_| crash_outcome())?;
-        let credential = github_credential(&refreshed).ok_or_else(crash_outcome)?;
+            .map_err(|_| {
+                recovery::repair("GitHub credential refresh is temporarily unavailable")
+            })?;
+        let credential = github_credential(&refreshed)
+            .ok_or_else(|| DeliveryStop::Outcome(WorkerOutcome::authentication_refusal()))?;
         self.token = credential.expose().to_owned();
         Ok(())
     }
@@ -216,6 +222,12 @@ impl NativeV2DeliveryAdapter {
         preparation: DeliveryPreparation<'_, '_>,
     ) -> Result<GitHubReviewReceipt, DeliveryStop> {
         let input = delivery_input(&preparation.invocation.node.input)?;
+        self.resume_pending_head(
+            preparation.credentials,
+            preparation.control,
+            &delivery_branch(preparation.invocation.node.reference.run_id.as_str()),
+        )
+        .await?;
         let head_revision = self
             .prepare_head(preparation.session, preparation.control, &input.title)
             .await?;
@@ -227,14 +239,24 @@ impl NativeV2DeliveryAdapter {
             description: input.description,
             source_issue: input.source_issue,
         };
-        self.push_review_head(&preparation, &review_request).await?;
+        let pending = GitHubReviewReceipt {
+            review_id: String::new(),
+            repository: review_request.target.repository.clone(),
+            target_branch: review_request.target.target_branch.clone(),
+            head_branch: review_request.head_branch.clone(),
+            head_revision: review_request.head_revision.clone(),
+        };
+        self.push_review_head(&preparation, &review_request)
+            .await
+            .map_err(|stop| stop.with_review(&pending))?;
         let review = self
             .synchronize_review(
                 &review_request,
                 preparation.credentials,
                 preparation.control,
             )
-            .await?;
+            .await
+            .map_err(|stop| stop.with_review(&pending))?;
         if !valid_review(&review_request, &review) {
             return Err(DeliveryStop::Outcome(WorkerOutcome::malformed()));
         }
@@ -253,27 +275,14 @@ impl NativeV2DeliveryAdapter {
         commit_message: &str,
     ) -> Result<String, DeliveryStop> {
         emit(control, "delivery: preparing workspace revision").await?;
-        match self
-            .git
+        self.git
             .prepare_revision(
                 &session.workspace,
                 &self.config.target.base_revision,
                 commit_message,
             )
             .await
-        {
-            Ok(revision) => Ok(revision),
-            Err(GitError::NoMutation) => {
-                emit(control, "delivery: workspace has no deliverable mutation").await?;
-                Err(DeliveryStop::Outcome(WorkerOutcome::declared_failure(
-                    WorkerErrorCode::Malformed,
-                )))
-            }
-            Err(GitError::Command) => {
-                emit(control, "delivery: local Git preparation failed").await?;
-                Err(crash_outcome())
-            }
-        }
+            .map_err(|error| recovery::repair(error.to_string()))
     }
 
     async fn push_review_head(
@@ -288,22 +297,16 @@ impl NativeV2DeliveryAdapter {
             head_revision: review.head_revision.clone(),
         };
         emit(preparation.control, "delivery: pushing run branch").await?;
-        if self
-            .authority
+        self.authority
             .push_branch(&push, preparation.credentials.current())
-            .await
-            .is_err()
-        {
-            emit(preparation.control, "delivery: Git push failed").await?;
-            return Err(crash_outcome());
-        }
+            .await?;
         Ok(())
     }
 
     async fn drive_review(
         &self,
         mut drive: ReviewDrive<'_>,
-    ) -> Result<WorkerOutcome, NodeRunnerError> {
+    ) -> Result<WorkerOutcome, DeliveryStop> {
         let mut completed_attempts = 0usize;
         loop {
             if let Some(outcome) = self.drive_review_step(&mut drive).await? {
@@ -325,16 +328,19 @@ impl NativeV2DeliveryAdapter {
     async fn drive_review_step(
         &self,
         drive: &mut ReviewDrive<'_>,
-    ) -> Result<Option<WorkerOutcome>, NodeRunnerError> {
+    ) -> Result<Option<WorkerOutcome>, DeliveryStop> {
         ensure_active(drive.control)?;
-        let progress = match self.observe_review(drive).await {
-            Ok(progress) => progress,
-            Err(stop) => return stop.result().map(Some),
-        };
-        match self.advance_review(drive, progress).await {
-            Ok(ReviewStep::Continue) => Ok(None),
-            Ok(ReviewStep::Complete(outcome)) => Ok(Some(outcome)),
-            Err(stop) => stop.result().map(Some),
+        let progress = self
+            .observe_review(drive)
+            .await
+            .map_err(|stop| stop.with_review(&drive.review))?;
+        match self
+            .advance_review(drive, progress)
+            .await
+            .map_err(|stop| stop.with_review(&drive.review))?
+        {
+            ReviewStep::Continue => Ok(None),
+            ReviewStep::Complete(outcome) => Ok(Some(outcome)),
         }
     }
 
@@ -444,13 +450,15 @@ impl NativeV2DeliveryAdapter {
             .await
         {
             Ok(observation) => observation,
-            Err(_) => {
-                emit(drive.control, "delivery: refreshing GitHub credential").await?;
-                drive.credentials.refresh().await?;
+            Err(error) => {
+                drive
+                    .credentials
+                    .refresh_after(error, drive.control)
+                    .await?;
                 self.authority
                     .inspect_review(&drive.review, drive.credentials.current())
                     .await
-                    .map_err(|_| crash_outcome())?
+                    .map_err(DeliveryStop::from)?
             }
         };
         if !valid_observation(&drive.review, &observation) {
@@ -470,13 +478,15 @@ impl NativeV2DeliveryAdapter {
             .await
         {
             Ok(outcome) => Ok(outcome),
-            Err(_) => {
-                emit(drive.control, "delivery: refreshing GitHub credential").await?;
-                drive.credentials.refresh().await?;
+            Err(error) => {
+                drive
+                    .credentials
+                    .refresh_after(error, drive.control)
+                    .await?;
                 self.authority
                     .request_merge(&drive.review, drive.credentials.current())
                     .await
-                    .map_err(|_| crash_outcome())
+                    .map_err(DeliveryStop::from)
             }
         }
     }

--- a/zeroshot/src/native_v2_delivery/adapter/conflict.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/conflict.rs
@@ -45,9 +45,9 @@ impl NativeV2DeliveryAdapter {
                 self.authority
                     .materialize_merge_conflict(request, credentials.current())
                     .await
-                    .map_err(|_| crash_outcome())
+                    .map_err(DeliveryStop::from)
             }
-            Err(_) => Err(crash_outcome()),
+            Err(error) => Err(error.into()),
         }
     }
 }

--- a/zeroshot/src/native_v2_delivery/adapter/head.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/head.rs
@@ -2,6 +2,12 @@ use super::*;
 
 const HEAD_SYNC_ATTEMPTS: usize = 5;
 
+#[derive(Clone)]
+pub(super) struct PendingHead {
+    previous: GitHubReviewReceipt,
+    updated: GitHubReviewReceipt,
+}
+
 impl NativeV2DeliveryAdapter {
     pub(super) async fn advance_review_head(
         &self,
@@ -45,46 +51,85 @@ impl NativeV2DeliveryAdapter {
             "delivery: GitHub authorized updated pull request head",
         )
         .await?;
-        self.synchronize_updated_head(drive, &previous).await?;
+        *self
+            .pending_head
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(PendingHead {
+            previous,
+            updated: drive.review.clone(),
+        });
+        self.resume_pending_head(
+            &mut drive.credentials,
+            drive.control,
+            &drive.review.head_branch,
+        )
+        .await?;
         emit(drive.control, "delivery: adopted updated pull request head").await?;
         Ok(ReviewStep::Continue)
     }
 
-    async fn synchronize_updated_head(
+    pub(super) async fn resume_pending_head(
         &self,
-        drive: &mut ReviewDrive<'_>,
-        previous: &GitHubReviewReceipt,
+        credentials: &mut DeliveryCredentials<'_>,
+        control: &DriverControl,
+        head_branch: &str,
+    ) -> Result<(), DeliveryStop> {
+        let pending = self
+            .pending_head
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let Some(pending) = pending else {
+            return Ok(());
+        };
+        if pending.updated.head_branch != head_branch {
+            return Err(DeliveryStop::Outcome(WorkerOutcome::malformed()));
+        }
+        self.synchronize_pending_head(&pending, credentials, control)
+            .await
+            .map_err(|stop| stop.with_review(&pending.updated))?;
+        *self
+            .pending_head
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        Ok(())
+    }
+
+    async fn synchronize_pending_head(
+        &self,
+        pending: &PendingHead,
+        credentials: &DeliveryCredentials<'_>,
+        control: &DriverControl,
     ) -> Result<(), DeliveryStop> {
         for attempt in 0..HEAD_SYNC_ATTEMPTS {
-            ensure_active(drive.control)?;
+            ensure_active(control)?;
             match self
                 .authority
                 .synchronize_review_head(
                     GitHubHeadSynchronization {
                         workspace: &self.config.workspace,
-                        previous,
-                        updated: &drive.review,
+                        previous: &pending.previous,
+                        updated: &pending.updated,
                     },
-                    drive.credentials.current(),
+                    credentials.current(),
                 )
                 .await
             {
                 Ok(()) => return Ok(()),
                 Err(GitHubAuthorityError::Unavailable) if attempt + 1 < HEAD_SYNC_ATTEMPTS => {
                     emit(
-                        drive.control,
+                        control,
                         "delivery: waiting to adopt GitHub pull request head",
                     )
                     .await?;
-                    drive.credentials.refresh().await?;
-                    wait_for_poll(drive.control, self.config.poll.interval).await?;
+                    wait_for_poll(control, self.config.poll.interval).await?;
                 }
-                Err(_) => {
-                    return Err(crash_outcome());
-                }
+                Err(error) => return Err(error.into()),
             }
         }
-        Err(crash_outcome())
+        Err(recovery::repair(
+            "authorized GitHub head could not be adopted",
+        ))
     }
 
     async fn request_head_update(
@@ -101,9 +146,11 @@ impl NativeV2DeliveryAdapter {
             .await
         {
             Ok(outcome) => outcome,
-            Err(_) => {
-                emit(drive.control, "delivery: refreshing GitHub credential").await?;
-                drive.credentials.refresh().await?;
+            Err(error) => {
+                drive
+                    .credentials
+                    .refresh_after(error, drive.control)
+                    .await?;
                 self.authority
                     .update_review_head(
                         &self.config.workspace,
@@ -111,7 +158,7 @@ impl NativeV2DeliveryAdapter {
                         drive.credentials.current(),
                     )
                     .await
-                    .map_err(|_| crash_outcome())?
+                    .map_err(DeliveryStop::from)?
             }
         };
         Ok(outcome)

--- a/zeroshot/src/native_v2_delivery/adapter/recovery.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/recovery.rs
@@ -1,0 +1,103 @@
+use super::*;
+
+pub(super) struct RepairFailure {
+    diagnostic: String,
+    review: Option<Box<GitHubReviewReceipt>>,
+}
+
+pub(super) fn repair(diagnostic: impl Into<String>) -> DeliveryStop {
+    DeliveryStop::Repair(RepairFailure {
+        diagnostic: diagnostic.into(),
+        review: None,
+    })
+}
+
+impl From<GitHubAuthorityError> for DeliveryStop {
+    fn from(error: GitHubAuthorityError) -> Self {
+        if error.authentication_failed() {
+            Self::Outcome(WorkerOutcome::authentication_refusal())
+        } else {
+            repair(error.to_string())
+        }
+    }
+}
+
+impl DeliveryStop {
+    pub(super) fn with_review(mut self, review: &GitHubReviewReceipt) -> Self {
+        if let Self::Repair(failure) = &mut self {
+            failure.review = Some(Box::new(review.clone()));
+        }
+        self
+    }
+}
+
+impl NativeV2DeliveryAdapter {
+    pub(super) async fn repair_outcome(
+        &self,
+        invocation: &DriverInvocation,
+        mode: DeliveryMode,
+        failure: RepairFailure,
+    ) -> Result<WorkerOutcome, NodeRunnerError> {
+        if !contract::supports_repair(&invocation.response) {
+            return Ok(WorkerOutcome::declared_failure(WorkerErrorCode::Crash));
+        }
+        let review = failure
+            .review
+            .map(|review| *review)
+            .unwrap_or_else(|| GitHubReviewReceipt {
+                review_id: String::new(),
+                repository: self.config.target.repository.clone(),
+                target_branch: self.config.target.target_branch.clone(),
+                head_branch: delivery_branch(invocation.node.reference.run_id.as_str()),
+                head_revision: String::new(),
+            });
+        let diagnostic = format!(
+            "repository: {}\ntargetBranch: {}\nbaseRevision: {}\nrunBranch: {}\nheadRevision: {}\n\
+             pullRequestId: {}\n{}",
+            review.repository,
+            review.target_branch,
+            self.config.target.base_revision,
+            review.head_branch,
+            review.head_revision,
+            review.review_id,
+            failure.diagnostic,
+        );
+        let diagnostic = self.redact_feedback(invocation, diagnostic);
+        delivery_outcome(
+            DeliveryResult {
+                mode,
+                outcome: DELIVERY_REPAIR_REQUIRED_LABEL,
+                review: &review,
+                merge_revision: None,
+            },
+            &diagnostic,
+        )
+    }
+
+    fn redact_feedback(&self, invocation: &DriverInvocation, mut diagnostic: String) -> String {
+        let tokens = [
+            self.trusted_github_token.as_deref(),
+            github_credential(&invocation.environment).map(GitHubCredential::expose),
+        ];
+        for token in tokens.into_iter().flatten() {
+            diagnostic = diagnostic
+                .replace(token, "[REDACTED]")
+                .replace(&git_auth::encode_basic_credential(token), "[REDACTED]");
+        }
+        diagnostic
+    }
+}
+
+impl DeliveryCredentials<'_> {
+    pub(super) async fn refresh_after(
+        &mut self,
+        error: GitHubAuthorityError,
+        control: &DriverControl,
+    ) -> Result<(), DeliveryStop> {
+        if !error.authentication_failed() || !self.can_refresh() {
+            return Err(error.into());
+        }
+        emit(control, "delivery: refreshing GitHub credential").await?;
+        self.refresh().await
+    }
+}

--- a/zeroshot/src/native_v2_delivery/adapter/sync.rs
+++ b/zeroshot/src/native_v2_delivery/adapter/sync.rs
@@ -91,6 +91,7 @@ impl NativeV2DeliveryAdapter {
     ) -> Result<GitHubReviewReceipt, DeliveryStop> {
         let deadline = tokio::time::Instant::now() + REVIEW_SYNC_DEADLINE;
         let mut retry_interval = REVIEW_SYNC_INTERVAL;
+        let mut last_failure = None;
         let mut state = ReviewSyncState {
             request,
             credentials,
@@ -102,27 +103,41 @@ impl NativeV2DeliveryAdapter {
             let progress = self.review_sync_progress(&mut state).await?;
             let error = match progress {
                 ReviewSyncProgress::Complete(review) => return Ok(review),
-                ReviewSyncProgress::Failed(error) => error,
-                ReviewSyncProgress::TimedOut => return review_sync_timeout(control).await,
+                ReviewSyncProgress::Failed(error) => {
+                    last_failure = Some(error.clone());
+                    error
+                }
+                ReviewSyncProgress::TimedOut => {
+                    return Err(last_failure.map_or_else(
+                        || recovery::repair("GitHub review synchronization timed out"),
+                        DeliveryStop::from,
+                    ));
+                }
             };
             match handle_review_sync_failure(ReviewSyncFailure {
                 control,
                 attempt,
-                error,
+                error: error.clone(),
                 deadline,
                 retry_interval,
             })
             .await?
             {
                 ReviewSyncDisposition::Retry => {}
-                ReviewSyncDisposition::Stop => return Err(crash_outcome()),
-                ReviewSyncDisposition::TimedOut => return review_sync_timeout(control).await,
+                ReviewSyncDisposition::Stop => return Err(error.into()),
+                ReviewSyncDisposition::TimedOut => {
+                    return Err(recovery::repair(format!(
+                        "GitHub review synchronization timed out\n{error}"
+                    )));
+                }
             }
             retry_interval = retry_interval
                 .saturating_mul(2)
                 .min(REVIEW_SYNC_MAX_INTERVAL);
         }
-        Err(crash_outcome())
+        Err(recovery::repair(
+            "GitHub review synchronization exhausted its attempts",
+        ))
     }
 
     async fn review_sync_progress(
@@ -232,11 +247,6 @@ async fn handle_review_sync_failure(
     } else {
         Ok(ReviewSyncDisposition::TimedOut)
     }
-}
-
-async fn review_sync_timeout(control: &DriverControl) -> Result<GitHubReviewReceipt, DeliveryStop> {
-    emit(control, "delivery: GitHub review synchronization timed out").await?;
-    Err(crash_outcome())
 }
 
 #[cfg(test)]

--- a/zeroshot/src/native_v2_delivery/authority_error.rs
+++ b/zeroshot/src/native_v2_delivery/authority_error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-const MAX_GITHUB_API_DIAGNOSTIC_BYTES: usize = 1024;
+const MAX_GITHUB_API_DIAGNOSTIC_BYTES: usize = 32 * 1024;
 
 /// Bounded provider-owned GitHub API failure detail.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -16,11 +16,12 @@ impl GitHubApiFailure {
             diagnostic = "GitHub API diagnostic redacted".to_owned();
         }
         if diagnostic.len() > MAX_GITHUB_API_DIAGNOSTIC_BYTES {
-            let mut boundary = MAX_GITHUB_API_DIAGNOSTIC_BYTES;
+            let mut boundary = MAX_GITHUB_API_DIAGNOSTIC_BYTES - "\n[diagnostic truncated]".len();
             while !diagnostic.is_char_boundary(boundary) {
                 boundary = boundary.saturating_sub(1);
             }
             diagnostic.truncate(boundary);
+            diagnostic.push_str("\n[diagnostic truncated]");
         }
         Self {
             status,
@@ -30,11 +31,11 @@ impl GitHubApiFailure {
 
     fn retryable_review_sync(&self) -> bool {
         self.status
-            .is_none_or(|status| matches!(status, 404 | 409 | 422 | 429 | 500..=599))
+            .is_none_or(|status| matches!(status, 403 | 404 | 409 | 422 | 429 | 500..=599))
     }
 
     fn authentication_failed(&self) -> bool {
-        matches!(self.status, Some(401 | 403))
+        matches!(self.status, Some(401))
     }
 }
 
@@ -52,9 +53,18 @@ pub enum GitHubAuthorityError {
     Rejected,
     #[error("GitHub API request failed: {0}")]
     Api(GitHubApiFailure),
+    #[error("{0}")]
+    Command(Box<super::GitCommandFailure>),
 }
 
 impl GitHubAuthorityError {
+    pub(super) fn api_status(&self) -> Option<u16> {
+        match self {
+            Self::Api(failure) => failure.status,
+            _ => None,
+        }
+    }
+
     pub(super) fn api(status: Option<u16>, diagnostic: impl Into<String>) -> Self {
         Self::Api(GitHubApiFailure::new(status, diagnostic))
     }
@@ -62,7 +72,7 @@ impl GitHubAuthorityError {
     pub(super) fn retryable_review_sync(&self) -> bool {
         match self {
             Self::Unavailable => true,
-            Self::Rejected => false,
+            Self::Rejected | Self::Command(_) => false,
             Self::Api(failure) => failure.retryable_review_sync(),
         }
     }
@@ -73,5 +83,11 @@ impl GitHubAuthorityError {
 
     pub(super) fn review_head_not_visible() -> Self {
         Self::api(None, "GitHub review head revision is not visible")
+    }
+}
+
+impl From<super::GitCommandFailure> for GitHubAuthorityError {
+    fn from(failure: super::GitCommandFailure) -> Self {
+        Self::Command(Box::new(failure))
     }
 }

--- a/zeroshot/src/native_v2_delivery/command.rs
+++ b/zeroshot/src/native_v2_delivery/command.rs
@@ -1,0 +1,384 @@
+//! Bounded command capture shared by trusted delivery Git operations.
+use std::fmt;
+use std::path::Path;
+use std::process::{ExitStatus, Stdio};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command;
+
+const MAX_DIAGNOSTIC_BYTES: usize =
+    4 * crate::native_v2_target_authority::MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitCommandFailure {
+    command: Box<str>,
+    working_directory: Box<str>,
+    pub(crate) exit_status: Option<i32>,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) stdout_truncated: bool,
+    pub(crate) stderr_truncated: bool,
+    context: Box<str>,
+}
+
+impl fmt::Display for GitCommandFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "command: {}\nworkingDirectory: {}\nexitStatus: {:?}\n{}\nstdout{}:\n{}\nstderr{}:\n{}",
+            self.command,
+            self.working_directory,
+            self.exit_status,
+            self.context,
+            if self.stdout_truncated {
+                " (truncated)"
+            } else {
+                ""
+            },
+            self.stdout,
+            if self.stderr_truncated {
+                " (truncated)"
+            } else {
+                ""
+            },
+            self.stderr
+        )
+    }
+}
+
+impl std::error::Error for GitCommandFailure {}
+
+impl GitCommandFailure {
+    pub(crate) fn require_success(self) -> Result<Self, Self> {
+        if self.exit_status == Some(0) {
+            Ok(self)
+        } else {
+            Err(self)
+        }
+    }
+}
+
+#[derive(Default)]
+struct CapturedBytes {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+/// Captures both pipes through process exit, bounds memory, and kills the child when dropped.
+/// Nonzero statuses are returned intact so callers can recognize command-specific expected exits.
+pub(crate) async fn capture(
+    command: &mut Command,
+    deadline: Duration,
+) -> Result<GitCommandFailure, GitCommandFailure> {
+    let secrets = command_secrets(command);
+    let mut diagnostic = command_diagnostic(command, &secrets);
+    command
+        .kill_on_drop(true)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.as_std_mut().process_group(0);
+    }
+    let mut child = command.spawn().map_err(|error| {
+        diagnostic.context = format!("could not start command: {error}").into_boxed_str();
+        diagnostic.clone()
+    })?;
+    let _process_group = ProcessGroup(child.id());
+    let Some(stdout) = child.stdout.take() else {
+        return Err(diagnostic);
+    };
+    let Some(stderr) = child.stderr.take() else {
+        return Err(diagnostic);
+    };
+    let mut captured_stdout = CapturedBytes::default();
+    let mut captured_stderr = CapturedBytes::default();
+    let retain = MAX_DIAGNOSTIC_BYTES + secrets.iter().map(String::len).max().unwrap_or(0);
+    let result = tokio::time::timeout(deadline, async {
+        let (status, (), ()) = tokio::join!(
+            child.wait(),
+            drain(stdout, &mut captured_stdout, retain),
+            drain(stderr, &mut captured_stderr, retain),
+        );
+        status
+    })
+    .await;
+    diagnostic.exit_status = result
+        .as_ref()
+        .ok()
+        .and_then(|r| r.as_ref().ok())
+        .and_then(ExitStatus::code);
+    if result.is_err() {
+        captured_stdout.truncated = true;
+        captured_stderr.truncated = true;
+    }
+    (diagnostic.stdout, diagnostic.stdout_truncated) = sanitize(captured_stdout, &secrets);
+    (diagnostic.stderr, diagnostic.stderr_truncated) = sanitize(captured_stderr, &secrets);
+    match result {
+        Ok(Ok(_)) => Ok(diagnostic),
+        other => {
+            let _ = child.start_kill();
+            diagnostic.context = match other {
+                Err(_) => format!("command timed out after {} seconds", deadline.as_secs()),
+                Ok(Err(error)) => format!("command status unavailable: {error}"),
+                Ok(Ok(_)) => unreachable!(),
+            }
+            .into_boxed_str();
+            Err(diagnostic)
+        }
+    }
+}
+
+fn command_diagnostic(command: &Command, secrets: &[String]) -> GitCommandFailure {
+    let command = command.as_std();
+    let arguments = std::iter::once(command.get_program())
+        .chain(command.get_args())
+        .map(|value| format!("{:?}", value.to_string_lossy()))
+        .collect::<Vec<_>>()
+        .join(" ");
+    GitCommandFailure {
+        command: redact(&arguments, secrets).into_boxed_str(),
+        working_directory: command
+            .get_current_dir()
+            .map_or_else(
+                || "inherited; repository selected by -C".to_owned(),
+                |path| path.display().to_string(),
+            )
+            .into_boxed_str(),
+        exit_status: None,
+        stdout: String::new(),
+        stderr: String::new(),
+        stdout_truncated: false,
+        stderr_truncated: false,
+        context: Box::<str>::default(),
+    }
+}
+
+fn command_secrets(command: &Command) -> Vec<String> {
+    let token = command.as_std().get_envs().find_map(|(name, value)| {
+        (name == "GH_TOKEN")
+            .then_some(value)
+            .flatten()
+            .map(|v| v.to_string_lossy().into_owned())
+    });
+    match token {
+        Some(token) => vec![super::git_auth::encode_basic_credential(&token), token],
+        None => Vec::new(),
+    }
+}
+
+async fn drain(mut reader: impl AsyncRead + Unpin, captured: &mut CapturedBytes, retain: usize) {
+    let mut buffer = [0_u8; 8 * 1024];
+    loop {
+        let read = match reader.read(&mut buffer).await {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => {
+                captured.truncated = true;
+                break;
+            }
+        };
+        let count = retain.saturating_sub(captured.bytes.len()).min(read);
+        captured.bytes.extend_from_slice(&buffer[..count]);
+        captured.truncated |= count < read;
+    }
+}
+
+fn sanitize(mut captured: CapturedBytes, secrets: &[String]) -> (String, bool) {
+    if captured.truncated {
+        let trim = secrets
+            .iter()
+            .filter(|s| !s.is_empty() && !captured.bytes.ends_with(s.as_bytes()))
+            .flat_map(|s| (1..s.len()).map(move |n| &s.as_bytes()[..n]))
+            .filter(|prefix| captured.bytes.ends_with(prefix))
+            .map(<[u8]>::len)
+            .max()
+            .unwrap_or(0);
+        captured
+            .bytes
+            .truncate(captured.bytes.len().saturating_sub(trim));
+    }
+    let mut text = redact(&String::from_utf8_lossy(&captured.bytes), secrets);
+    let truncated = captured.truncated || text.len() > MAX_DIAGNOSTIC_BYTES;
+    let mut boundary = text.len().min(MAX_DIAGNOSTIC_BYTES);
+    while !text.is_char_boundary(boundary) {
+        boundary = boundary.saturating_sub(1);
+    }
+    text.truncate(boundary);
+    (text, truncated)
+}
+
+fn redact(value: &str, secrets: &[String]) -> String {
+    secrets
+        .iter()
+        .filter(|s| !s.is_empty())
+        .fold(value.to_owned(), |text, secret| {
+            text.replace(secret, "[REDACTED]")
+        })
+}
+
+pub(crate) fn local_git_command(program: &Path, workspace: &Path) -> Command {
+    let mut command = Command::new(program);
+    command
+        .kill_on_drop(true)
+        .env_clear()
+        .env("LANG", "C")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .arg("-c")
+        .arg("core.hooksPath=/dev/null")
+        .arg("-c")
+        .arg("maintenance.autoDetach=false")
+        .arg("-c")
+        .arg(format!("safe.directory={}", workspace.display()))
+        .arg("-C")
+        .arg(workspace)
+        .stdin(Stdio::null());
+    command
+}
+
+// Dropping a cancelled capture must stop helpers such as git-remote-https as well as Git itself.
+struct ProcessGroup(Option<u32>);
+
+impl Drop for ProcessGroup {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(pid) = self
+            .0
+            .and_then(|pid| i32::try_from(pid).ok())
+            .filter(|pid| *pid > 0)
+        {
+            // The process was started in its own group; no launcher process belongs to this group.
+            unsafe {
+                libc::kill(-pid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+pub(super) fn diagnostic_text(bytes: Vec<u8>, truncated: bool, token: &str) -> (String, bool) {
+    sanitize(
+        CapturedBytes { bytes, truncated },
+        &[
+            token.to_owned(),
+            super::git_auth::encode_basic_credential(token),
+        ],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncated_output_cannot_retain_a_partial_secret() {
+        let captured = CapturedBytes {
+            bytes: b"safe credential-val".to_vec(),
+            truncated: true,
+        };
+        let (text, truncated) = sanitize(captured, &["credential-value".to_owned()]);
+        assert_eq!(text, "safe ");
+        assert!(truncated);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn raw_failure_is_bounded_and_credentials_are_redacted() {
+        let mut command = Command::new("/bin/sh");
+        command
+            .env_clear()
+            .env("GH_TOKEN", "credential-value")
+            .args([
+                "-c",
+                "printf 'unfamiliar error: %s' \"$GH_TOKEN\" >&2; printf 'output'; exit 17",
+            ]);
+        let output = capture(&mut command, Duration::from_secs(1))
+            .await
+            .expect("command exited");
+        assert_eq!(output.exit_status, Some(17));
+        assert_eq!(output.stdout, "output");
+        assert_eq!(output.stderr, "unfamiliar error: [REDACTED]");
+        assert!(output.require_success().is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn cancellation_stops_the_owned_git_helper_process() {
+        use crate::native_v2_candidate::test_support::TestGitRepository;
+        let repository = TestGitRepository::delivery();
+        let marker = repository.root.path().join("helper-pid");
+        let mut command = Command::new("/bin/sh");
+        command
+            .args([
+                "-c",
+                "/usr/bin/sleep 30 & printf '%s' $! > \"$1\"; wait",
+                "git-helper",
+            ])
+            .arg(&marker);
+        let task =
+            tokio::spawn(async move { capture(&mut command, Duration::from_secs(30)).await });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !marker.exists() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("helper started");
+        let pid = std::fs::read_to_string(marker).expect("helper PID");
+        task.abort();
+        assert!(task.await.expect_err("capture cancelled").is_cancelled());
+        assert_helper_stopped(&pid).await;
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn assert_helper_stopped(pid: &str) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let status = std::fs::read_to_string(format!("/proc/{pid}/stat"));
+                if status
+                    .as_ref()
+                    .map_or(true, |text| text.split_whitespace().nth(2) == Some("Z"))
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("helper stopped after capture cancellation");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn completed_commands_cannot_leave_background_helpers_mutating_the_workspace() {
+        for status in [0, 17] {
+            let mut command = Command::new("/bin/sh");
+            command.args([
+                "-c",
+                &format!("/usr/bin/sleep 30 >/dev/null 2>&1 & printf '%s' $!; exit {status}"),
+            ]);
+            let output = capture(&mut command, Duration::from_secs(2))
+                .await
+                .expect("command exited");
+            assert_eq!(output.exit_status, Some(status));
+            assert_helper_stopped(&output.stdout).await;
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timeout_includes_inherited_pipe_drain() {
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "(/usr/bin/sleep 2) & exit 17"]);
+        let started = std::time::Instant::now();
+        let error = capture(&mut command, Duration::from_millis(20))
+            .await
+            .expect_err("deadline");
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(error.context.contains("timed out"));
+        assert!(error.stderr_truncated);
+    }
+}

--- a/zeroshot/src/native_v2_delivery/command.rs
+++ b/zeroshot/src/native_v2_delivery/command.rs
@@ -50,6 +50,22 @@ impl fmt::Display for GitCommandFailure {
 impl std::error::Error for GitCommandFailure {}
 
 impl GitCommandFailure {
+    pub(crate) fn operator_stderr(&self) -> String {
+        format!(
+            "stderr{}:\n{}\ncommand: {}\nworkingDirectory: {}\nexitStatus: {:?}\n{}",
+            if self.stderr_truncated {
+                " (truncated)"
+            } else {
+                ""
+            },
+            self.stderr,
+            self.command,
+            self.working_directory,
+            self.exit_status,
+            self.context,
+        )
+    }
+
     pub(crate) fn require_success(self) -> Result<Self, Self> {
         if self.exit_status == Some(0) {
             Ok(self)

--- a/zeroshot/src/native_v2_delivery/contract.rs
+++ b/zeroshot/src/native_v2_delivery/contract.rs
@@ -11,7 +11,8 @@ use super::{
     DELIVERY_MERGED_LABEL, DELIVERY_MERGE_REVISION_FIELD, DELIVERY_MODE_FIELD,
     DELIVERY_OPENED_LABEL, DELIVERY_OUTCOME_FIELD, DELIVERY_PULL_REQUEST_ID_FIELD,
     DELIVERY_REPOSITORY_FIELD, DELIVERY_SIGNAL_FIELD, DELIVERY_TARGET_BRANCH_FIELD,
-    DELIVERY_VERSION_FIELD, DeliveryMode, DeliveryTarget, valid_review_id, valid_revision,
+    DELIVERY_VERSION_FIELD, DELIVERY_REPAIR_REQUIRED_LABEL, DeliveryMode, DeliveryTarget,
+    valid_review_id, valid_revision,
 };
 
 pub fn validate_delivery_contract(
@@ -40,14 +41,17 @@ fn delivery_contract_matches(
     signals: &std::collections::BTreeMap<FieldName, NonEmptyEnumSet>,
     diagnostic: &PayloadType,
 ) -> Result<bool, ContractValueError> {
-    let expected_output = delivery_result_schema(mode)?;
-    let expected_diagnostic = delivery_diagnostic_schema()?;
     let field = FieldName::new(DELIVERY_SIGNAL_FIELD)?;
-    let expected_labels = delivery_signal_labels(mode)?;
-    Ok(output == &expected_output
-        && diagnostic == &expected_diagnostic
-        && signals.len() == 1
-        && signals.get(&field) == Some(&expected_labels))
+    let matching = [true, false]
+        .into_iter()
+        .map(|repair| {
+            Ok(output == &result_schema(mode, repair)?
+                && signals.get(&field) == Some(&signal_labels(mode, repair)?))
+        })
+        .collect::<Result<Vec<_>, ContractValueError>>()?
+        .into_iter()
+        .any(|matches| matches);
+    Ok(matching && diagnostic == &delivery_diagnostic_schema()? && signals.len() == 1)
 }
 
 pub(crate) fn delivery_diagnostic_schema() -> Result<PayloadType, ContractValueError> {
@@ -106,8 +110,12 @@ struct DeliveryResultWire {
 pub(crate) fn delivery_result_schema(
     mode: DeliveryMode,
 ) -> Result<PayloadType, ContractValueError> {
+    result_schema(mode, true)
+}
+
+fn result_schema(mode: DeliveryMode, repair: bool) -> Result<PayloadType, ContractValueError> {
     let mut fields = delivery_identity_fields(mode)?;
-    fields.extend(delivery_mode_fields(mode)?);
+    fields.extend(delivery_mode_fields(mode, repair)?);
     Ok(PayloadType::Record {
         fields: fields.into_iter().collect(),
     })
@@ -137,13 +145,14 @@ fn delivery_identity_fields(
 
 fn delivery_mode_fields(
     mode: DeliveryMode,
+    repair: bool,
 ) -> Result<Vec<(FieldName, RecordField)>, ContractValueError> {
     Ok(vec![
         contract_field(DELIVERY_MODE_FIELD, contract_enum(&[mode.label()])?)?,
         contract_field(
             DELIVERY_OUTCOME_FIELD,
             PayloadType::Enum {
-                values: delivery_signal_labels(mode)?,
+                values: signal_labels(mode, repair)?,
             },
         )?,
     ])
@@ -152,14 +161,34 @@ fn delivery_mode_fields(
 pub(crate) fn delivery_signal_labels(
     mode: DeliveryMode,
 ) -> Result<NonEmptyEnumSet, ContractValueError> {
-    match mode {
-        DeliveryMode::PullRequest => contract_labels(&[DELIVERY_OPENED_LABEL]),
-        DeliveryMode::MergeV1 | DeliveryMode::Merge => contract_labels(&[
+    signal_labels(mode, true)
+}
+
+fn signal_labels(mode: DeliveryMode, repair: bool) -> Result<NonEmptyEnumSet, ContractValueError> {
+    let mut labels = match mode {
+        DeliveryMode::PullRequest => vec![DELIVERY_OPENED_LABEL],
+        DeliveryMode::MergeV1 | DeliveryMode::Merge => vec![
             DELIVERY_MERGED_LABEL,
             DELIVERY_CONFLICT_LABEL,
             DELIVERY_CI_FAILED_LABEL,
-        ]),
+        ],
+    };
+    if repair {
+        labels.push(DELIVERY_REPAIR_REQUIRED_LABEL);
     }
+    contract_labels(&labels)
+}
+
+pub(super) fn supports_repair(response: &NodeResponseContract) -> bool {
+    let NodeResponseContract::Verifier { signals, .. } = response else {
+        return false;
+    };
+    signals.values().any(|labels| {
+        labels
+            .values()
+            .iter()
+            .any(|label| label.as_str() == DELIVERY_REPAIR_REQUIRED_LABEL)
+    })
 }
 
 fn contract_field(

--- a/zeroshot/src/native_v2_delivery/git.rs
+++ b/zeroshot/src/native_v2_delivery/git.rs
@@ -1,14 +1,24 @@
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::time::Duration;
 
 use tokio::process::Command;
 
-use super::valid_revision;
+use super::{command, valid_revision, GitCommandFailure};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 pub(super) enum GitError {
+    #[error("workspace has no deliverable mutation relative to the requested base revision")]
     NoMutation,
-    Command,
+    #[error("Git returned an invalid HEAD revision")]
+    InvalidRevision,
+    #[error("{0}")]
+    Command(Box<GitCommandFailure>),
+}
+
+impl From<GitCommandFailure> for GitError {
+    fn from(failure: GitCommandFailure) -> Self {
+        Self::Command(Box::new(failure))
+    }
 }
 
 #[derive(Clone)]
@@ -29,11 +39,11 @@ impl SystemGit {
     ) -> Result<String, GitError> {
         self.require_success(workspace, &["add", "--all"]).await?;
         let staged = self
-            .exit_code(workspace, &["diff", "--cached", "--quiet", "--exit-code"])
+            .execute(workspace, &["diff", "--cached", "--quiet", "--exit-code"])
             .await?;
-        match staged {
-            0 => {}
-            1 => {
+        match staged.exit_status {
+            Some(0) => {}
+            Some(1) => {
                 self.require_success(
                     workspace,
                     &[
@@ -49,7 +59,7 @@ impl SystemGit {
                 )
                 .await?;
             }
-            _ => return Err(GitError::Command),
+            _ => return Err(staged.into()),
         }
         self.deliverable_revision(workspace, base_revision).await
     }
@@ -59,10 +69,12 @@ impl SystemGit {
         workspace: &Path,
         base_revision: &str,
     ) -> Result<String, GitError> {
-        let revision = self.capture(workspace, &["rev-parse", "HEAD"]).await?;
-        let revision = revision.trim().to_owned();
+        let output = self
+            .require_success(workspace, &["rev-parse", "HEAD"])
+            .await?;
+        let revision = output.stdout.trim().to_owned();
         if !valid_revision(&revision) {
-            return Err(GitError::Command);
+            return Err(GitError::InvalidRevision);
         }
         if revision == base_revision {
             return Err(GitError::NoMutation);
@@ -75,51 +87,33 @@ impl SystemGit {
         Ok(revision)
     }
 
-    async fn require_success(&self, workspace: &Path, arguments: &[&str]) -> Result<(), GitError> {
-        (self.exit_code(workspace, arguments).await? == 0)
-            .then_some(())
-            .ok_or(GitError::Command)
+    async fn require_success(
+        &self,
+        workspace: &Path,
+        arguments: &[&str],
+    ) -> Result<GitCommandFailure, GitError> {
+        self.execute(workspace, arguments)
+            .await?
+            .require_success()
+            .map_err(Into::into)
     }
 
-    async fn exit_code(&self, workspace: &Path, arguments: &[&str]) -> Result<i32, GitError> {
-        self.command(workspace, arguments)
-            .status()
-            .await
-            .map_err(|_| GitError::Command)?
-            .code()
-            .ok_or(GitError::Command)
-    }
-
-    async fn capture(&self, workspace: &Path, arguments: &[&str]) -> Result<String, GitError> {
-        let output = self
-            .command(workspace, arguments)
-            .stdout(Stdio::piped())
-            .output()
-            .await
-            .map_err(|_| GitError::Command)?;
-        if !output.status.success() || output.stdout.len() > 4_096 {
-            return Err(GitError::Command);
-        }
-        String::from_utf8(output.stdout).map_err(|_| GitError::Command)
+    async fn execute(
+        &self,
+        workspace: &Path,
+        arguments: &[&str],
+    ) -> Result<GitCommandFailure, GitError> {
+        command::capture(
+            &mut self.command(workspace, arguments),
+            Duration::from_secs(10 * 60),
+        )
+        .await
+        .map_err(Into::into)
     }
 
     fn command(&self, workspace: &Path, arguments: &[&str]) -> Command {
-        let mut command = Command::new(&self.program);
-        command
-            .env_clear()
-            .env("LANG", "C")
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .arg("-c")
-            .arg("core.hooksPath=/dev/null")
-            .arg("-c")
-            .arg(format!("safe.directory={}", workspace.display()))
-            .arg("-C")
-            .arg(workspace)
-            .args(arguments)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+        let mut command = command::local_git_command(&self.program, workspace);
+        command.args(arguments);
         command
     }
 }

--- a/zeroshot/src/native_v2_delivery/github.rs
+++ b/zeroshot/src/native_v2_delivery/github.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use openengine_cluster_protocol::RunId;
 use tokio::process::Command;
-use tokio::time::timeout;
+use super::command::capture;
 
 use crate::native_v2_delivery::git_auth::encode_basic_credential;
 use crate::native_v2_target_authority::OperatorDiagnosticStore;
@@ -265,6 +265,9 @@ impl GhCliDeliveryAuthority {
             GitHubReviewState::Open { .. } if snapshot.head_update.is_some() => {
                 Ok(GitHubMergeRequestOutcome::HeadUpdateRequired)
             }
+            GitHubReviewState::Open {
+                checks: GitHubChecks::Passed | GitHubChecks::NotRequired,
+            } => Err(GitHubAuthorityError::Rejected),
             GitHubReviewState::Open { .. } => Ok(GitHubMergeRequestOutcome::Pending),
             GitHubReviewState::Closed => Err(GitHubAuthorityError::Rejected),
         }
@@ -335,10 +338,10 @@ impl GitHubDeliveryAuthority for GhCliDeliveryAuthority {
         }
         match bounded_status(command, self.config.api_deadline).await {
             Ok(()) => Ok(GitHubMergeRequestOutcome::Accepted),
-            Err(GitHubAuthorityError::Rejected) => {
-                self.classify_rejected_merge(review, credential).await
-            }
-            Err(error) => Err(error),
+            Err(error) => match self.classify_rejected_merge(review, credential).await {
+                Ok(outcome) => Ok(outcome),
+                Err(_) => Err(error),
+            },
         }
     }
 
@@ -483,24 +486,8 @@ fn git_command(
 }
 
 fn local_git_command(config: &GhCliAuthorityConfig, workspace: &std::path::Path) -> Command {
-    let mut command = Command::new(&config.git_program);
-    command
-        .kill_on_drop(true)
-        .env_clear()
-        .env("HOME", &config.home_directory)
-        .env("LANG", "C")
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .arg("-c")
-        .arg("core.hooksPath=/dev/null")
-        .arg("-c")
-        .arg(format!("safe.directory={}", workspace.display()))
-        .arg("-C")
-        .arg(workspace)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+    let mut command = super::command::local_git_command(&config.git_program, workspace);
+    command.env("HOME", &config.home_directory);
     command
 }
 
@@ -527,14 +514,8 @@ async fn bounded_status(
     mut command: Command,
     deadline: Duration,
 ) -> Result<(), GitHubAuthorityError> {
-    let status = timeout(deadline, command.status())
-        .await
-        .map_err(|_| GitHubAuthorityError::Unavailable)?
-        .map_err(|_| GitHubAuthorityError::Unavailable)?;
-    status
-        .success()
-        .then_some(())
-        .ok_or(GitHubAuthorityError::Rejected)
+    capture(&mut command, deadline).await?.require_success()?;
+    Ok(())
 }
 
 async fn bounded_git_output(
@@ -542,15 +523,14 @@ async fn bounded_git_output(
     deadline: Duration,
     maximum_bytes: usize,
 ) -> Result<String, GitHubAuthorityError> {
-    command.stdout(Stdio::piped());
-    let output = timeout(deadline, command.output())
-        .await
-        .map_err(|_| GitHubAuthorityError::Unavailable)?
-        .map_err(|_| GitHubAuthorityError::Unavailable)?;
-    if !output.status.success() || output.stdout.len() > maximum_bytes {
-        return Err(GitHubAuthorityError::Rejected);
+    let output = capture(command, deadline).await?.require_success()?;
+    if output.stdout_truncated || output.stdout.len() > maximum_bytes {
+        return Err(GitHubAuthorityError::api(
+            None,
+            format!("Git output exceeded {maximum_bytes} bytes\n{output}"),
+        ));
     }
-    String::from_utf8(output.stdout).map_err(|_| GitHubAuthorityError::Rejected)
+    Ok(output.stdout)
 }
 
 #[cfg(test)]

--- a/zeroshot/src/native_v2_delivery/github/api.rs
+++ b/zeroshot/src/native_v2_delivery/github/api.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::time::timeout;
 
 use super::wire::{GitReferenceWire, reference_revision, require_review_head};
 use super::*;
@@ -25,7 +26,15 @@ impl GhCliDeliveryAuthority {
     ) -> Result<Vec<u8>, GitHubAuthorityError> {
         let mut command = clean_command(&self.config, &self.config.gh_program, credential);
         command.arg("api").args(arguments).stdout(Stdio::piped());
-        bounded_output(command, self.config.api_deadline).await
+        let context = format!("command: {:?} api {arguments:?}", self.config.gh_program);
+        bounded_output(command, self.config.api_deadline, credential)
+            .await
+            .map_err(|error| {
+                let diagnostic = format!("{context}\n{error}")
+                    .replace(credential.expose(), "[REDACTED]")
+                    .replace(&encode_basic_credential(credential.expose()), "[REDACTED]");
+                GitHubAuthorityError::api(error.api_status(), diagnostic)
+            })
     }
 
     pub(super) async fn confirm_review_head(
@@ -33,18 +42,24 @@ impl GhCliDeliveryAuthority {
         request: &GitHubReviewRequest,
         credential: GitHubCredential<'_>,
     ) -> Result<(), GitHubAuthorityError> {
-        let value = self
-            .api(
-                &[format!(
-                    "repos/{}/git/ref/heads/{}",
-                    request.target.repository, request.head_branch
-                )],
-                credential,
-            )
+        let reference = self
+            .read_reference(&request.target.repository, &request.head_branch, credential)
             .await?;
-        let reference: GitReferenceWire =
-            serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
         require_review_head(reference, request)
+    }
+
+    pub(super) async fn confirm_pushed_head(
+        &self,
+        request: &GitHubPushRequest,
+        credential: GitHubCredential<'_>,
+    ) -> Result<(), GitHubAuthorityError> {
+        let reference = self
+            .read_reference(&request.target.repository, &request.head_branch, credential)
+            .await?;
+        let revision = reference_revision(reference, &request.head_branch)?;
+        (revision == request.head_revision)
+            .then_some(())
+            .ok_or(GitHubAuthorityError::Rejected)
     }
 
     pub(super) async fn target_revision(
@@ -52,24 +67,31 @@ impl GhCliDeliveryAuthority {
         review: &GitHubReviewReceipt,
         credential: GitHubCredential<'_>,
     ) -> Result<String, GitHubAuthorityError> {
+        let reference = self
+            .read_reference(&review.repository, &review.target_branch, credential)
+            .await?;
+        reference_revision(reference, &review.target_branch)
+    }
+    async fn read_reference(
+        &self,
+        repository: &str,
+        branch: &str,
+        credential: GitHubCredential<'_>,
+    ) -> Result<GitReferenceWire, GitHubAuthorityError> {
         let value = self
             .api(
-                &[format!(
-                    "repos/{}/git/ref/heads/{}",
-                    review.repository, review.target_branch
-                )],
+                &[format!("repos/{repository}/git/ref/heads/{branch}")],
                 credential,
             )
             .await?;
-        let reference: GitReferenceWire =
-            serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)?;
-        reference_revision(reference, &review.target_branch)
+        serde_json::from_value(value).map_err(|_| GitHubAuthorityError::Rejected)
     }
 }
 
 async fn bounded_output(
     mut command: Command,
     deadline: Duration,
+    credential: GitHubCredential<'_>,
 ) -> Result<Vec<u8>, GitHubAuthorityError> {
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
@@ -97,7 +119,22 @@ async fn bounded_output(
     .map_err(|_| GitHubAuthorityError::Unavailable)?
     .map_err(|_| GitHubAuthorityError::Unavailable)?;
     if !status.success() {
-        return Err(github_api_error(&error_output));
+        let error = github_api_error(&error_output);
+        let stdout_truncated = output.len() > MAX_API_OUTPUT_BYTES;
+        let stderr_truncated = error_output.len() > MAX_API_ERROR_BYTES;
+        let (stdout, stdout_truncated) =
+            super::super::command::diagnostic_text(output, stdout_truncated, credential.expose());
+        let (stderr, stderr_truncated) = super::super::command::diagnostic_text(
+            error_output,
+            stderr_truncated,
+            credential.expose(),
+        );
+        let diagnostic = format!(
+            "exitStatus: {:?}\nstdout (truncated={stdout_truncated}):\n{stdout}\n\
+            stderr (truncated={stderr_truncated}):\n{stderr}",
+            status.code()
+        );
+        return Err(GitHubAuthorityError::api(error.api_status(), diagnostic));
     }
     validate_api_output(output)
 }
@@ -129,30 +166,7 @@ fn github_api_error(output: &[u8]) -> GitHubAuthorityError {
         .as_ref()
         .and_then(github_api_status)
         .or_else(|| github_api_status_from_text(&text));
-    let mut parts = Vec::new();
-    if let Some(message) = value
-        .as_ref()
-        .and_then(|value| value.get("message"))
-        .and_then(Value::as_str)
-        .and_then(github_api_message)
-    {
-        parts.push(message);
-    }
-    if let Some(errors) = value
-        .as_ref()
-        .and_then(|value| value.get("errors"))
-        .and_then(Value::as_array)
-    {
-        parts.extend(errors.iter().take(3).filter_map(github_api_error_detail));
-    }
-    if parts.is_empty() {
-        parts.push("GitHub CLI returned a non-structured API error".to_owned());
-    }
-    let diagnostic = status.map_or_else(
-        || parts.join("; "),
-        |status| format!("HTTP {status}: {}", parts.join("; ")),
-    );
-    GitHubAuthorityError::api(status, diagnostic)
+    GitHubAuthorityError::api(status, text.into_owned())
 }
 
 fn github_api_error_value(text: &str) -> Option<Value> {
@@ -183,75 +197,6 @@ fn github_api_status_from_text(text: &str) -> Option<u16> {
     let start = text.rfind(marker)? + marker.len();
     let digits = text.get(start..)?.split(')').next()?;
     digits.parse().ok()
-}
-
-fn github_api_error_detail(value: &Value) -> Option<String> {
-    if let Some(message) = value.as_str() {
-        return github_api_message(message);
-    }
-    let mut fields = ["resource", "field", "code"]
-        .into_iter()
-        .filter_map(|field| value.get(field).and_then(Value::as_str))
-        .filter_map(safe_api_identifier)
-        .collect::<Vec<_>>();
-    if let Some(message) = value
-        .get("message")
-        .and_then(Value::as_str)
-        .and_then(github_api_message)
-    {
-        fields.push(message);
-    }
-    (!fields.is_empty()).then(|| fields.join(" "))
-}
-
-fn safe_api_identifier(value: &str) -> Option<String> {
-    (!value.is_empty()
-        && value.len() <= 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')))
-    .then(|| value.to_owned())
-}
-
-fn github_api_message(value: &str) -> Option<String> {
-    let normalized = value
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_lowercase();
-    exact_github_api_message(&normalized)
-        .or_else(|| classified_github_api_message(&normalized))
-        .map(str::to_owned)
-}
-
-fn exact_github_api_message(value: &str) -> Option<&'static str> {
-    Some(match value {
-        "validation failed" => "validation failed",
-        "not found" => "not found",
-        "bad credentials" => "bad credentials",
-        "server error" => "server error",
-        "service unavailable" => "service unavailable",
-        _ => return None,
-    })
-}
-
-fn classified_github_api_message(value: &str) -> Option<&'static str> {
-    if value.contains("head sha can't be blank") || value.contains("head is invalid") {
-        return Some("pull request head revision is not visible");
-    }
-    if value.contains("no commits between") {
-        return Some("no commits are visible between base and head");
-    }
-    if value.contains("pull request already exists") {
-        return Some("pull request already exists");
-    }
-    if value.contains("rate limit") {
-        return Some("rate limited");
-    }
-    if value.contains("resource not accessible by integration") {
-        return Some("resource not accessible by integration");
-    }
-    None
 }
 
 fn validate_api_output(output: Vec<u8>) -> Result<Vec<u8>, GitHubAuthorityError> {

--- a/zeroshot/src/native_v2_delivery/github/api/tests.rs
+++ b/zeroshot/src/native_v2_delivery/github/api/tests.rs
@@ -39,19 +39,20 @@ fn api_error_parser_preserves_bounded_provider_status_and_reason() {
 }
 "#,
     );
-    assert_eq!(
-        error,
-        GitHubAuthorityError::api(
-            Some(422),
-            concat!(
-                "HTTP 422: validation failed; PullRequest head invalid ",
-                "pull request head revision is not visible"
-            ),
-        )
-    );
+    assert!(error.to_string().contains("Head sha can't be blank"));
+    assert!(error.to_string().contains("Validation Failed (HTTP 422)"));
     assert!(error.retryable_review_sync());
 
     let unauthorized = GitHubAuthorityError::api(Some(401), "HTTP 401: Bad credentials");
     assert!(!unauthorized.retryable_review_sync());
     assert!(unauthorized.authentication_failed());
+}
+
+#[test]
+fn unfamiliar_errors_and_rate_limits_remain_repairable() {
+    let error = github_api_error(b"gh: unusual remote refusal (HTTP 403)\nPlease try again later.");
+    assert!(!error.authentication_failed());
+    assert!(error.retryable_review_sync());
+    assert!(error.to_string().contains("unusual remote refusal"));
+    assert!(error.to_string().contains("Please try again later."));
 }

--- a/zeroshot/src/native_v2_delivery/github/conflict.rs
+++ b/zeroshot/src/native_v2_delivery/github/conflict.rs
@@ -1,6 +1,5 @@
 use std::path::{Component, Path};
 use tokio::process::Command;
-use tokio::time::timeout;
 
 use super::*;
 
@@ -253,12 +252,11 @@ async fn bounded_exit_code(
     mut command: Command,
     deadline: Duration,
 ) -> Result<i32, GitHubAuthorityError> {
-    timeout(deadline, command.status())
-        .await
-        .map_err(|_| GitHubAuthorityError::Unavailable)?
-        .map_err(|_| GitHubAuthorityError::Unavailable)?
-        .code()
-        .ok_or(GitHubAuthorityError::Rejected)
+    let output = capture(&mut command, deadline).await?;
+    match output.exit_status {
+        Some(code @ (0 | 1)) => Ok(code),
+        _ => Err(output.into()),
+    }
 }
 
 #[cfg(test)]

--- a/zeroshot/src/native_v2_delivery/github/head.rs
+++ b/zeroshot/src/native_v2_delivery/github/head.rs
@@ -196,9 +196,7 @@ async fn adopt_local_head(
         &format!("https://github.com/{}.git", previous.repository),
         &updated.head_revision,
     ]);
-    bounded_status(fetch, context.authority.config.push_deadline)
-        .await
-        .map_err(|_| GitHubAuthorityError::Unavailable)?;
+    bounded_status(fetch, context.authority.config.push_deadline).await?;
     adopt_fetched_head(context, previous, updated).await
 }
 

--- a/zeroshot/src/native_v2_delivery/github/push.rs
+++ b/zeroshot/src/native_v2_delivery/github/push.rs
@@ -1,28 +1,16 @@
-use std::process::{ExitStatus, Stdio};
-use std::time::Duration;
-
-use tokio::io::{AsyncRead, AsyncReadExt};
-use tokio::process::{Child, ChildStderr, ChildStdout, Command};
-use tokio::time::timeout;
-
-use crate::native_v2_delivery::git_auth::encode_basic_credential;
-use crate::native_v2_target_authority::{MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES, NewOperatorDiagnostic};
+use crate::native_v2_delivery::command::{capture, GitCommandFailure};
+use crate::native_v2_target_authority::NewOperatorDiagnostic;
 
 use super::{
     GhCliDeliveryAuthority, GitHubAuthorityError, GitHubCredential, GitHubPushRequest,
     authenticated_git_command,
 };
 
-const REDACTED: &str = "[REDACTED]";
-const READ_BUFFER_BYTES: usize = 8 * 1024;
-
 pub(super) async fn push_branch(
     authority: &GhCliDeliveryAuthority,
     request: &GitHubPushRequest,
     credential: GitHubCredential<'_>,
 ) -> Result<(), GitHubAuthorityError> {
-    let basic_credential = encode_basic_credential(credential.expose());
-    let secrets = [credential.expose().as_bytes(), basic_credential.as_bytes()];
     let mut command = authenticated_git_command(&authority.config, &request.workspace, credential);
     command
         .arg("push")
@@ -32,252 +20,29 @@ pub(super) async fn push_branch(
             "https://github.com/{}.git",
             request.target.repository
         ))
-        .arg(format!("HEAD:refs/heads/{}", request.head_branch))
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    match capture(command, authority.config.push_deadline, &secrets).await {
-        Ok(()) => Ok(()),
+        .arg(format!("HEAD:refs/heads/{}", request.head_branch));
+    match capture(&mut command, authority.config.push_deadline)
+        .await
+        .and_then(GitCommandFailure::require_success)
+    {
+        Ok(_) => Ok(()),
         Err(failure) => {
-            authority.record_push_failure(failure.diagnostic);
-            Err(failure.error)
-        }
-    }
-}
-
-struct PushFailure {
-    error: GitHubAuthorityError,
-    diagnostic: CommandDiagnostic,
-}
-
-impl PushFailure {
-    fn unavailable(message: &str) -> Self {
-        Self {
-            error: GitHubAuthorityError::Unavailable,
-            diagnostic: CommandDiagnostic::message(message),
-        }
-    }
-}
-
-struct CommandDiagnostic {
-    exit_status: Option<i32>,
-    stdout: CapturedText,
-    stderr: CapturedText,
-}
-
-impl CommandDiagnostic {
-    fn message(message: &str) -> Self {
-        Self {
-            exit_status: None,
-            stdout: CapturedText::default(),
-            stderr: CapturedText {
-                text: message.to_owned(),
-                truncated: false,
-            },
-        }
-    }
-}
-
-#[derive(Default)]
-struct CapturedText {
-    text: String,
-    truncated: bool,
-}
-
-struct CapturedBytes {
-    bytes: Vec<u8>,
-    retain_bytes: usize,
-    truncated: bool,
-    read_failed: bool,
-}
-
-impl CapturedBytes {
-    fn new(retain_bytes: usize) -> Self {
-        Self {
-            bytes: Vec::with_capacity(retain_bytes),
-            retain_bytes,
-            truncated: false,
-            read_failed: false,
-        }
-    }
-}
-
-struct ChildOutputs {
-    stdout: ChildStdout,
-    stderr: ChildStderr,
-}
-
-struct CapturedStreams {
-    stdout: CapturedBytes,
-    stderr: CapturedBytes,
-}
-
-enum Termination {
-    Exited(ExitStatus),
-    TimedOut,
-    Unavailable,
-}
-
-async fn capture(
-    mut command: Command,
-    deadline: Duration,
-    secrets: &[&[u8]],
-) -> Result<(), PushFailure> {
-    let retain_bytes = MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES
-        .saturating_add(secrets.iter().map(|secret| secret.len()).max().unwrap_or(0));
-    let mut child = command
-        .spawn()
-        .map_err(|_| PushFailure::unavailable("git push could not be started"))?;
-    let outputs = match (child.stdout.take(), child.stderr.take()) {
-        (Some(stdout), Some(stderr)) => ChildOutputs { stdout, stderr },
-        _ => {
-            stop_child(&mut child);
-            return Err(PushFailure::unavailable(
-                "git push output capture was unavailable",
-            ));
-        }
-    };
-    let mut captured = CapturedStreams {
-        stdout: CapturedBytes::new(retain_bytes),
-        stderr: CapturedBytes::new(retain_bytes),
-    };
-    let termination = wait_for_capture(&mut child, outputs, &mut captured, deadline).await;
-    capture_result(termination, captured, secrets)
-}
-
-fn capture_result(
-    termination: Termination,
-    captured: CapturedStreams,
-    secrets: &[&[u8]],
-) -> Result<(), PushFailure> {
-    let diagnostic = CommandDiagnostic {
-        exit_status: match &termination {
-            Termination::Exited(status) => status.code(),
-            Termination::TimedOut | Termination::Unavailable => None,
-        },
-        stdout: sanitize_output(captured.stdout, secrets),
-        stderr: sanitize_output(captured.stderr, secrets),
-    };
-    match termination {
-        Termination::Exited(status) if status.success() => Ok(()),
-        Termination::Exited(_) => Err(PushFailure {
-            error: GitHubAuthorityError::Rejected,
-            diagnostic,
-        }),
-        Termination::TimedOut => Err(PushFailure {
-            error: GitHubAuthorityError::Unavailable,
-            diagnostic: with_context(diagnostic, "git push timed out"),
-        }),
-        Termination::Unavailable => Err(PushFailure {
-            error: GitHubAuthorityError::Unavailable,
-            diagnostic: with_context(diagnostic, "git push status was unavailable"),
-        }),
-    }
-}
-
-async fn wait_for_capture(
-    child: &mut Child,
-    mut outputs: ChildOutputs,
-    captured: &mut CapturedStreams,
-    deadline: Duration,
-) -> Termination {
-    let operation = async {
-        let (status, (), ()) = tokio::join!(
-            child.wait(),
-            drain_bounded(&mut outputs.stdout, &mut captured.stdout),
-            drain_bounded(&mut outputs.stderr, &mut captured.stderr),
-        );
-        status
-    };
-    match timeout(deadline, operation).await {
-        Ok(Ok(status)) => Termination::Exited(status),
-        Ok(Err(_)) => {
-            stop_child(child);
-            Termination::Unavailable
-        }
-        Err(_) => {
-            captured.stdout.truncated = true;
-            captured.stderr.truncated = true;
-            stop_child(child);
-            Termination::TimedOut
-        }
-    }
-}
-
-fn stop_child(child: &mut Child) {
-    let _ = child.start_kill();
-}
-
-async fn drain_bounded(reader: &mut (impl AsyncRead + Unpin), captured: &mut CapturedBytes) {
-    let mut buffer = [0_u8; READ_BUFFER_BYTES];
-    loop {
-        let read = match reader.read(&mut buffer).await {
-            Ok(0) => break,
-            Ok(read) => read,
-            Err(_) => {
-                captured.read_failed = true;
-                break;
+            authority.record_push_failure(&failure);
+            // A transport failure may follow an accepted push. Observe the exact remote ref before repair.
+            if authority
+                .confirm_pushed_head(request, credential)
+                .await
+                .is_ok()
+            {
+                return Ok(());
             }
-        };
-        let retained = captured
-            .retain_bytes
-            .saturating_sub(captured.bytes.len())
-            .min(read);
-        captured.bytes.extend_from_slice(&buffer[..retained]);
-        captured.truncated |= retained < read;
-    }
-}
-
-fn sanitize_output(mut captured: CapturedBytes, secrets: &[&[u8]]) -> CapturedText {
-    if captured.truncated || captured.read_failed {
-        trim_trailing_secret_prefix(&mut captured.bytes, secrets);
-    }
-    let mut text = String::from_utf8_lossy(&captured.bytes).into_owned();
-    for secret in secrets.iter().filter(|secret| !secret.is_empty()) {
-        if let Ok(secret) = std::str::from_utf8(secret) {
-            text = text.replace(secret, REDACTED);
+            Err(failure.into())
         }
     }
-    let truncated = captured.truncated || captured.read_failed;
-    let (text, text_truncated) = truncate_text(text);
-    CapturedText {
-        text,
-        truncated: truncated || text_truncated,
-    }
-}
-
-fn trim_trailing_secret_prefix(bytes: &mut Vec<u8>, secrets: &[&[u8]]) {
-    let trim = secrets
-        .iter()
-        .filter(|secret| !secret.is_empty() && !bytes.ends_with(secret))
-        .flat_map(|secret| (1..secret.len()).map(move |length| &secret[..length]))
-        .filter(|prefix| bytes.ends_with(prefix))
-        .map(<[u8]>::len)
-        .max()
-        .unwrap_or(0);
-    bytes.truncate(bytes.len().saturating_sub(trim));
-}
-
-fn truncate_text(mut text: String) -> (String, bool) {
-    if text.len() <= MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES {
-        return (text, false);
-    }
-    let mut boundary = MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES;
-    while !text.is_char_boundary(boundary) {
-        boundary = boundary.saturating_sub(1);
-    }
-    text.truncate(boundary);
-    (text, true)
-}
-
-fn with_context(mut diagnostic: CommandDiagnostic, context: &str) -> CommandDiagnostic {
-    if diagnostic.stderr.text.is_empty() {
-        diagnostic.stderr.text = context.to_owned();
-    }
-    diagnostic
 }
 
 impl GhCliDeliveryAuthority {
-    fn record_push_failure(&self, diagnostic: CommandDiagnostic) {
+    fn record_push_failure(&self, diagnostic: &GitCommandFailure) {
         let Some(reporter) = &self.operator_diagnostics else {
             return;
         };
@@ -286,10 +51,10 @@ impl GhCliDeliveryAuthority {
             code: "git_push_failed",
             operation: "delivery.git_push",
             exit_status: diagnostic.exit_status,
-            stdout: diagnostic.stdout.text,
-            stderr: diagnostic.stderr.text,
-            stdout_truncated: diagnostic.stdout.truncated,
-            stderr_truncated: diagnostic.stderr.truncated,
+            stdout: diagnostic.stdout.clone(),
+            stderr: diagnostic.stderr.clone(),
+            stdout_truncated: diagnostic.stdout_truncated,
+            stderr_truncated: diagnostic.stderr_truncated,
         });
     }
 }
@@ -297,6 +62,9 @@ impl GhCliDeliveryAuthority {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+    use crate::native_v2_target_authority::MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES;
+    const REDACTED: &str = "[REDACTED]";
 
     #[cfg(unix)]
     use std::fs;
@@ -305,7 +73,7 @@ mod tests {
     #[cfg(unix)]
     use std::sync::Arc;
     #[cfg(unix)]
-    use std::time::Instant;
+    use crate::native_v2_delivery::git_auth::encode_basic_credential;
 
     #[cfg(unix)]
     use openengine_cluster_protocol::RunId;
@@ -318,22 +86,6 @@ mod tests {
     use crate::native_v2_delivery::GhCliAuthorityConfig;
     #[cfg(unix)]
     use crate::native_v2_target_authority::OperatorDiagnosticStore;
-
-    #[test]
-    fn truncation_never_retains_a_partial_registered_secret() {
-        let secret = b"credential-value".as_slice();
-        let captured = CapturedBytes {
-            bytes: b"safe output\ncredential-val".to_vec(),
-            retain_bytes: MAX_OPERATOR_DIAGNOSTIC_TEXT_BYTES,
-            truncated: true,
-            read_failed: false,
-        };
-
-        let sanitized = sanitize_output(captured, &[secret]);
-
-        assert_eq!(sanitized.text, "safe output\n");
-        assert!(sanitized.truncated);
-    }
 
     #[cfg(unix)]
     #[tokio::test]
@@ -363,10 +115,10 @@ exit 17
         let token = "raw-github-token";
         let basic = encode_basic_credential(token);
 
-        assert_eq!(
+        assert!(matches!(
             push_branch(&authority, &request, GitHubCredential(token)).await,
-            Err(GitHubAuthorityError::Rejected)
-        );
+            Err(GitHubAuthorityError::Command(_))
+        ));
 
         let snapshot = store.snapshot(&run_id);
         assert_eq!(snapshot.diagnostics.len(), 1);
@@ -427,28 +179,36 @@ exit 17
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn capture_deadline_includes_drain_completion() {
+    async fn ambiguous_push_requires_an_exact_remote_head_observation() {
         let repository = TestGitRepository::delivery();
-        let program = executable(
-            repository.root.path(),
-            "inherited-pipe-git",
-            "#!/bin/sh\n(/usr/bin/sleep 2) &\nexit 17\n",
-        );
-        let mut command = Command::new(program);
-        command
-            .kill_on_drop(true)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        let started = Instant::now();
-
-        let failure = capture(command, Duration::from_millis(20), &[])
-            .await
-            .expect_err("inherited output pipes exceed the deadline");
-
-        assert_eq!(failure.error, GitHubAuthorityError::Unavailable);
-        assert!(started.elapsed() < Duration::from_secs(1));
-        assert!(failure.diagnostic.stdout.truncated);
-        assert!(failure.diagnostic.stderr.truncated);
+        let request = push_request(&repository);
+        for revision in [
+            &request.head_revision,
+            &"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
+        ] {
+            let body = serde_json::json!({
+                "ref": format!("refs/heads/{}", request.head_branch),
+                "object": { "type": "commit", "sha": revision }
+            });
+            let program = executable(
+                repository.root.path(),
+                "observed-head",
+                &format!("#!/bin/sh\nprintf '%s' '{}'\n", body),
+            );
+            let authority = GhCliDeliveryAuthority::new(GhCliAuthorityConfig {
+                git_program: "/usr/bin/false".into(),
+                gh_program: program,
+                home_directory: repository.root.path().to_owned(),
+                api_deadline: Duration::from_secs(1),
+                push_deadline: Duration::from_secs(1),
+            });
+            assert_eq!(
+                push_branch(&authority, &request, GitHubCredential("test-token"))
+                    .await
+                    .is_ok(),
+                revision == &request.head_revision
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/zeroshot/src/native_v2_delivery/tests.rs
+++ b/zeroshot/src/native_v2_delivery/tests.rs
@@ -395,16 +395,14 @@ async fn rewritten_history_is_rejected_before_push() {
 
     let outcome = run_delivery(&repo, authority.clone(), 2, DeliveryMode::Merge).await;
 
-    assert_eq!(
-        outcome,
-        WorkerOutcome::declared_failure(WorkerErrorCode::Crash)
-    );
+    assert_delivery_signal(&outcome, DELIVERY_REPAIR_REQUIRED_LABEL);
+    assert!(outcome_diagnostic(&outcome).contains("merge-base"));
     assert!(!authority.pushed.load(Ordering::SeqCst));
     assert!(authority.review_requests().is_empty());
 }
 
 #[tokio::test]
-async fn push_rejection_emits_a_short_safe_public_failure_line() {
+async fn unfamiliar_push_rejection_reaches_repair_before_a_pr_exists() {
     let repo = TempRepo::delivery();
     let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), Script::PushRejected));
 
@@ -420,15 +418,13 @@ async fn push_rejection_emits_a_short_safe_public_failure_line() {
     )
     .await;
 
-    assert_eq!(
-        execution.outcome,
-        WorkerOutcome::declared_failure(WorkerErrorCode::Crash)
-    );
+    assert_delivery_signal(&execution.outcome, DELIVERY_REPAIR_REQUIRED_LABEL);
+    assert!(outcome_diagnostic(&execution.outcome).contains("unfamiliar remote refusal"));
     assert!(
         execution
             .output
             .iter()
-            .any(|output| output.text == "delivery: Git push failed")
+            .all(|output| !output.text.contains("test-token"))
     );
 }
 
@@ -448,6 +444,8 @@ fn delivery_contract_rejects_the_other_modes_schema() {
 
 #[path = "tests/github_acceptance.rs"]
 mod github_acceptance;
+#[path = "tests/recovery.rs"]
+mod recovery;
 
 async fn run_delivery(
     repo: &TempRepo,
@@ -492,7 +490,6 @@ async fn run_delivery_execution(
     request: DeliveryRunRequest<'_>,
     authority: Arc<FakeGitHub>,
 ) -> DeliveryExecution {
-    let admitted = admitted(request.repo, request.mode).await;
     let config = NativeV2DeliveryConfig {
         workspace: request.repo.workspace.clone(),
         git_program: PathBuf::from("/usr/bin/git"),
@@ -500,6 +497,14 @@ async fn run_delivery_execution(
         poll: DeliveryPollPolicy::new(request.attempts, Duration::ZERO).assert_value(),
     };
     let adapter = Arc::new(NativeV2DeliveryAdapter::new(config, authority));
+    run_with_adapter(request, adapter).await
+}
+
+async fn run_with_adapter(
+    request: DeliveryRunRequest<'_>,
+    adapter: Arc<NativeV2DeliveryAdapter>,
+) -> DeliveryExecution {
+    let admitted = admitted(request.repo, request.mode).await;
     let runner = NativeNodeRunner::new(&admitted, adapter.clone(), adapter).assert_value();
     let binding = admitted
         .runtime
@@ -594,14 +599,7 @@ fn worker_ref(mode: DeliveryMode) -> &'static str {
 }
 
 fn delivery_node(mode: DeliveryMode) -> Value {
-    let labels: &[&str] = match mode {
-        DeliveryMode::PullRequest => &[DELIVERY_OPENED_LABEL],
-        DeliveryMode::MergeV1 | DeliveryMode::Merge => &[
-            DELIVERY_MERGED_LABEL,
-            DELIVERY_CONFLICT_LABEL,
-            DELIVERY_CI_FAILED_LABEL,
-        ],
-    };
+    let labels = delivery_signal_labels(mode).assert_value();
     json!({
         "kind":"verifier","name":"deliver","worker":worker_ref(mode),
         "input":{"kind":"null"},"output":delivery_result_schema(mode).assert_value(),

--- a/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_acceptance.rs
@@ -151,16 +151,10 @@ exit 1
         .await
         .assert_error_with("GitHub API rejection should be preserved");
 
-    assert_eq!(
-        error,
-        GitHubAuthorityError::api(
-            Some(422),
-            concat!(
-                "HTTP 422: validation failed; PullRequest head invalid ",
-                "pull request head revision is not visible"
-            ),
-        )
-    );
+    assert_eq!(error.api_status(), Some(422));
+    assert!(error.to_string().contains("Head sha can't be blank"));
+    assert!(error.to_string().contains("Validation Failed (HTTP 422)"));
+    assert!(error.to_string().contains("exitStatus: Some(1)"));
     assert!(error.retryable_review_sync());
     assert!(!error.to_string().contains("test-token"));
 }

--- a/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
+++ b/zeroshot/src/native_v2_delivery/tests/github_fixture.rs
@@ -13,6 +13,8 @@ use super::*;
 pub(super) enum Script {
     NoCi,
     PushRejected,
+    InspectFailed,
+    MergeFailed,
     CiFailed,
     Conflict,
     ConflictAtMerge,
@@ -21,6 +23,7 @@ pub(super) enum Script {
     DeferredMerge,
     StrictBehind,
     HeadAdoptionRace,
+    HeadAdoptionAfterRepair,
     HeadAdoptionRejected,
     HeadAdoptionUnavailable,
     RepeatedBehind,
@@ -67,7 +70,11 @@ impl FakeGitHub {
 
     fn review_state(&self, inspection: usize) -> GitHubReviewState {
         match self.script {
-            Script::NoCi | Script::CredentialExpires | Script::ReviewSyncRace => self.no_ci_state(),
+            Script::NoCi
+            | Script::CredentialExpires
+            | Script::ReviewSyncRace
+            | Script::InspectFailed
+            | Script::MergeFailed => self.no_ci_state(),
             Script::ReviewSyncCredentialExpires => self.no_ci_state(),
             Script::RegistrationRace => self.registration_race_state(inspection),
             Script::MultipleRegistrationWaves => self.multiple_registration_waves_state(inspection),
@@ -87,6 +94,7 @@ impl FakeGitHub {
             Script::DeferredMerge => self.no_ci_state(),
             Script::StrictBehind
             | Script::HeadAdoptionRace
+            | Script::HeadAdoptionAfterRepair
             | Script::HeadAdoptionRejected
             | Script::HeadAdoptionUnavailable
             | Script::RepeatedBehind => self.no_ci_state(),
@@ -227,7 +235,10 @@ impl GitHubDeliveryAuthority for FakeGitHub {
     ) -> Result<(), GitHubAuthorityError> {
         assert_eq!(credential.expose(), "test-token");
         if matches!(self.script, Script::PushRejected) {
-            return Err(GitHubAuthorityError::Rejected);
+            return Err(GitHubAuthorityError::api(
+                None,
+                "unfamiliar remote refusal: uploaded pack rejected",
+            ));
         }
         if !push_succeeded(request, &self.remote).await {
             return Err(GitHubAuthorityError::Rejected);
@@ -284,9 +295,15 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         review: &GitHubReviewReceipt,
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubReviewObservation, GitHubAuthorityError> {
+        if matches!(self.script, Script::InspectFailed) {
+            return Err(GitHubAuthorityError::api(
+                Some(503),
+                "remote inspection service returned an unfamiliar error",
+            ));
+        }
         let inspection = self.inspections.fetch_add(1, Ordering::SeqCst) + 1;
         if matches!(self.script, Script::CredentialExpires) && credential.expose() == "test-token" {
-            return Err(GitHubAuthorityError::Rejected);
+            return Err(GitHubAuthorityError::api(Some(401), "Bad credentials"));
         }
         let expected = if self.uses_refreshed_credential() {
             "refreshed-token"
@@ -303,6 +320,12 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         _review: &GitHubReviewReceipt,
         credential: GitHubCredential<'_>,
     ) -> Result<GitHubMergeRequestOutcome, GitHubAuthorityError> {
+        if matches!(self.script, Script::MergeFailed) {
+            return Err(GitHubAuthorityError::api(
+                None,
+                "remote merge service connection reset",
+            ));
+        }
         let expected = if self.uses_refreshed_credential() {
             "refreshed-token"
         } else {
@@ -318,6 +341,7 @@ impl GitHubDeliveryAuthority for FakeGitHub {
             self.script,
             Script::StrictBehind
                 | Script::HeadAdoptionRace
+                | Script::HeadAdoptionAfterRepair
                 | Script::HeadAdoptionRejected
                 | Script::HeadAdoptionUnavailable
         ) && updates == 0)
@@ -343,6 +367,7 @@ impl GitHubDeliveryAuthority for FakeGitHub {
             self.script,
             Script::StrictBehind
                 | Script::HeadAdoptionRace
+                | Script::HeadAdoptionAfterRepair
                 | Script::HeadAdoptionRejected
                 | Script::HeadAdoptionUnavailable
                 | Script::RepeatedBehind
@@ -395,16 +420,31 @@ impl GitHubDeliveryAuthority for FakeGitHub {
         self.head_updates.fetch_add(1, Ordering::SeqCst);
         let mut updated = review.clone();
         updated.head_revision = head_revision;
+        if matches!(self.script, Script::HeadAdoptionAfterRepair) {
+            git(workspace, &["reset", "--hard", &review.head_revision]);
+        }
         Ok(GitHubHeadUpdateOutcome::Updated(updated))
     }
 
     async fn synchronize_review_head(
         &self,
-        _request: GitHubHeadSynchronization<'_>,
+        request: GitHubHeadSynchronization<'_>,
         credential: GitHubCredential<'_>,
     ) -> Result<(), GitHubAuthorityError> {
         assert_eq!(credential.expose(), "test-token");
         let attempt = self.head_sync_attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        if matches!(self.script, Script::HeadAdoptionAfterRepair) {
+            if attempt == 1 {
+                return Err(GitHubAuthorityError::api(
+                    None,
+                    "local fetch failed before adoption",
+                ));
+            }
+            git(
+                request.workspace,
+                &["merge", "--ff-only", &request.updated.head_revision],
+            );
+        }
         if matches!(self.script, Script::HeadAdoptionRace) && attempt == 1 {
             return Err(GitHubAuthorityError::Unavailable);
         }

--- a/zeroshot/src/native_v2_delivery/tests/head_update.rs
+++ b/zeroshot/src/native_v2_delivery/tests/head_update.rs
@@ -22,31 +22,20 @@ async fn provider_receipt_survives_a_transient_local_adoption_failure() {
 }
 
 #[tokio::test]
-async fn permanent_local_adoption_rejection_fails_closed_without_retrying_cas() {
-    let (repo, authority) = delivery_harness(Script::HeadAdoptionRejected);
-
-    let outcome = run_delivery(&repo, authority.clone(), 3, DeliveryMode::Merge).await;
-
-    assert_eq!(
-        outcome,
-        WorkerOutcome::declared_failure(WorkerErrorCode::Crash)
-    );
-    assert_eq!(authority.head_updates.load(Ordering::SeqCst), 1);
-    assert_eq!(authority.head_sync_attempts.load(Ordering::SeqCst), 1);
-}
-
-#[tokio::test]
-async fn repeated_local_adoption_unavailability_is_bounded_without_retrying_cas() {
-    let (repo, authority) = delivery_harness(Script::HeadAdoptionUnavailable);
-
-    let outcome = run_delivery(&repo, authority.clone(), 3, DeliveryMode::Merge).await;
-
-    assert_eq!(
-        outcome,
-        WorkerOutcome::declared_failure(WorkerErrorCode::Crash)
-    );
-    assert_eq!(authority.head_updates.load(Ordering::SeqCst), 1);
-    assert_eq!(authority.head_sync_attempts.load(Ordering::SeqCst), 5);
+async fn failed_head_adoption_routes_repair_without_repeating_the_remote_mutation() {
+    for (script, expected_attempts) in [
+        (Script::HeadAdoptionRejected, 1),
+        (Script::HeadAdoptionUnavailable, 5),
+    ] {
+        let (repo, authority) = delivery_harness(script);
+        let outcome = run_delivery(&repo, authority.clone(), 3, DeliveryMode::Merge).await;
+        assert_delivery_signal(&outcome, DELIVERY_REPAIR_REQUIRED_LABEL);
+        assert_eq!(authority.head_updates.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            authority.head_sync_attempts.load(Ordering::SeqCst),
+            expected_attempts
+        );
+    }
 }
 
 async fn assert_head_updates(

--- a/zeroshot/src/native_v2_delivery/tests/recovery.rs
+++ b/zeroshot/src/native_v2_delivery/tests/recovery.rs
@@ -1,0 +1,149 @@
+use super::*;
+use openengine_cluster_protocol::NonEmptyEnumSet;
+
+#[tokio::test]
+async fn locked_index_provides_raw_git_feedback_and_can_recover() {
+    for mode in [DeliveryMode::PullRequest, DeliveryMode::Merge] {
+        let repo = TempRepo::delivery();
+        let lock = repo.workspace.join(".git/index.lock");
+        fs::write(&lock, "").assert_value();
+        let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), Script::NoCi));
+        let failure = run_delivery(&repo, authority.clone(), 3, mode).await;
+        let output = assert_delivery_signal(&failure, DELIVERY_REPAIR_REQUIRED_LABEL);
+        assert_eq!(output["pullRequestId"], "");
+        assert!(!authority.pushed.load(Ordering::SeqCst));
+        let diagnostic = outcome_diagnostic(&failure);
+        assert!(diagnostic.contains("index.lock"));
+        assert!(diagnostic.contains("exitStatus: Some(128)"));
+        assert!(diagnostic.contains("File exists"));
+        assert!(diagnostic.contains("baseRevision:"));
+        assert_receipt_match(output, mode, &repo, false);
+
+        // The repair worker removes this stale lock; delivery itself never manages user files.
+        fs::remove_file(lock).assert_value();
+        let completed = run_delivery(&repo, authority, 3, mode).await;
+        assert_delivery_signal(&completed, mode.success_outcome());
+    }
+}
+
+#[tokio::test]
+async fn repair_can_remove_tooling_from_unpublished_history_then_deliver() {
+    let repo = TempRepo::delivery();
+    let tools = repo.workspace.join(".tools");
+    fs::create_dir(&tools).assert_value();
+    fs::write(tools.join("downloaded-compiler"), "not part of the change").assert_value();
+    let rejected = Arc::new(FakeGitHub::new(repo.remote.clone(), Script::PushRejected));
+    let failure = run_delivery(&repo, rejected, 3, DeliveryMode::Merge).await;
+    assert_delivery_signal(&failure, DELIVERY_REPAIR_REQUIRED_LABEL);
+    assert!(
+        git_output(&repo.workspace, &["ls-tree", "-r", "--name-only", "HEAD"]).contains(".tools/")
+    );
+
+    // Simulate agent diagnosis: rewriting only unpublished history removes blobs from the push.
+    git(&repo.workspace, &["reset", "--mixed", &repo.base]);
+    fs::rename(&tools, repo.root.path().join("downloaded-tools")).assert_value();
+    let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), Script::NoCi));
+    let completed = run_delivery(&repo, authority, 3, DeliveryMode::Merge).await;
+    let output = assert_delivery_signal(&completed, DELIVERY_MERGED_LABEL);
+    let revision = output["headRevision"].as_str().assert_value();
+    let published = git_output(&repo.remote, &["rev-list", "--objects", revision]);
+    assert!(!published.contains(".tools"));
+    assert!(published.contains("result.txt"));
+}
+
+#[tokio::test]
+async fn legacy_response_contract_keeps_receipt_validation_without_repair_opt_in() {
+    for mode in [
+        DeliveryMode::PullRequest,
+        DeliveryMode::MergeV1,
+        DeliveryMode::Merge,
+    ] {
+        // Work with the typed schema so the optional capability cannot alter any other field.
+        let mut output = delivery_result_schema(mode).assert_value();
+        if let openengine_cluster_protocol::PayloadType::Record { fields } = &mut output {
+            let field = fields
+                .get_mut(&FieldName::new("outcome").assert_value())
+                .assert_value();
+            if let openengine_cluster_protocol::PayloadType::Enum { values } = &mut field.value_type
+            {
+                *values = NonEmptyEnumSet::new(
+                    values
+                        .values()
+                        .iter()
+                        .filter(|v| v.as_str() != DELIVERY_REPAIR_REQUIRED_LABEL)
+                        .cloned()
+                        .collect(),
+                )
+                .assert_value();
+            }
+        }
+        let labels = delivery_signal_labels(mode).assert_value();
+        let response = NodeResponseContract::Verifier {
+            output,
+            signals: BTreeMap::from([(
+                FieldName::new(DELIVERY_SIGNAL_FIELD).assert_value(),
+                NonEmptyEnumSet::new(
+                    labels
+                        .values()
+                        .iter()
+                        .filter(|v| v.as_str() != DELIVERY_REPAIR_REQUIRED_LABEL)
+                        .cloned()
+                        .collect(),
+                )
+                .assert_value(),
+            )]),
+            diagnostic: delivery_diagnostic_schema().assert_value(),
+        };
+        validate_delivery_contract(mode, &response).assert_value();
+        assert!(!contract::supports_repair(&response));
+    }
+}
+
+#[tokio::test]
+async fn later_delivery_errors_preserve_the_existing_review_in_repair_feedback() {
+    for script in [Script::InspectFailed, Script::MergeFailed] {
+        let repo = TempRepo::delivery();
+        let authority = Arc::new(FakeGitHub::new(repo.remote.clone(), script));
+        let outcome = run_delivery(&repo, authority, 3, DeliveryMode::Merge).await;
+        let output = assert_delivery_signal(&outcome, DELIVERY_REPAIR_REQUIRED_LABEL);
+        assert!(!output["pullRequestId"].as_str().assert_value().is_empty());
+        assert!(!output["headRevision"].as_str().assert_value().is_empty());
+        assert!(outcome_diagnostic(&outcome).contains("remote"));
+        assert_receipt_match(output, DeliveryMode::Merge, &repo, false);
+    }
+}
+
+#[tokio::test]
+async fn repair_retry_resumes_the_authorized_remote_head_before_pushing() {
+    let repo = TempRepo::delivery();
+    let authority = Arc::new(FakeGitHub::new(
+        repo.remote.clone(),
+        Script::HeadAdoptionAfterRepair,
+    ));
+    let adapter = Arc::new(NativeV2DeliveryAdapter::new(
+        NativeV2DeliveryConfig {
+            workspace: repo.workspace.clone(),
+            git_program: "/usr/bin/git".into(),
+            target: target(&repo),
+            poll: DeliveryPollPolicy::new(3, Duration::ZERO).assert_value(),
+        },
+        authority.clone(),
+    ));
+    let request = || DeliveryRunRequest {
+        repo: &repo,
+        attempts: 3,
+        mode: DeliveryMode::Merge,
+        run_id: "resume-authorized-head",
+        refresh: None,
+    };
+    let failure = run_with_adapter(request(), adapter.clone()).await.outcome;
+    let output = assert_delivery_signal(&failure, DELIVERY_REPAIR_REQUIRED_LABEL);
+    assert_ne!(
+        git_output(&repo.workspace, &["rev-parse", "HEAD"]),
+        output["headRevision"].as_str().assert_value()
+    );
+    let success = run_with_adapter(request(), adapter).await.outcome;
+    assert_delivery_signal(&success, DELIVERY_MERGED_LABEL);
+    assert_eq!(authority.head_updates.load(Ordering::SeqCst), 1);
+    assert_eq!(authority.head_sync_attempts.load(Ordering::SeqCst), 2);
+}

--- a/zeroshot/src/native_v2_hosting/allocator.rs
+++ b/zeroshot/src/native_v2_hosting/allocator.rs
@@ -130,7 +130,10 @@ impl ProductionCapsuleAllocator {
             github_token,
         })
         .await
-        .map_err(|_| CapsuleAllocationUnavailable::SourceCheckout)?;
+        .map_err(|error| {
+            error.record_diagnostic(run_id, &self.config.operator_diagnostics);
+            CapsuleAllocationUnavailable::SourceCheckout
+        })?;
         let github_config = GhCliAuthorityConfig {
             git_program: self.config.git_program.clone(),
             gh_program: self.config.gh_program.clone(),

--- a/zeroshot/src/native_v2_hosting/repository.rs
+++ b/zeroshot/src/native_v2_hosting/repository.rs
@@ -1,13 +1,17 @@
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
-use std::process::Stdio;
 use std::time::Duration;
 
+use openengine_cluster_protocol::RunId;
+
 use tokio::process::Command;
-use tokio::time::timeout;
+use tokio::time::Instant;
 
 use crate::execution::process::{HostedProcessPool, HostedProcessScope};
 use crate::native_v2_delivery::DeliveryTarget;
+use crate::native_v2_delivery::command::{GitCommandFailure, capture, local_git_command};
+use crate::native_v2_portable_controller::WorkspaceIdentity;
+use crate::native_v2_target_authority::{NewOperatorDiagnostic, OperatorDiagnosticStore};
 use crate::native_v2_delivery::git_auth::encode_basic_credential;
 use crate::native_v2_contract::ResolvedSource;
 
@@ -15,7 +19,8 @@ use crate::native_v2_contract::ResolvedSource;
 mod tests;
 
 const GIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
-const MAX_GIT_OUTPUT_BYTES: usize = 4_096;
+const MAX_CHECKOUT_ATTEMPTS: u32 = 3;
+const CHECKOUT_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub(super) struct RepositoryInstall<'a> {
     pub git_program: &'a Path,
@@ -29,19 +34,64 @@ pub(super) struct RepositoryInstall<'a> {
 pub(super) async fn install_repository(
     request: RepositoryInstall<'_>,
 ) -> Result<DeliveryTarget, RepositoryInstallError> {
+    install_before_deadline(request, Instant::now() + GIT_TIMEOUT, CHECKOUT_RETRY_DELAY).await
+}
+
+async fn install_before_deadline(
+    request: RepositoryInstall<'_>,
+    deadline: Instant,
+    retry_delay: Duration,
+) -> Result<DeliveryTarget, RepositoryInstallError> {
+    let identity = pristine_workspace(request.workspace)?;
     let writer = request
         .process_pool
         .identity(HostedProcessScope::Writer)
-        .map_err(|_| RepositoryInstallError)?;
+        .map_err(|_| RepositoryInstallError::Workspace("writer identity is unavailable"))?;
     let git = GitProcess {
         program: request.git_program,
         token: request.github_token,
         uid: writer.uid(),
         gid: writer.gid(),
+        deadline,
     };
-    initialize_repository(&git, &request).await?;
-    fetch_source(&git, request.workspace, request.resolved).await?;
-    checkout_revision(&git, request.workspace, request.resolved.revision.as_str()).await?;
+    let mut previous_failure = None;
+    for attempt in 1..=MAX_CHECKOUT_ATTEMPTS {
+        let error = match install_once(&git, &request).await {
+            Ok(target) => return Ok(target),
+            Err(RepositoryInstallError::Deadline) => {
+                return Err(previous_failure.unwrap_or(RepositoryInstallError::Deadline));
+            }
+            Err(error) => error,
+        };
+        if !error.permits_retry(
+            attempt,
+            deadline.saturating_duration_since(Instant::now()),
+            retry_delay,
+        ) {
+            return Err(error);
+        }
+        tokio::time::sleep(retry_delay).await;
+        if Instant::now() >= deadline {
+            return Err(error);
+        }
+        if let Err(cleanup) = reset_workspace(request.workspace, &identity, deadline) {
+            return Err(RepositoryInstallError::Recovery {
+                failure: Box::new(error),
+                message: cleanup.to_string(),
+            });
+        }
+        previous_failure = Some(error);
+    }
+    unreachable!("checkout returns on success or the final attempt")
+}
+
+async fn install_once(
+    git: &GitProcess<'_>,
+    request: &RepositoryInstall<'_>,
+) -> Result<DeliveryTarget, RepositoryInstallError> {
+    initialize_repository(git, request).await?;
+    fetch_source(git, request.workspace, request.resolved).await?;
+    checkout_revision(git, request.workspace, request.resolved.revision.as_str()).await?;
     let revision = git
         .capture(
             request.workspace,
@@ -49,14 +99,64 @@ pub(super) async fn install_repository(
         )
         .await?;
     if revision.trim() != request.resolved.revision.as_str() {
-        return Err(RepositoryInstallError);
+        return Err(RepositoryInstallError::RevisionMismatch {
+            expected: request.resolved.revision.as_str().to_owned(),
+            observed: revision.trim().to_owned(),
+        });
     }
     DeliveryTarget::new(
         request.resolved.repository.as_str(),
         request.resolved.branch.as_str(),
         revision.trim(),
     )
-    .map_err(|_| RepositoryInstallError)
+    .map_err(|_| RepositoryInstallError::Workspace("resolved delivery target is invalid"))
+}
+
+fn pristine_workspace(workspace: &Path) -> Result<WorkspaceIdentity, RepositoryInstallError> {
+    let identity = WorkspaceIdentity::capture(workspace)
+        .map_err(|_| RepositoryInstallError::Workspace("staging directory is unavailable"))?;
+    if std::fs::read_dir(workspace)?.next().transpose()?.is_some() {
+        return Err(RepositoryInstallError::Workspace(
+            "staging directory is not empty",
+        ));
+    }
+    Ok(identity)
+}
+
+fn reset_workspace(
+    workspace: &Path,
+    identity: &WorkspaceIdentity,
+    deadline: Instant,
+) -> Result<(), RepositoryInstallError> {
+    check_deadline(deadline)?;
+    if !identity.is_current(workspace) {
+        return Err(RepositoryInstallError::Workspace(
+            "staging directory was replaced",
+        ));
+    }
+    // No agent has run yet. Keep the admitted directory inode and permissions, removing only
+    // entries from this fresh checkout. Neither file_type nor remove_dir_all follows symlinks.
+    for entry in std::fs::read_dir(workspace)? {
+        check_deadline(deadline)?;
+        remove_checkout_entry(entry?)?;
+    }
+    check_deadline(deadline)
+}
+
+fn remove_checkout_entry(entry: std::fs::DirEntry) -> Result<(), std::io::Error> {
+    if entry.file_type()?.is_dir() {
+        std::fs::remove_dir_all(entry.path())
+    } else {
+        std::fs::remove_file(entry.path())
+    }
+}
+
+fn check_deadline(deadline: Instant) -> Result<(), RepositoryInstallError> {
+    if Instant::now() >= deadline {
+        Err(RepositoryInstallError::Deadline)
+    } else {
+        Ok(())
+    }
 }
 
 async fn initialize_repository(
@@ -128,6 +228,7 @@ struct GitProcess<'a> {
     token: Option<&'a str>,
     uid: u32,
     gid: u32,
+    deadline: Instant,
 }
 
 impl GitProcess<'_> {
@@ -136,12 +237,7 @@ impl GitProcess<'_> {
         workspace: Option<&Path>,
         arguments: &[OsString],
     ) -> Result<(), RepositoryInstallError> {
-        let mut command = self.command(workspace, arguments);
-        let status = timeout(GIT_TIMEOUT, command.status())
-            .await
-            .map_err(|_| RepositoryInstallError)?
-            .map_err(|_| RepositoryInstallError)?;
-        status.success().then_some(()).ok_or(RepositoryInstallError)
+        self.capture_at(workspace, arguments).await.map(|_| ())
     }
 
     async fn capture(
@@ -149,58 +245,39 @@ impl GitProcess<'_> {
         workspace: &Path,
         arguments: &[OsString],
     ) -> Result<String, RepositoryInstallError> {
-        self.capture_at(Some(workspace), arguments).await
+        self.capture_at(Some(workspace), arguments)
+            .await
+            .map(|output| output.stdout)
     }
 
     async fn capture_at(
         &self,
         workspace: Option<&Path>,
         arguments: &[OsString],
-    ) -> Result<String, RepositoryInstallError> {
-        let mut command = self.command(workspace, arguments);
-        command.stdout(Stdio::piped());
-        let output = timeout(GIT_TIMEOUT, command.output())
-            .await
-            .map_err(|_| RepositoryInstallError)?
-            .map_err(|_| RepositoryInstallError)?;
-        if !output.status.success() || output.stdout.len() > MAX_GIT_OUTPUT_BYTES {
-            return Err(RepositoryInstallError);
+    ) -> Result<GitCommandFailure, RepositoryInstallError> {
+        let remaining = self.deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(RepositoryInstallError::Deadline);
         }
-        String::from_utf8(output.stdout).map_err(|_| RepositoryInstallError)
+        let mut command = self.command(workspace, arguments);
+        capture(&mut command, remaining)
+            .await
+            .and_then(GitCommandFailure::require_success)
+            .map_err(|error| RepositoryInstallError::Git(Box::new(error)))
     }
 
     fn command(&self, workspace: Option<&Path>, arguments: &[OsString]) -> Command {
-        let mut command = Command::new(self.program);
-        command
-            // Hosted identities must not inherit a launcher cwd they cannot traverse. Every Git
-            // effect below already uses an explicit source, destination, or `-C` workspace.
-            .current_dir(Path::new("/"))
-            .kill_on_drop(true)
-            .env_clear()
-            .env("LANG", "C")
-            .env("GIT_CONFIG_NOSYSTEM", "1")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_TERMINAL_PROMPT", "0")
-            // Checkout and the agent share a UID. Detached maintenance can leave an orphan
-            // under that UID after Git exits, preventing the agent's containment registration.
-            .arg("-c")
-            .arg("maintenance.autoDetach=false")
-            .arg("-c")
-            .arg("core.hooksPath=/dev/null");
+        let mut command = local_git_command(self.program, workspace.unwrap_or(Path::new("/")));
+        // Hosted identities cannot inherit a launcher cwd they cannot traverse.
+        command.current_dir("/");
         if let Some(token) = self.token {
-            command.arg("-c").arg(format!(
+            // This environment exists only for trusted checkout and the shared redactor.
+            command.env("GH_TOKEN", token).arg("-c").arg(format!(
                 "http.https://github.com/.extraheader=AUTHORIZATION: basic {}",
                 encode_basic_credential(token)
             ));
         }
-        if let Some(workspace) = workspace {
-            command.arg("-C").arg(workspace);
-        }
-        command
-            .args(arguments)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+        command.args(arguments);
         configure_identity(&mut command, self.uid, self.gid);
         command
     }
@@ -216,9 +293,62 @@ fn configure_identity(command: &mut Command, uid: u32, gid: u32) {
 #[cfg(not(target_os = "linux"))]
 fn configure_identity(_command: &mut Command, _uid: u32, _gid: u32) {}
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
-#[error("repository checkout could not be installed")]
-pub(super) struct RepositoryInstallError;
+#[derive(Debug, thiserror::Error)]
+pub(super) enum RepositoryInstallError {
+    #[error("Git checkout command failed: {0}")]
+    Git(Box<GitCommandFailure>),
+    #[error("checkout workspace is unavailable: {0}")]
+    Workspace(&'static str),
+    #[error("checkout workspace could not be prepared: {0}")]
+    Filesystem(#[from] std::io::Error),
+    #[error("checkout revision mismatch: expected {expected}, observed {observed}")]
+    RevisionMismatch { expected: String, observed: String },
+    #[error("repository checkout exceeded its total deadline")]
+    Deadline,
+    #[error("{failure}\nCheckout recovery failed: {message}")]
+    Recovery { failure: Box<Self>, message: String },
+}
+
+impl RepositoryInstallError {
+    fn permits_retry(&self, attempt: u32, remaining: Duration, delay: Duration) -> bool {
+        attempt < MAX_CHECKOUT_ATTEMPTS && matches!(self, Self::Git(_)) && remaining > delay
+    }
+
+    fn git_failure(&self) -> Option<&GitCommandFailure> {
+        match self {
+            Self::Git(error) => Some(error),
+            Self::Recovery { failure, .. } => failure.git_failure(),
+            _ => None,
+        }
+    }
+
+    fn operator_stderr(&self) -> String {
+        match self {
+            Self::Git(error) => error.operator_stderr(),
+            Self::Recovery { failure, message } => {
+                format!(
+                    "Checkout recovery failed: {message}\n{}",
+                    failure.operator_stderr()
+                )
+            }
+            _ => self.to_string(),
+        }
+    }
+
+    pub(super) fn record_diagnostic(&self, run_id: &RunId, store: &OperatorDiagnosticStore) {
+        let git = self.git_failure();
+        store.record(NewOperatorDiagnostic {
+            run_id: run_id.clone(),
+            code: "git_checkout_failed",
+            operation: "source.checkout",
+            exit_status: git.and_then(|error| error.exit_status),
+            stdout: git.map_or_else(String::new, |error| error.stdout.clone()),
+            stderr: self.operator_stderr(),
+            stdout_truncated: git.is_some_and(|error| error.stdout_truncated),
+            stderr_truncated: git.is_some_and(|error| error.stderr_truncated),
+        });
+    }
+}
 
 #[cfg(test)]
 pub(super) fn path_source(path: &Path) -> OsString {

--- a/zeroshot/src/native_v2_hosting/repository/tests.rs
+++ b/zeroshot/src/native_v2_hosting/repository/tests.rs
@@ -1,4 +1,4 @@
-use openengine_cluster_testkit::assertions::AssertValue;
+use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
 use serde_json::Value;
 
 use super::*;
@@ -16,6 +16,7 @@ async fn fetch_waits_for_automatic_maintenance() {
         token: None,
         uid: unsafe { libc::geteuid() },
         gid: unsafe { libc::getegid() },
+        deadline: Instant::now() + GIT_TIMEOUT,
     };
     let seed = root.child("seed");
     let workspace = root.child("workspace");
@@ -102,4 +103,134 @@ async fn fetch_waits_for_automatic_maintenance() {
         assert!(args.iter().any(|arg| arg == "--no-detach"), "{event}");
         assert!(!args.iter().any(|arg| arg == "--detach"), "{event}");
     }
+}
+
+#[test]
+fn checkout_cleanup_rejects_nonempty_or_replaced_staging() {
+    let root = TestDirectory::new("checkout-staging-identity");
+    let workspace = root.child("workspace");
+    let external = root.child("external");
+    std::fs::create_dir(&workspace).assert_value();
+    std::fs::create_dir(&external).assert_value();
+    std::fs::write(external.join("keep"), "user-owned").assert_value();
+    let identity = pristine_workspace(&workspace).assert_value();
+    std::fs::write(workspace.join("existing"), "installed files").assert_value();
+    assert!(pristine_workspace(&workspace).is_err());
+    assert_eq!(root.read("workspace/existing"), "installed files");
+
+    std::fs::rename(&workspace, root.child("original")).assert_value();
+    std::os::unix::fs::symlink(&external, &workspace).assert_value();
+    assert!(reset_workspace(&workspace, &identity, Instant::now() + GIT_TIMEOUT).is_err());
+    assert_eq!(root.read("external/keep"), "user-owned");
+}
+
+#[tokio::test]
+async fn checkout_commands_share_one_deadline_and_retain_timeout_output() {
+    let root = TestDirectory::new("checkout-total-deadline");
+    let program = root.write_executable(
+        "git-slow",
+        "#!/bin/sh\n/usr/bin/printf 'checkout progress\n' >&2\n/usr/bin/sleep 0.2\n",
+    );
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let git = GitProcess {
+        program: &program,
+        token: None,
+        uid: unsafe { libc::geteuid() },
+        gid: unsafe { libc::getegid() },
+        deadline,
+    };
+    git.run(None, &[]).await.assert_value();
+    tokio::time::sleep_until(deadline - Duration::from_millis(100)).await;
+    let error = git.run(None, &[]).await.assert_error();
+    let RepositoryInstallError::Git(failure) = error else {
+        panic!("expected captured Git timeout");
+    };
+    assert!(failure.stderr.contains("checkout progress"));
+    assert!(failure.to_string().contains("timed out"));
+    assert!(failure.stderr_truncated);
+    let error = RepositoryInstallError::Recovery {
+        failure: Box::new(RepositoryInstallError::Git(failure)),
+        message: "staging directory was replaced".to_owned(),
+    };
+    let run_id = RunId::new("checkout-timeout-cleanup");
+    let diagnostics = OperatorDiagnosticStore::default();
+    error.record_diagnostic(&run_id, &diagnostics);
+    let snapshot = diagnostics.snapshot(&run_id);
+    assert!(snapshot.diagnostics[0].stderr.contains("checkout progress"));
+    assert!(
+        snapshot.diagnostics[0]
+            .stderr
+            .contains("staging directory was replaced")
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn cancelling_checkout_kills_git_and_its_helper_processes() {
+    let root = TestDirectory::new("checkout-cancellation");
+    let program = root.write_executable(
+        "git-hanging",
+        "#!/bin/sh\n/usr/bin/sleep 30 &\nchild=$!\n/usr/bin/printf '%s' \"$child\" > \"$0.pid\"\nwait\n",
+    );
+    let pid_path = root.child("git-hanging.pid");
+    let capture = tokio::spawn(async move {
+        GitProcess {
+            program: &program,
+            token: None,
+            uid: unsafe { libc::geteuid() },
+            gid: unsafe { libc::getegid() },
+            deadline: Instant::now() + GIT_TIMEOUT,
+        }
+        .run(None, &[])
+        .await
+    });
+    let pid: u32 = poll_until(|| std::fs::read_to_string(&pid_path).ok()?.parse().ok()).await;
+    capture.abort();
+    assert!(capture.await.assert_error().is_cancelled());
+    poll_until(|| {
+        let running = std::fs::read_to_string(format!("/proc/{pid}/stat"))
+            .ok()
+            .and_then(|stat| {
+                stat.rsplit_once(") ")
+                    .map(|(_, fields)| fields.starts_with('Z'))
+            })
+            .is_some_and(|zombie| !zombie);
+        (!running).then_some(())
+    })
+    .await;
+}
+
+#[cfg(target_os = "linux")]
+async fn poll_until<T>(mut read: impl FnMut() -> Option<T>) -> T {
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if let Some(value) = read() {
+                return value;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .assert_value_with("checkout process did not reach the expected state")
+}
+
+#[test]
+fn cleanup_stops_at_the_original_deadline() {
+    let root = TestDirectory::new("checkout-cleanup-deadline");
+    let workspace = root.child("workspace");
+    std::fs::create_dir(&workspace).assert_value();
+    let identity = pristine_workspace(&workspace).assert_value();
+    for index in 0..5000 {
+        std::fs::write(workspace.join(index.to_string()), "partial checkout").assert_value();
+    }
+    let deadline = Instant::now() + Duration::from_millis(1);
+    let error = reset_workspace(&workspace, &identity, deadline).assert_error();
+    assert!(matches!(error, RepositoryInstallError::Deadline));
+    assert!(
+        std::fs::read_dir(&workspace)
+            .assert_value()
+            .next()
+            .is_some()
+    );
+    assert!(identity.is_current(&workspace));
 }

--- a/zeroshot/src/native_v2_hosting/tests.rs
+++ b/zeroshot/src/native_v2_hosting/tests.rs
@@ -25,6 +25,7 @@ use crate::native_v2_target_authority::TargetAuthorityErrorKind;
 use super::allocator::{ProductionCapsuleAllocator, monitor_workspace_identity};
 use super::repository::{RepositoryInstall, install_repository, path_source};
 
+mod checkout;
 mod fixtures;
 
 use fixtures::*;

--- a/zeroshot/src/native_v2_hosting/tests/checkout.rs
+++ b/zeroshot/src/native_v2_hosting/tests/checkout.rs
@@ -1,0 +1,199 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::native_v2_cloud::{AllocatedCapsule, CapsuleAllocationUnavailable};
+use crate::native_v2_delivery::git_auth::encode_basic_credential;
+use crate::native_v2_target_authority::OperatorDiagnosticStore;
+
+const CHECKOUT_TOKEN: &str = "checkout-secret";
+
+struct CheckoutFixture {
+    _repository: RepositoryFixture,
+    root: TestDirectory,
+    allocator: ProductionCapsuleAllocator,
+    admitted: native_v2_contract::AdmittedRun,
+    diagnostics: Arc<OperatorDiagnosticStore>,
+    run_id: RunId,
+}
+
+impl CheckoutFixture {
+    async fn new(body: &str) -> Self {
+        let repository = RepositoryFixture::new();
+        let root = TestDirectory::new("checkout-recovery");
+        prepare_storage_root(&root.path().to_owned()).assert_value();
+        let script = format!(
+            r#"#!/bin/sh
+set -eu
+previous=
+workspace=/
+for argument do
+  if [ "$previous" = -C ]; then workspace=$argument; fi
+  previous=$argument
+done
+case " $* " in
+  *" fetch "*) /usr/bin/printf x >> "$0.attempts" ;;
+esac
+{body}
+exec /usr/bin/git "$@"
+"#
+        );
+        let program = root.write_executable("git-script", &script);
+        let attempts = root.write("git-script.attempts", "");
+        fs::set_permissions(attempts, fs::Permissions::from_mode(0o666)).assert_value();
+        let external = root.child("git-script.external");
+        fs::create_dir(&external).assert_value();
+        fs::write(external.join("keep"), "outside checkout").assert_value();
+        let mut config = capsule_config(root.path().to_owned());
+        config.git_program = program;
+        let diagnostics = config.operator_diagnostics.clone();
+        let allocator = ProductionCapsuleAllocator::new(config)
+            .assert_value()
+            .with_test_filesystem_and_source(repository.remote.clone(), portable_filesystem);
+        let admitted = admit(submission(
+            runtime(BTreeSet::new()),
+            &repository.main_revision,
+            "checkout-recovery",
+        ))
+        .await;
+        Self {
+            _repository: repository,
+            root,
+            allocator,
+            admitted,
+            diagnostics,
+            run_id: RunId::new("checkout-recovery"),
+        }
+    }
+
+    async fn allocate(&self) -> Result<AllocatedCapsule, CapsuleAllocationUnavailable> {
+        self.allocator
+            .allocate(&self.run_id, &self.admitted, Some(CHECKOUT_TOKEN))
+            .await
+    }
+}
+
+#[tokio::test]
+async fn transient_fetch_failure_recovers_in_the_same_allocation_at_the_exact_revision() {
+    let fixture = CheckoutFixture::new(
+        r#"case " $* " in
+  *" fetch "*)
+    if [ "$(/usr/bin/cat "$0.attempts")" = x ]; then
+      /usr/bin/git "$@"
+      /usr/bin/mkdir "$workspace/partial"
+      /usr/bin/ln -s "$0.external" "$workspace/partial/external"
+      /usr/bin/printf stale > "$workspace/.git/index.lock"
+      /usr/bin/printf 'temporary remote disconnect\n' >&2
+      exit 42
+    fi ;;
+esac"#,
+    )
+    .await;
+    let capsule = fixture.allocate().await.assert_value();
+    let workspace = fixture
+        .allocator
+        .run_path(&fixture.run_id)
+        .join("workspace");
+    let head = std::process::Command::new("/usr/bin/git")
+        .arg("-C")
+        .arg(&workspace)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .assert_value();
+    assert!(head.status.success());
+    assert_eq!(
+        String::from_utf8(head.stdout).assert_value().trim(),
+        fixture.admitted.source.revision.as_str()
+    );
+    assert_eq!(fixture.root.read("git-script.attempts"), "xx");
+    assert!(!workspace.join("partial").exists());
+    assert!(!workspace.join(".git/index.lock").exists());
+    assert_eq!(
+        fixture.root.read("git-script.external/keep"),
+        "outside checkout"
+    );
+    assert!(
+        fixture
+            .diagnostics
+            .snapshot(&fixture.run_id)
+            .diagnostics
+            .is_empty()
+    );
+    capsule
+        .cleanup
+        .destroy_or_confirm_absent(RunRuntimeExit::Completed)
+        .await
+        .assert_value();
+}
+
+#[tokio::test]
+async fn exhausted_checkout_preserves_redacted_operator_diagnostics() {
+    let fixture = CheckoutFixture::new(
+        r#"case " $* " in
+  *" fetch "*)
+    /usr/bin/printf 'upstream status body\n'
+    /usr/bin/printf '%05000d\n' 0
+    /usr/bin/printf 'unfamiliar fetch failure: %s\n%s\n' "$GH_TOKEN" "$*" >&2
+    exit 42 ;;
+esac"#,
+    )
+    .await;
+    assert!(matches!(
+        fixture.allocate().await,
+        Err(CapsuleAllocationUnavailable::SourceCheckout)
+    ));
+    assert_eq!(fixture.root.read("git-script.attempts"), "xxx");
+    let snapshot = fixture.diagnostics.snapshot(&fixture.run_id);
+    assert_eq!(snapshot.diagnostics.len(), 1);
+    let diagnostic = &snapshot.diagnostics[0];
+    assert_eq!(diagnostic.operation, "source.checkout");
+    assert_eq!(diagnostic.exit_status, Some(42));
+    assert!(diagnostic.stdout.starts_with("upstream status body\n"));
+    assert!(diagnostic.stdout_truncated);
+    assert!(!diagnostic.stderr.contains("upstream status body"));
+    assert!(
+        diagnostic
+            .stderr
+            .contains("unfamiliar fetch failure: [REDACTED]")
+    );
+    assert!(diagnostic.stderr.contains("fetch"));
+    assert!(!diagnostic.stderr.contains(CHECKOUT_TOKEN));
+    assert!(
+        !diagnostic
+            .stderr
+            .contains(&encode_basic_credential(CHECKOUT_TOKEN))
+    );
+    assert!(!fixture.allocator.run_path(&fixture.run_id).exists());
+    assert_eq!(
+        fixture.root.read("git-script.external/keep"),
+        "outside checkout"
+    );
+    assert!(matches!(
+        fixture.allocate().await,
+        Err(CapsuleAllocationUnavailable::Runtime)
+    ));
+}
+
+#[tokio::test]
+async fn wrong_checkout_revision_never_exposes_a_runner() {
+    let fixture = CheckoutFixture::new(
+        r#"case " $* " in
+  *" rev-parse HEAD "*)
+    /usr/bin/printf '0000000000000000000000000000000000000000\n'
+    exit 0 ;;
+esac"#,
+    )
+    .await;
+    assert!(matches!(
+        fixture.allocate().await,
+        Err(CapsuleAllocationUnavailable::SourceCheckout)
+    ));
+    assert_eq!(fixture.root.read("git-script.attempts"), "x");
+    let diagnostics = fixture.diagnostics.snapshot(&fixture.run_id).diagnostics;
+    assert!(diagnostics[0].stderr.contains("checkout revision mismatch"));
+    assert!(
+        diagnostics[0]
+            .stderr
+            .contains(fixture.admitted.source.revision.as_str())
+    );
+    assert!(!fixture.allocator.run_path(&fixture.run_id).exists());
+}

--- a/zeroshot/src/native_v2_runner/state.rs
+++ b/zeroshot/src/native_v2_runner/state.rs
@@ -208,7 +208,7 @@ impl SessionPool {
             Some(SessionEntry::Lost) => Err(NodeRunnerError::SessionLost),
             Some(SessionEntry::Live(session)) => Ok(CheckoutAction::Reuse(session.clone())),
             Some(SessionEntry::Opening(ready)) => Ok(CheckoutAction::Wait(ready.subscribe())),
-            None => {
+            None | Some(SessionEntry::Replaceable) => {
                 let (ready, _) = watch::channel(false);
                 let ready = Arc::new(ready);
                 entries.insert(key.clone(), SessionEntry::Opening(ready.clone()));
@@ -229,7 +229,7 @@ impl SessionPool {
             live = session.is_live() => live,
         };
         if !live {
-            self.invalidate(key, session).await;
+            self.invalidate(key, session, SessionEntry::Lost).await;
             return Err(NodeRunnerError::SessionLost);
         }
         Ok(SessionLease {
@@ -317,11 +317,11 @@ impl SessionPool {
         result
     }
 
-    async fn invalidate(&self, key: SessionKey, session: ManagedSession) {
+    async fn invalidate(&self, key: SessionKey, session: ManagedSession, next: SessionEntry) {
         let mut entries = self.entries.lock().await;
         if matches!(entries.get(&key), Some(SessionEntry::Live(current)) if current.same(&session))
         {
-            entries.insert(key, SessionEntry::Lost);
+            entries.insert(key, next);
         }
         drop(entries);
         session.close().await;
@@ -339,7 +339,7 @@ impl SessionPool {
             .filter_map(|key| match entries.insert(key, SessionEntry::Lost) {
                 Some(SessionEntry::Live(session)) => Some(EntryToClose::Session(session)),
                 Some(SessionEntry::Opening(ready)) => Some(EntryToClose::Opening(ready)),
-                Some(SessionEntry::Lost) | None => None,
+                Some(SessionEntry::Replaceable | SessionEntry::Lost) | None => None,
             })
             .collect::<Vec<_>>();
         drop(entries);
@@ -393,6 +393,9 @@ struct SessionKey {
 enum SessionEntry {
     Opening(Arc<watch::Sender<bool>>),
     Live(ManagedSession),
+    /// The previous execution invalidated its session, so a reducer-authorized dispatch may
+    /// establish a replacement. Passive session loss remains permanently fail-closed.
+    Replaceable,
     Lost,
 }
 
@@ -407,7 +410,11 @@ impl SessionLease {
         match self.kind {
             SessionLeaseKind::Execution => self.session.close().await,
             SessionLeaseKind::NodeInstance(_) if clean => {}
-            SessionLeaseKind::NodeInstance(key) => self.pool.invalidate(key, self.session).await,
+            SessionLeaseKind::NodeInstance(key) => {
+                self.pool
+                    .invalidate(key, self.session, SessionEntry::Replaceable)
+                    .await;
+            }
         }
     }
 }

--- a/zeroshot/src/native_v2_runner/tests.rs
+++ b/zeroshot/src/native_v2_runner/tests.rs
@@ -117,6 +117,30 @@ async fn a_lost_reused_session_fails_without_replacement() {
 }
 
 #[tokio::test]
+async fn closing_a_run_permanently_loses_a_replaceable_session() {
+    const RUN_NAME: &str = "run";
+
+    let factory = Arc::new(FakeFactory::default());
+    let pool = SessionPool::new(factory.clone());
+    let (_cancel, mut cancellation) = watch::channel(false);
+    let first = request(RUN_NAME, "looped", (1, 1));
+    pool.checkout(&first.invocation, &first.environment, &mut cancellation)
+        .await
+        .assert_value()
+        .finish(false)
+        .await;
+
+    pool.close_run(&RunId::new(RUN_NAME)).await;
+    let retry = request(RUN_NAME, "looped", (1, 2));
+    assert!(matches!(
+        pool.checkout(&retry.invocation, &retry.environment, &mut cancellation,)
+            .await,
+        Err(NodeRunnerError::SessionLost)
+    ));
+    assert_eq!(factory.opened.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn closing_a_run_closes_and_permanently_loses_its_reused_sessions() {
     let (runner, _, factory) = runner();
     runner

--- a/zeroshot/src/native_v2_supervisor/tests.rs
+++ b/zeroshot/src/native_v2_supervisor/tests.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 use std::time::Duration;
 
@@ -13,6 +14,7 @@ use serde_json::{Value, json};
 use super::*;
 use crate::native_v2_admission::NativeV2Admission;
 use crate::native_v2_contract::RunSubmission;
+use crate::execution::SessionScope;
 use crate::native_v2_runner::{
     DriverControl, DriverInvocation, LiveOutput, LiveOutputStream, NativeNodeRunner, NodeDriver,
     NodeRole, NodeSession, SessionFactory,
@@ -20,7 +22,9 @@ use crate::native_v2_runner::{
 use crate::v2_run_ledger::CreateRun;
 use crate::v2_run_ledger::fake::FakeRunLedger;
 
-struct FakeSession;
+struct FakeSession {
+    closed: Arc<AtomicUsize>,
+}
 
 #[async_trait]
 impl NodeSession for FakeSession {
@@ -32,11 +36,16 @@ impl NodeSession for FakeSession {
         true
     }
 
-    async fn close(&self) {}
+    async fn close(&self) {
+        self.closed.fetch_add(1, Ordering::SeqCst);
+    }
 }
 
-#[derive(Clone, Default)]
-struct FakeSessionFactory;
+#[derive(Default)]
+struct FakeSessionFactory {
+    opened: AtomicUsize,
+    closed: Arc<AtomicUsize>,
+}
 
 #[async_trait]
 impl SessionFactory for FakeSessionFactory {
@@ -45,7 +54,10 @@ impl SessionFactory for FakeSessionFactory {
         _invocation: &NodeInvocation,
         _environment: &ResolvedEnvironment,
     ) -> Result<Arc<dyn NodeSession>, NodeRunnerError> {
-        Ok(Arc::new(FakeSession))
+        self.opened.fetch_add(1, Ordering::SeqCst);
+        Ok(Arc::new(FakeSession {
+            closed: self.closed.clone(),
+        }))
     }
 }
 
@@ -55,6 +67,7 @@ enum Behavior {
         delay: Duration,
         outcome: WorkerOutcome,
     },
+    Fail(NodeRunnerError),
     Hang,
 }
 
@@ -163,6 +176,7 @@ impl NodeDriver for FakeDriver {
                 self.state().cancellations.push(node.clone());
                 Err(NodeRunnerError::Cancelled)
             }
+            Behavior::Fail(error) => Err(error),
         };
         self.state().active -= 1;
         result
@@ -195,6 +209,7 @@ struct Harness {
     supervisor: NativeV2Supervisor,
     ledger: Arc<FakeRunLedger>,
     driver: Arc<FakeDriver>,
+    sessions: Arc<FakeSessionFactory>,
 }
 
 #[derive(Clone, Default)]
@@ -254,6 +269,15 @@ impl LiveOutputRegistrar for RejectLiveRegistrar {
 }
 
 async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> Harness {
+    harness_with_session_scope(graph, initial_input, driver, SessionScope::Execution).await
+}
+
+async fn harness_with_session_scope(
+    graph: GraphSpec,
+    initial_input: Value,
+    driver: FakeDriver,
+    session_scope: SessionScope,
+) -> Harness {
     let runtime_nodes = executable_names(&graph.root)
         .into_iter()
         .map(|name| {
@@ -263,6 +287,7 @@ async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> 
                     "kind": "agent",
                     "model": "gpt-5.6",
                     "effort": "max",
+                    "sessionScope": session_scope,
                     "connections": {}
                 }),
             )
@@ -303,8 +328,9 @@ async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> 
         .await
         .assert_value_with("create run");
     let driver = Arc::new(driver);
+    let sessions = Arc::new(FakeSessionFactory::default());
     let runner = Arc::new(
-        NativeNodeRunner::new(&admitted, driver.clone(), Arc::new(FakeSessionFactory))
+        NativeNodeRunner::new(&admitted, driver.clone(), sessions.clone())
             .assert_value_with("runner"),
     );
     let environment = RunEnvironment::exact(&admitted.runtime, BTreeMap::new())
@@ -313,6 +339,7 @@ async fn harness(graph: GraphSpec, initial_input: Value, driver: FakeDriver) -> 
         supervisor: NativeV2Supervisor::new(run_id, ledger.clone(), runner, Arc::new(environment)),
         ledger,
         driver,
+        sessions,
     }
 }
 

--- a/zeroshot/src/native_v2_supervisor/tests/cases_3.rs
+++ b/zeroshot/src/native_v2_supervisor/tests/cases_3.rs
@@ -1,5 +1,46 @@
 use super::*;
 
+#[tokio::test]
+async fn crashed_node_instance_verifier_retries_with_a_fresh_provider_session() {
+    const VERIFIER_ATTEMPTS: u64 = 2;
+
+    let mut verifier = verifier("review", 1_000);
+    verifier["attempts"] = json!(VERIFIER_ATTEMPTS);
+    let graph = graph(
+        sequence(vec![verifier, succeed("done")], null_type()),
+        null_type(),
+    );
+    let harness = harness_with_session_scope(
+        graph,
+        Value::Null,
+        FakeDriver::scripted([(
+            "review",
+            vec![
+                Behavior::Fail(NodeRunnerError::Driver),
+                Behavior::Complete {
+                    delay: Duration::ZERO,
+                    outcome: verifier_outcome("accepted"),
+                },
+            ],
+        )]),
+        SessionScope::NodeInstance,
+    )
+    .await;
+
+    assert_eq!(
+        harness.supervisor.drive().await.assert_value_with("drive"),
+        TerminalResult::Succeeded {
+            output: Value::Null
+        }
+    );
+    assert_eq!(harness.driver.starts("review"), VERIFIER_ATTEMPTS as usize);
+    assert!(harness.sessions.closed.load(Ordering::SeqCst) >= 1);
+    assert_eq!(
+        harness.sessions.opened.load(Ordering::SeqCst),
+        VERIFIER_ATTEMPTS as usize
+    );
+}
+
 async fn seed_active_execution(ledger: &FakeRunLedger, run_id: &RunId) -> ExecutionRef {
     let reference = ExecutionRef {
         run_id: run_id.clone(),

--- a/zeroshot/src/native_v2_templates.rs
+++ b/zeroshot/src/native_v2_templates.rs
@@ -15,7 +15,8 @@ use crate::native_v2_delivery::contract::{
     delivery_diagnostic_schema, delivery_result_schema, delivery_signal_labels,
 };
 use crate::native_v2_delivery::{
-    DeliveryMode, DELIVERY_CI_FAILED_LABEL, DELIVERY_CONFLICT_LABEL, DELIVERY_SIGNAL_FIELD,
+    DeliveryMode, DELIVERY_CI_FAILED_LABEL, DELIVERY_CONFLICT_LABEL,
+    DELIVERY_REPAIR_REQUIRED_LABEL, DELIVERY_SIGNAL_FIELD,
 };
 
 #[path = "native_v2_templates/catalog.rs"]
@@ -72,7 +73,9 @@ fn software_change_graph(delivery: TemplateDelivery) -> Result<GraphSpec, Builti
     let worker = task_worker(
         "builtin.agent.software-worker@1",
         "Implement the requested software change fully in the shared workspace. Follow the \
-         repository's guidance, keep the change focused, and run relevant checks.",
+         repository's guidance, keep the change focused, and run relevant checks. Delivery runs \
+         `git add --all`; put downloaded tools and other files you do not want committed outside \
+         the repository checkout.",
     )?;
     let worker_route = initial_worker_route(state.clone(), delivery)?;
     graph(
@@ -263,7 +266,8 @@ fn review_repair() -> Result<GraphNode, BuiltinTemplateError> {
         instructions: Some(instructions(
             "Address both verifier diagnostics in the shared workspace without weakening the \
              requested behavior. Account for any delivery feedback and run the relevant checks \
-             before returning.",
+             before returning. Delivery runs `git add --all`; put downloaded tools and other files \
+             you do not want committed outside the repository checkout.",
         )?),
         input: review_repair_input_type()?,
         output: PayloadType::Null,
@@ -291,26 +295,26 @@ fn accepted_change(
 }
 
 fn pull_request_delivery(state: PayloadType) -> Result<GraphNode, BuiltinTemplateError> {
-    let mode = DeliveryMode::PullRequest;
-    let route = choice(
-        "delivery_result",
-        state.clone(),
-        vec![ChoiceBranch {
-            when: executable_error_guard(DELIVERY_NODE)?,
-            node: fail("delivery_failed", "delivery_failed")?,
-        }],
-        Some(delivery_success("done", mode)?),
-    )?;
-    sequence(
-        "pull_request_delivery",
-        state,
-        vec![delivery_node(mode)?, route],
-        Vec::new(),
-    )
+    delivery_with_repair(state, DeliveryMode::PullRequest, "pull_request_delivery")
 }
 
 fn merge_delivery(state: PayloadType) -> Result<GraphNode, BuiltinTemplateError> {
-    let mode = DeliveryMode::Merge;
+    delivery_with_repair(state, DeliveryMode::Merge, "merge_delivery")
+}
+
+fn delivery_with_repair(
+    state: PayloadType,
+    mode: DeliveryMode,
+    name: &str,
+) -> Result<GraphNode, BuiltinTemplateError> {
+    let labels = match mode {
+        DeliveryMode::PullRequest => vec![DELIVERY_REPAIR_REQUIRED_LABEL],
+        DeliveryMode::MergeV1 | DeliveryMode::Merge => vec![
+            DELIVERY_CI_FAILED_LABEL,
+            DELIVERY_CONFLICT_LABEL,
+            DELIVERY_REPAIR_REQUIRED_LABEL,
+        ],
+    };
     let route = choice(
         "delivery_result",
         state.clone(),
@@ -320,30 +324,32 @@ fn merge_delivery(state: PayloadType) -> Result<GraphNode, BuiltinTemplateError>
                 node: fail("delivery_failed", "delivery_failed")?,
             },
             ChoiceBranch {
-                when: delivery_signal_guard(&[DELIVERY_CI_FAILED_LABEL, DELIVERY_CONFLICT_LABEL])?,
-                node: delivery_repair()?,
+                when: delivery_signal_guard(&labels)?,
+                node: delivery_repair(mode)?,
             },
         ],
         Some(delivery_success("done", mode)?),
     )?;
     sequence(
-        "merge_delivery",
+        name,
         state,
         vec![delivery_node(mode)?, route],
         vec![field_path(DELIVERY_FEEDBACK_FIELD)?],
     )
 }
 
-fn delivery_repair() -> Result<GraphNode, BuiltinTemplateError> {
+fn delivery_repair(mode: DeliveryMode) -> Result<GraphNode, BuiltinTemplateError> {
     Ok(GraphNode::Step(StepNode {
         name: node_name("delivery_repair")?,
         worker: worker_ref("builtin.agent.delivery-repair@1")?,
         instructions: Some(instructions(
-            "Resolve the reported CI failure or merge conflict in the shared workspace. Preserve \
-             the requested behavior and verifier-approved change. Use the delivery feedback as \
-             authoritative failure context, then run the relevant checks.",
+            "Diagnose the reported Git, delivery, CI failure, or merge conflict using the original \
+             diagnostics. Repair the shared workspace when needed and run relevant checks, \
+             preserving the requested behavior and verifier-approved change. Delivery will retry \
+             with the updated workspace. Delivery runs `git add --all`; put downloaded tools and \
+             other files you do not want committed outside the repository checkout.",
         )?),
-        input: delivery_repair_input_type()?,
+        input: delivery_repair_input_type(mode)?,
         output: PayloadType::Null,
         input_bindings: vec![
             state_input(TASK_FIELD, TASK_FIELD)?,

--- a/zeroshot/src/native_v2_templates.rs
+++ b/zeroshot/src/native_v2_templates.rs
@@ -9,6 +9,7 @@ use openengine_cluster_protocol::{
     WorkerErrorCode, WorkerRef, WriteBinding,
 };
 
+use crate::native_v2_admission::MAX_AGENT_VERIFIER_ATTEMPTS;
 use crate::native_v2_contract::{GIT_DELIVERY_MERGE_V2_WORKER_REF, GIT_DELIVERY_PR_WORKER_REF};
 use crate::native_v2_delivery::contract::{
     delivery_diagnostic_schema, delivery_result_schema, delivery_signal_labels,
@@ -226,7 +227,7 @@ fn review_verifier(spec: ReviewVerifierSpec<'_>) -> Result<GraphNode, BuiltinTem
         ],
         write_bindings,
         timeout_ms: positive(NODE_TIMEOUT_MS)?,
-        attempts: positive(1)?,
+        attempts: positive(MAX_AGENT_VERIFIER_ATTEMPTS)?,
         signals,
         diagnostic: diagnostic_type()?,
         instructions: Some(instructions(spec.authored_instructions)?),

--- a/zeroshot/src/native_v2_templates/tests.rs
+++ b/zeroshot/src/native_v2_templates/tests.rs
@@ -167,6 +167,116 @@ async fn rejected_parallel_reviews_dispatch_repair_with_both_diagnostics() {
     )));
 }
 
+fn crashed_parallel_review_history() -> Vec<DurableExecution> {
+    let review_input = json!({"task":"repair checkout","deliveryFeedback":""});
+    vec![
+        settled_worker(),
+        settled_review(
+            2,
+            "acceptance",
+            REJECTED_LABEL,
+            "missing requested behavior",
+        ),
+        settled_failure(
+            SettledExecutionSpec {
+                execution: 3,
+                node_instance: 3,
+                node: "code",
+                settled_at: 3,
+                input: review_input,
+            },
+            WorkerErrorCode::Crash,
+        ),
+    ]
+}
+
+#[tokio::test]
+async fn crashed_parallel_review_retries_only_the_failed_verifier() {
+    let (verified, initial_input) = verified_software_template(TemplateDelivery::None).await;
+    let mut history = crashed_parallel_review_history();
+    let reduction = reduce(&verified, &initial_input, &history);
+
+    assert_eq!(
+        reduction
+            .decisions
+            .iter()
+            .filter(|decision| matches!(decision, Decision::Dispatch { .. }))
+            .count(),
+        1
+    );
+    assert!(reduction.decisions.iter().any(|decision| matches!(
+        decision,
+        Decision::Dispatch { occurrence, attempt, input, .. }
+            if occurrence.node.as_str() == "code"
+                && attempt.get() == MAX_AGENT_VERIFIER_ATTEMPTS
+                && input == &json!({"task":"repair checkout","deliveryFeedback":""})
+    )));
+    assert!(reduction.terminal.is_none());
+
+    let mut recovered = settled_review_execution(
+        SettledExecutionSpec {
+            execution: 4,
+            node_instance: 3,
+            node: "code",
+            settled_at: 5,
+            input: json!({"task":"repair checkout","deliveryFeedback":""}),
+        },
+        ACCEPTED_LABEL,
+        "implementation sound",
+    );
+    recovered.attempt = PositiveInteger::new(MAX_AGENT_VERIFIER_ATTEMPTS).assert_value();
+    history.push(recovered);
+    let reviewed = reduce(&verified, &initial_input, &history);
+    assert_dispatched_together(&reviewed, &["review_repair"]);
+    let repair_input = json!({
+        "task":"repair checkout",
+        "acceptanceFeedback":"missing requested behavior",
+        "codeFeedback":"implementation sound",
+        "deliveryFeedback":""
+    });
+    assert!(reviewed.decisions.iter().any(|decision| matches!(
+        decision, Decision::Dispatch { input, .. } if input == &repair_input
+    )));
+    history.push(settled_agent(SettledExecutionSpec {
+        execution: 5,
+        node_instance: 4,
+        node: "review_repair",
+        settled_at: 6,
+        input: repair_input,
+    }));
+    let next_round = reduce(&verified, &initial_input, &history);
+    assert_dispatched_together(&next_round, &["acceptance", "code"]);
+    assert!(next_round.decisions.iter().all(|decision| match decision {
+        Decision::Dispatch { attempt, .. } => attempt.get() == 1,
+        _ => true,
+    }));
+}
+
+#[tokio::test]
+async fn repeatedly_crashed_parallel_review_fails_after_the_retry_limit() {
+    let (verified, initial_input) = verified_software_template(TemplateDelivery::None).await;
+    let review_input = json!({"task":"repair checkout","deliveryFeedback":""});
+    let mut history = crashed_parallel_review_history();
+    history.push(settled_failure_attempt(
+        SettledExecutionSpec {
+            execution: 4,
+            node_instance: 3,
+            node: "code",
+            settled_at: 5,
+            input: review_input,
+        },
+        WorkerErrorCode::Crash,
+        MAX_AGENT_VERIFIER_ATTEMPTS,
+    ));
+
+    assert_eq!(
+        reduce(&verified, &initial_input, &history).terminal,
+        Some(TerminalProjection::Failed {
+            reason: "review_failed".parse().assert_value()
+        })
+    );
+}
+
 #[tokio::test]
 async fn accepted_second_review_round_ignores_stale_sibling_verdicts() {
     let (verified, initial_input) = verified_software_template(TemplateDelivery::None).await;

--- a/zeroshot/src/native_v2_templates/tests.rs
+++ b/zeroshot/src/native_v2_templates/tests.rs
@@ -93,7 +93,14 @@ async fn every_supported_materialization_is_admissible() {
         (
             BuiltinGraphTemplate::SoftwareChange,
             TemplateDelivery::PullRequest,
-            vec!["acceptance", "code", "deliver", "review_repair", "worker"],
+            vec![
+                "acceptance",
+                "code",
+                "deliver",
+                "delivery_repair",
+                "review_repair",
+                "worker",
+            ],
         ),
         (
             BuiltinGraphTemplate::SoftwareChange,
@@ -378,7 +385,11 @@ async fn accepted_reviews_complete_or_dispatch_pull_request_delivery() {
 
 #[tokio::test]
 async fn merge_delivery_repairs_recoverable_outcomes_then_returns_the_receipt() {
-    for recoverable in [DELIVERY_CI_FAILED_LABEL, DELIVERY_CONFLICT_LABEL] {
+    for recoverable in [
+        DELIVERY_CI_FAILED_LABEL,
+        DELIVERY_CONFLICT_LABEL,
+        DELIVERY_REPAIR_REQUIRED_LABEL,
+    ] {
         assert_recoverable_delivery(recoverable).await;
     }
 }
@@ -615,4 +626,30 @@ fn all_nodes(root: &GraphNode) -> Vec<&GraphNode> {
         pending.extend(openengine_cluster_server::graph_verifier::graph_node_children(node));
     }
     nodes
+}
+
+#[tokio::test]
+async fn pull_request_delivery_routes_a_pre_review_git_failure_to_repair() {
+    let (verified, initial_input) = verified_software_template(TemplateDelivery::PullRequest).await;
+    let mut history = accepted_review_history(TemplateDelivery::PullRequest);
+    history.push(settled_delivery_with_diagnostic(
+        SettledExecutionSpec {
+            execution: 4,
+            node_instance: 4,
+            node: DELIVERY_NODE,
+            settled_at: 4,
+            input: delivery_input(),
+        },
+        DeliveryMode::PullRequest,
+        DELIVERY_REPAIR_REQUIRED_LABEL,
+        "git push: unfamiliar failure",
+    ));
+    assert_dispatch(
+        &reduce(&verified, &initial_input, &history),
+        "delivery_repair",
+        &json!({
+            "task":"repair checkout", "outcome":"repair_required",
+            "deliveryFeedback":"git push: unfamiliar failure"
+        }),
+    );
 }

--- a/zeroshot/src/native_v2_templates/tests/support.rs
+++ b/zeroshot/src/native_v2_templates/tests/support.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use openengine_cluster_protocol::{
     EnumLabel, FieldName, NodeName, NodeRuntimeBinding, PositiveInteger, ReasoningEffort, RunSize,
     RuntimePlan, SessionScope, SourceBranchId, SourceRepositoryId, SourceRevisionId,
-    ResolvedSource, WorkerOutcome,
+    ResolvedSource, WorkerErrorCode, WorkerOutcome,
 };
 use openengine_cluster_server::graph_verifier::graph_node_children;
 use openengine_cluster_testkit::assertions::AssertValue;
@@ -161,6 +161,23 @@ pub(super) fn settled_agent(spec: SettledExecutionSpec<'_>) -> DurableExecution 
             artifacts: Vec::new(),
         },
     )
+}
+
+pub(super) fn settled_failure(
+    spec: SettledExecutionSpec<'_>,
+    code: WorkerErrorCode,
+) -> DurableExecution {
+    settled_execution(spec, WorkerOutcome::declared_failure(code))
+}
+
+pub(super) fn settled_failure_attempt(
+    spec: SettledExecutionSpec<'_>,
+    code: WorkerErrorCode,
+    attempt: u64,
+) -> DurableExecution {
+    let mut execution = settled_failure(spec, code);
+    execution.attempt = PositiveInteger::new(attempt).assert_value();
+    execution
 }
 
 pub(super) fn settled_review(

--- a/zeroshot/src/native_v2_templates/values.rs
+++ b/zeroshot/src/native_v2_templates/values.rs
@@ -127,13 +127,15 @@ pub(super) fn review_input_type() -> Result<PayloadType, BuiltinTemplateError> {
     ])
 }
 
-pub(super) fn delivery_repair_input_type() -> Result<PayloadType, BuiltinTemplateError> {
+pub(super) fn delivery_repair_input_type(
+    mode: DeliveryMode,
+) -> Result<PayloadType, BuiltinTemplateError> {
     record_type(vec![
         (TASK_FIELD, PayloadType::String, true),
         (
             "outcome",
             PayloadType::Enum {
-                values: static_value(delivery_signal_labels(DeliveryMode::Merge))?,
+                values: static_value(delivery_signal_labels(mode))?,
             },
             true,
         ),

--- a/zeroshot/tests/full_v1_reducer/cases_2.rs
+++ b/zeroshot/tests/full_v1_reducer/cases_2.rs
@@ -66,14 +66,7 @@ async fn native_v2_loop_reuses_node_instance_with_fresh_attempt_one_executions()
         SettledSpec::new(1, 1, "check").position(3),
         verdict("rejected"),
     );
-    let reduction = FullV1Reducer::native_v2(&graph)
-        .reduce(ReductionInput {
-            initial_input: &json!({}),
-            executions: std::slice::from_ref(&first),
-            next_node_instance: 2,
-            next_execution: 2,
-        })
-        .assert_value();
+    let reduction = reduce_native(&graph, std::slice::from_ref(&first)).assert_value();
     assert!(reduction.decisions.iter().any(|decision| matches!(
         decision,
         Decision::Dispatch { node_instance, execution, attempt, .. }
@@ -85,17 +78,167 @@ async fn native_v2_loop_reuses_node_instance_with_fresh_attempt_one_executions()
         verdict("accepted"),
     );
     assert!(
-        FullV1Reducer::native_v2(&graph)
-            .reduce(ReductionInput {
-                initial_input: &json!({}),
-                executions: &[first, second],
-                next_node_instance: 2,
-                next_execution: 3,
-            })
+        reduce_native(&graph, &[first, second])
             .assert_value()
             .terminal
             .is_some()
     );
+}
+
+#[tokio::test]
+async fn native_v2_retries_a_failed_execution_before_continuing() {
+    let graph = retryable_verifier_graph(2).await;
+    let failed = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    let retry = reduce_native(&graph, std::slice::from_ref(&failed)).assert_value();
+    let dispatches = retry
+        .decisions
+        .iter()
+        .filter_map(|decision| match decision {
+            Decision::Dispatch {
+                node_instance,
+                execution,
+                attempt,
+                ..
+            } => Some((node_instance.get(), execution.get(), attempt.get())),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(dispatches, vec![(1, 2, 2)]);
+    assert!(retry.terminal.is_none());
+
+    let succeeded = successful_native_retry();
+    assert!(matches!(
+        reduce_native(&graph, &[failed, succeeded])
+            .assert_value()
+            .terminal,
+        Some(TerminalProjection::Succeeded { .. })
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_a_retry_that_does_not_follow_an_error() {
+    let graph = retryable_verifier_graph(2).await;
+    let history = [
+        settled(
+            SettledSpec::new(1, 1, "check").position(3),
+            verdict("accepted"),
+        ),
+        settled(
+            SettledSpec::new(2, 1, "check").attempt(2).position(6),
+            verdict("accepted"),
+        ),
+    ];
+
+    assert!(matches!(
+        reduce_native(&graph, &history),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_does_not_retry_a_non_crash_error() {
+    let graph = retryable_verifier_graph(2).await;
+    let timed_out = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Timeout),
+    );
+    let reduction = reduce_native(&graph, std::slice::from_ref(&timed_out)).assert_value();
+
+    assert!(!reduction.decisions.iter().any(|decision| matches!(
+        decision,
+        Decision::Dispatch { occurrence, .. } if occurrence.node.as_str() == "check"
+    )));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_a_retry_visit_with_mismatched_prior_input() {
+    let graph = retryable_verifier_graph(2).await;
+    let mut failed = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    failed.input = json!({"unexpected":true});
+    let succeeded = successful_native_retry();
+
+    assert!(matches!(
+        reduce_native(&graph, &[failed, succeeded]),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_a_retry_dispatched_before_the_failure_settled() {
+    let graph = retryable_verifier_graph(2).await;
+    let mut failed = settled(
+        SettledSpec::new(1, 1, "check").position(5),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    failed.dispatch_position = HistoryPosition::new(1).assert_value();
+    let retry = settled(
+        SettledSpec::new(2, 1, "check").attempt(2).position(4),
+        verdict("accepted"),
+    );
+
+    assert!(matches!(
+        reduce_native(&graph, &[failed, retry]),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+#[tokio::test]
+async fn native_v2_rejects_invalid_initial_and_excess_attempts() {
+    let graph = retryable_verifier_graph(1).await;
+    let invalid_initial = settled(
+        SettledSpec::new(1, 1, "check").attempt(2).position(3),
+        verdict("accepted"),
+    );
+    assert!(matches!(
+        reduce_native(&graph, &[invalid_initial]),
+        Err(ReducerError::InconsistentHistory)
+    ));
+
+    let failed = settled(
+        SettledSpec::new(1, 1, "check").position(3),
+        WorkerOutcome::declared_failure(openengine_cluster_protocol::WorkerErrorCode::Crash),
+    );
+    let excess_attempt = settled(
+        SettledSpec::new(2, 1, "check").attempt(2).position(6),
+        verdict("accepted"),
+    );
+    assert!(matches!(
+        reduce_native(&graph, &[failed, excess_attempt]),
+        Err(ReducerError::InconsistentHistory)
+    ));
+}
+
+fn successful_native_retry() -> DurableExecution {
+    settled(
+        SettledSpec::new(2, 1, "check").attempt(2).position(6),
+        verdict("accepted"),
+    )
+}
+
+async fn retryable_verifier_graph(attempts: u64) -> VerifiedGraph {
+    verified(
+        sequence("root", vec![verifier("check", attempts), succeed("done")]),
+        json!({"check":attempts}),
+    )
+    .await
+}
+
+fn reduce_native(
+    graph: &VerifiedGraph,
+    executions: &[DurableExecution],
+) -> Result<Reduction, ReducerError> {
+    FullV1Reducer::native_v2(graph).reduce(ReductionInput {
+        initial_input: &json!({}),
+        executions,
+        next_node_instance: 2,
+        next_execution: executions.len() as u64 + 1,
+    })
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Git failures can currently end a run before it reaches delivery repair. Route recoverable and unfamiliar failures to the existing repair agent with bounded, credential-redacted command output, while keeping cancellation, confirmed authentication refusal and authority mismatches terminal.

Ship the native build tools, Rust, Node.js and Python needed for ordinary project checks. The image uses one Rust baseline and respects user toolchain settings and installations.

## Related Issues

Fixes #1067. Adapts the verifier recovery from #1090 to current main, with thanks and co-author credit to @ousamabenyounes.

## Changes Made

- Both built-in delivery graphs route Git repair before or after PR creation. Writing agents are told that delivery runs `git add --all` and to keep unwanted files outside the checkout.
- Retry crashed verifiers once while preserving settled siblings; replace actively invalidated provider sessions without reopening passively lost or closed sessions.
- Retry initial checkout within its existing deadline, preserve the allocated workspace identity and verify the exact admitted revision before starting agents.
- Exercise the image toolchains with native, Rust, Python and Node builds under an isolated user, read-only root, fresh home and no network.

## Testing

Formatting, workspace/all-targets Clippy, all 1,151 workspace tests (5 ignored) and Rustdoc with warnings denied pass. Coverage includes real Git repair, command cleanup, checkout recovery, session replacement and review causality. Repository lint, all 28 tooling tests, distribution validation and generated protocol validation also pass. CI additionally builds the final target image and runs the restricted toolchain smoke tests.

Opcore Verify covers the changed source files without findings. Dependency Sense has partial Rust coverage; compiler checks, behavioral tests and independent review cover those limits.

## Checklist

- [x] Tests pass (`npm test`)
- [x] Documentation updated
- [x] Follows commit guidelines

Co-authored-by: Ben Younes <2910651+ousamabenyounes@users.noreply.github.com>
