### PR TITLE
fix(runtime): remove built-in execution deadlines and retain failure diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,13 +74,16 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   milliseconds and remain unchanged across durable replay.
 - Run close reserves and tombstones execution activity atomically. No late start, handle, or stream
   may surface after close returns.
+- Node deadlines are optional: omitted `timeoutMs` means completion or explicit cancellation.
+  Built-in graphs have no node deadlines, and provider adapters impose no separate turn timeout.
+  The supervisor records node error codes and elapsed time in durable logs before settlement.
 - Native-v2 retries only a settled `crash` outcome when the executable has another authored
   attempt. A provider session invalidated by that active execution becomes replaceable for the
   authorized retry; passive session loss and run closure remain permanent, fail-closed loss.
 - Hosted source checkout retries only its fresh platform-owned staging workspace, within one
   allocation and one total deadline. Preserve the exact admitted revision before starting any
   graph node; terminal Git details remain redacted and private operator diagnostics.
-- Contained provider sessions bound post-exit I/O draining by the command deadline and a ten-minute
+- Contained provider sessions bound post-exit I/O draining by any explicit command deadline and a ten-minute
   ceiling while still observing cancellation and cleanup.
 - Git delivery captures bounded, credential-redacted command/status/stdout/stderr diagnostics and
   routes unfamiliar failures to the existing delivery repair worker through `repair_required`.

--- a/crates/openengine-cluster-protocol/src/graph.rs
+++ b/crates/openengine-cluster-protocol/src/graph.rs
@@ -275,7 +275,9 @@ pub struct StepNode {
     pub output: PayloadType,
     pub input_bindings: Vec<InputBinding>,
     pub write_bindings: Vec<WriteBinding>,
-    pub timeout_ms: PositiveInteger,
+    /// Omit to run until completion or cancellation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<PositiveInteger>,
     pub attempts: PositiveInteger,
 }
 
@@ -288,7 +290,9 @@ pub struct VerifierNode {
     pub output: PayloadType,
     pub input_bindings: Vec<InputBinding>,
     pub write_bindings: Vec<WriteBinding>,
-    pub timeout_ms: PositiveInteger,
+    /// Omit to run until completion or cancellation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_ms: Option<PositiveInteger>,
     pub attempts: PositiveInteger,
     #[schemars(
         schema_with = "crate::value::identifier_keyed_map_schema::<FieldName, NonEmptyEnumSet>"

--- a/crates/openengine-cluster-protocol/tests/graph_wire.rs
+++ b/crates/openengine-cluster-protocol/tests/graph_wire.rs
@@ -401,3 +401,24 @@ fn diagnostic_indices_have_matching_u32_bounds_in_rust_and_schema() {
         );
     }
 }
+
+#[test]
+fn omitted_node_deadlines_round_trip_and_match_the_schema() {
+    let mut graph = full_graph();
+    for index in [0, 1] {
+        graph
+            .pointer_mut(&format!("/root/children/{index}"))
+            .assert_value()
+            .as_object_mut()
+            .assert_value()
+            .remove("timeoutMs");
+    }
+    let parsed: GraphSpec = serde_json::from_value(graph.clone()).assert_value();
+    assert_eq!(serde_json::to_value(parsed).assert_value(), graph);
+    let schema = serde_json::to_value(schemars::schema_for!(GraphSpec)).assert_value();
+    assert!(
+        jsonschema::validator_for(&schema)
+            .assert_value()
+            .is_valid(&graph)
+    );
+}

--- a/docker/zeroshot-target/smoke-toolchains.sh
+++ b/docker/zeroshot-target/smoke-toolchains.sh
@@ -65,6 +65,7 @@ fn main() {
 }
 RUST
 rustc --version | grep '^rustc 1\.97\.0 '
+rustc -vV | grep '^host: .*unknown-linux-gnu$'
 cargo fmt --all
 cargo fmt --all -- --check
 cargo clippy --offline -- -D warnings

--- a/docs/reference/cluster/graph.md
+++ b/docs/reference/cluster/graph.md
@@ -39,8 +39,10 @@ Every graph node is tagged by `kind`. Node payloads reject unknown fields.
 Parallel joins are `all`, `any`, `quorum { count }`, or `first { when }`. The closed worker error
 channel is `timeout`, `crash`, `malformed`, and `refusal`. Choice reachability/exhaustiveness, loop
 exit satisfiability, selector typing, dominance, promotion safety, and structural folds are
-production-verifier responsibilities, not parser claims. `timeoutMs` accepts exactly the
-`PositiveInteger` wire range; the verifier imposes no superseded 24-hour product ceiling.
+production-verifier responsibilities, not parser claims. Omitting `timeoutMs` lets a node run until
+completion or cancellation. An explicit `timeoutMs` accepts the `PositiveInteger` wire range.
+Built-in graphs omit deadlines for every node; provider processes have no separate execution
+deadline. Custom graphs may still declare a node deadline.
 Normal-success continuation requires every branch for `all`, one branch for `any`/`first`, and
 `count` branches for `quorum`. Quorum flow and promotion guarantees range over every valid
 size-`count` completing branch set. A set is valid only when its branch-completion predicates are

--- a/protocol/openengine-cluster/v1/compiled-ir.schema.json
+++ b/protocol/openengine-cluster/v1/compiled-ir.schema.json
@@ -149,9 +149,13 @@
               "$ref": "#/$defs/PayloadType"
             },
             "timeoutMs": {
+              "description": "Omit to run until completion or cancellation.",
               "maximum": 9007199254740991,
               "minimum": 1,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "worker": {
               "maxLength": 256,
@@ -173,7 +177,6 @@
             "output",
             "inputBindings",
             "writeBindings",
-            "timeoutMs",
             "attempts"
           ],
           "type": "object"
@@ -243,9 +246,13 @@
               "type": "object"
             },
             "timeoutMs": {
+              "description": "Omit to run until completion or cancellation.",
               "maximum": 9007199254740991,
               "minimum": 1,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "worker": {
               "maxLength": 256,
@@ -267,7 +274,6 @@
             "output",
             "inputBindings",
             "writeBindings",
-            "timeoutMs",
             "attempts",
             "signals",
             "diagnostic"

--- a/protocol/openengine-cluster/v1/graph.schema.json
+++ b/protocol/openengine-cluster/v1/graph.schema.json
@@ -371,9 +371,13 @@
               "$ref": "#/$defs/PayloadType"
             },
             "timeoutMs": {
+              "description": "Omit to run until completion or cancellation.",
               "maximum": 9007199254740991,
               "minimum": 1,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "worker": {
               "maxLength": 256,
@@ -395,7 +399,6 @@
             "output",
             "inputBindings",
             "writeBindings",
-            "timeoutMs",
             "attempts"
           ],
           "type": "object"
@@ -465,9 +468,13 @@
               "type": "object"
             },
             "timeoutMs": {
+              "description": "Omit to run until completion or cancellation.",
               "maximum": 9007199254740991,
               "minimum": 1,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "worker": {
               "maxLength": 256,
@@ -489,7 +496,6 @@
             "output",
             "inputBindings",
             "writeBindings",
-            "timeoutMs",
             "attempts",
             "signals",
             "diagnostic"

--- a/protocol/openengine-cluster/v1/schema.json
+++ b/protocol/openengine-cluster/v1/schema.json
@@ -1014,9 +1014,13 @@
               "$ref": "#/$defs/PayloadType"
             },
             "timeoutMs": {
+              "description": "Omit to run until completion or cancellation.",
               "maximum": 9007199254740991,
               "minimum": 1,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "worker": {
               "maxLength": 256,
@@ -1038,7 +1042,6 @@
             "output",
             "inputBindings",
             "writeBindings",
-            "timeoutMs",
             "attempts"
           ],
           "type": "object"
@@ -1108,9 +1111,13 @@
               "type": "object"
             },
             "timeoutMs": {
+              "description": "Omit to run until completion or cancellation.",
               "maximum": 9007199254740991,
               "minimum": 1,
-              "type": "integer"
+              "type": [
+                "integer",
+                "null"
+              ]
             },
             "worker": {
               "maxLength": 256,
@@ -1132,7 +1139,6 @@
             "output",
             "inputBindings",
             "writeBindings",
-            "timeoutMs",
             "attempts",
             "signals",
             "diagnostic"

--- a/zeroshot/Cargo.toml
+++ b/zeroshot/Cargo.toml
@@ -59,4 +59,5 @@ windows-sys = { workspace = true, features = [
 dbus.workspace = true
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 openengine-cluster-testkit.workspace = true

--- a/zeroshot/src/execution/process.rs
+++ b/zeroshot/src/execution/process.rs
@@ -27,6 +27,14 @@ pub use session::{
 };
 pub(crate) use session::ProcessStdout;
 
+/// An absent deadline waits only for the caller's completion or cancellation branch.
+pub(crate) async fn wait_for_deadline(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
 pub const MAX_PROCESS_DIAGNOSTIC_BYTES: usize = 64 * 1024;
 /// Last-resort allocation guards for already-constructed provider commands.
 ///

--- a/zeroshot/src/execution/process/session.rs
+++ b/zeroshot/src/execution/process/session.rs
@@ -30,7 +30,7 @@ pub struct ProcessSessionCommand {
     pub argv: Vec<String>,
     pub environment: BTreeMap<String, String>,
     pub workspace: WorkspaceCapability,
-    pub deadline: Instant,
+    pub deadline: Option<Instant>,
 }
 
 impl fmt::Debug for ProcessSessionCommand {

--- a/zeroshot/src/execution/process/session_runtime.rs
+++ b/zeroshot/src/execution/process/session_runtime.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use tokio::process::Child;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
-use tokio::time::{Duration, Instant, sleep_until, timeout, timeout_at};
+use tokio::time::{Duration, Instant, timeout, timeout_at};
 
 use crate::execution::driver::DriverCancellation;
 use super::platform::{ProcessTreeHandle, process_tree_has_live_members, terminate_process_tree};
@@ -21,7 +21,7 @@ pub(super) struct SupervisorRequest {
     pub child: Child,
     pub process_tree: ProcessTreeHandle,
     pub cancellation: DriverCancellation,
-    pub deadline: Instant,
+    pub deadline: Option<Instant>,
     pub release: watch::Receiver<bool>,
     pub writer_stop: watch::Sender<bool>,
     pub io_failures: mpsc::UnboundedReceiver<IoFailure>,
@@ -79,7 +79,7 @@ impl SessionState {
 
 pub(super) async fn supervise_session(mut request: SupervisorRequest) {
     let mut state = SessionState::default();
-    let deadline = sleep_until(request.deadline);
+    let deadline = super::wait_for_deadline(request.deadline);
     tokio::pin!(deadline);
     loop {
         tokio::select! {
@@ -242,8 +242,10 @@ async fn drain_io_tasks(request: &mut SupervisorRequest, state: &mut SessionStat
     }
 
     let io_cap = Instant::now() + PROCESS_IO_DRAIN_TIMEOUT;
-    let command_deadline_wins = request.deadline <= io_cap;
-    let drain_deadline = std::cmp::min(request.deadline, io_cap);
+    let command_deadline_wins = request.deadline.is_some_and(|deadline| deadline <= io_cap);
+    let drain_deadline = request
+        .deadline
+        .map_or(io_cap, |deadline| deadline.min(io_cap));
     let mut cancellation = request.cancellation.clone();
     let mut release = request.release.clone();
     enum DrainResult {

--- a/zeroshot/src/execution/process/tests.rs
+++ b/zeroshot/src/execution/process/tests.rs
@@ -378,7 +378,7 @@ fn process_command_with_deadline(
             current_dir: std::env::current_dir().assert_value(),
             mode: WorkspaceAccessMode::ReadOnly,
         },
-        deadline,
+        deadline: Some(deadline),
     }
 }
 

--- a/zeroshot/src/native_v2_candidate/tests/fixtures.rs
+++ b/zeroshot/src/native_v2_candidate/tests/fixtures.rs
@@ -185,7 +185,6 @@ pub(super) fn candidate_config(
                 ("PATH".to_owned(), "/usr/bin:/bin".to_owned()),
             ]))
             .assert_value_with("Claude environment"),
-            turn_timeout: Duration::from_secs(1),
             process_pool: pool,
         }),
     };

--- a/zeroshot/src/native_v2_capsule/provider_process.rs
+++ b/zeroshot/src/native_v2_capsule/provider_process.rs
@@ -5,7 +5,6 @@ use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::Mutex;
-use tokio::time::Instant;
 
 use crate::execution::SessionScope;
 use crate::execution::process::{
@@ -334,7 +333,6 @@ pub(crate) struct ProviderFailure<'a> {
     pub(crate) detail: Option<&'a str>,
     pub(crate) retryable: bool,
     pub(crate) has_session: bool,
-    pub(crate) deadline: Instant,
 }
 
 impl ProviderFailureRetry {
@@ -361,7 +359,7 @@ impl ProviderFailureRetry {
         control
             .emit(LiveOutput::new(LiveOutputStream::Error, diagnostic)?)
             .await?;
-        if !failure.retryable || self.used || Instant::now() >= failure.deadline {
+        if !failure.retryable || self.used {
             return Err(NodeRunnerError::Driver);
         }
         self.used = true;

--- a/zeroshot/src/native_v2_claude.rs
+++ b/zeroshot/src/native_v2_claude.rs
@@ -16,9 +16,6 @@ mod turn_process;
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
-
-use tokio::time::Instant;
 
 use crate::execution::process::{HostedProcessPool, ProcessSessionCommand, ProcessStdout};
 use crate::native_v2_capsule::provider_process::{
@@ -112,7 +109,6 @@ pub struct ClaudeAdapter {
     runtime_home: PathBuf,
     local_user_home: Option<PathBuf>,
     base_environment: ClaudeProcessEnvironment,
-    turn_timeout: Duration,
     runners: ProviderProcessRunners,
 }
 
@@ -125,7 +121,6 @@ pub struct ClaudeAdapterConfig {
     /// Current-user home is available only to the built-in local target.
     pub local_user_home: Option<PathBuf>,
     pub base_environment: ClaudeProcessEnvironment,
-    pub turn_timeout: Duration,
     pub process_pool: HostedProcessPool,
 }
 
@@ -155,7 +150,6 @@ impl ClaudeAdapter {
             runtime_home: configuration.runtime_home,
             local_user_home: configuration.local_user_home,
             base_environment: configuration.base_environment,
-            turn_timeout: configuration.turn_timeout,
             runners,
         })
     }
@@ -213,7 +207,7 @@ impl ClaudeAdapter {
                     with_driver_detail(error, "Claude workspace policy rejected the node role")
                 })?,
             },
-            deadline: turn.deadline,
+            deadline: None,
         })
     }
 
@@ -376,7 +370,6 @@ struct ClaudeTurn<'a> {
     invocation: &'a DriverInvocation,
     session: &'a ClaudeSession,
     control: &'a DriverControl,
-    deadline: Instant,
 }
 
 enum ClaudeTurnAdvance {

--- a/zeroshot/src/native_v2_claude/session.rs
+++ b/zeroshot/src/native_v2_claude/session.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use openengine_cluster_protocol::WorkerOutcome;
 use tokio::sync::Mutex;
-use tokio::time::Instant;
 
 use crate::execution::SessionScope;
 use crate::native_v2_capsule::provider_process::{
@@ -68,7 +67,6 @@ impl NodeDriver for ClaudeAdapter {
             invocation: &invocation,
             session,
             control: &control,
-            deadline: Instant::now() + self.turn_timeout,
         };
         let mut state = ClaudeRunState::new(&invocation, session).await?;
         loop {
@@ -162,7 +160,6 @@ impl ClaudeRunState {
                     detail: Some(detail),
                     retryable,
                     has_session: self.resume_id.is_some(),
-                    deadline: turn.deadline,
                 },
             )
             .await?;

--- a/zeroshot/src/native_v2_claude/tests.rs
+++ b/zeroshot/src/native_v2_claude/tests.rs
@@ -174,7 +174,6 @@ async fn runner_with_command(
             runtime_home: workspace.path().to_owned(),
             local_user_home: None,
             base_environment,
-            turn_timeout: Duration::from_secs(10),
             process_pool: HostedProcessPool::new(10_002, 10_002, 20_000, 20_000).assert_value(),
         })
         .assert_value(),

--- a/zeroshot/src/native_v2_claude/tests/environment.rs
+++ b/zeroshot/src/native_v2_claude/tests/environment.rs
@@ -99,7 +99,6 @@ fn bedrock_environment(
             "/usr/bin:/bin".to_owned(),
         )]))
         .assert_value(),
-        turn_timeout: Duration::from_secs(1),
         process_pool: HostedProcessPool::new(10_002, 10_002, 20_000, 20_000).assert_value(),
     })
     .assert_value();

--- a/zeroshot/src/native_v2_claude/tests/local_identity.rs
+++ b/zeroshot/src/native_v2_claude/tests/local_identity.rs
@@ -18,7 +18,6 @@ fn local_claude_user_reuses_home_without_moving_session_state() {
             ("TMPDIR".to_owned(), "/shared/tmp".to_owned()),
         ]))
         .assert_value(),
-        turn_timeout: Duration::from_secs(1),
         process_pool: HostedProcessPool::new(10_002, 10_002, 20_000, 20_000).assert_value(),
     })
     .assert_value();

--- a/zeroshot/src/native_v2_codex.rs
+++ b/zeroshot/src/native_v2_codex.rs
@@ -16,7 +16,6 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use openengine_cluster_protocol::WorkerOutcome;
-use tokio::time::{Duration, Instant};
 
 use crate::execution::driver::WorkspaceCapability;
 use crate::execution::process::{
@@ -43,8 +42,6 @@ use process::{ProcessOpen, exchange_turn, open_process};
 use schema_file::CodexSchemaFile;
 use session::CodexSession;
 use turn::{CodexCommandInput, CodexTurnProcess, CodexTurnProcessOpen};
-
-const PROCESS_TIMEOUT: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// Runtime capabilities required to launch Codex. None of these paths are durable run data.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -168,7 +165,7 @@ impl NativeV2CodexAdapter {
                 current_dir: workspace,
                 mode: access,
             },
-            deadline: turn.deadline,
+            deadline: None,
         })
     }
 
@@ -240,7 +237,6 @@ impl NativeV2CodexAdapter {
             invocation,
             session,
             control: &control,
-            deadline: Instant::now() + PROCESS_TIMEOUT,
         };
         let prompt = render_agent_prompt(
             invocation.agent_instructions()?,
@@ -366,7 +362,6 @@ struct CodexTurn<'a> {
     invocation: &'a DriverInvocation,
     session: &'a CodexSession,
     control: &'a DriverControl,
-    deadline: Instant,
 }
 
 struct CodexRunState {
@@ -405,7 +400,6 @@ impl CodexRunState {
                     detail,
                     retryable: true,
                     has_session,
-                    deadline: turn.deadline,
                 },
             )
             .await?;

--- a/zeroshot/src/native_v2_hosting.rs
+++ b/zeroshot/src/native_v2_hosting.rs
@@ -15,7 +15,6 @@ mod tests;
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use openengine_cluster_protocol::RunSubmitParams;
@@ -38,7 +37,6 @@ use openengine_cluster_server::admission::VerificationError;
 
 use allocator::{ProductionCapsuleAllocator, ProductionCapsuleConfig};
 use connections::build_connection_resolver;
-const DEFAULT_CLAUDE_TURN_TIMEOUT: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// Composes the production target around exact sourceful run requests.
 pub async fn build_production_target_authority(
@@ -64,7 +62,6 @@ pub struct ProductionHostingConfig {
     pub git_program: PathBuf,
     pub gh_program: PathBuf,
     pub process_pool: HostedProcessPool,
-    pub claude_turn_timeout: Duration,
 }
 
 impl fmt::Debug for ProductionHostingConfig {
@@ -114,7 +111,6 @@ impl ProductionTargetControllerFactory {
             git_program: self.config.git_program.clone(),
             gh_program: self.config.gh_program.clone(),
             process_pool: self.config.process_pool,
-            claude_turn_timeout: self.config.claude_turn_timeout,
             operator_diagnostics: self.operator_diagnostics.clone(),
         })?);
         let controller = NativeV2CloudController::new_with_delivery_policy(
@@ -280,7 +276,6 @@ impl Default for ProductionHostingConfig {
             git_program: PathBuf::from("/usr/bin/git"),
             gh_program: PathBuf::from("/usr/bin/gh"),
             process_pool: HostedProcessPool::hosted_default(),
-            claude_turn_timeout: DEFAULT_CLAUDE_TURN_TIMEOUT,
         }
     }
 }

--- a/zeroshot/src/native_v2_hosting/allocator.rs
+++ b/zeroshot/src/native_v2_hosting/allocator.rs
@@ -47,7 +47,6 @@ pub(super) struct ProductionCapsuleConfig {
     pub git_program: PathBuf,
     pub gh_program: PathBuf,
     pub process_pool: HostedProcessPool,
-    pub claude_turn_timeout: Duration,
     pub operator_diagnostics: Arc<OperatorDiagnosticStore>,
 }
 
@@ -224,7 +223,6 @@ impl ProductionCapsuleAllocator {
                     runtime_home: filesystem.runtime_home.clone(),
                     local_user_home: None,
                     base_environment,
-                    turn_timeout: self.config.claude_turn_timeout,
                     process_pool,
                 }))
             }

--- a/zeroshot/src/native_v2_hosting/tests/fixtures.rs
+++ b/zeroshot/src/native_v2_hosting/tests/fixtures.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
 
 use openengine_cluster_protocol::{
     DeclaredConnections, DeclaredEnvironment, GraphSpec, IdempotencyKey, NodeName, RunSize,
@@ -81,7 +80,6 @@ pub(super) fn hosting_config(storage_root: PathBuf) -> ProductionHostingConfig {
         git_program: PathBuf::from("/usr/bin/git"),
         gh_program: PathBuf::from("/usr/bin/false"),
         process_pool: test_process_pool(),
-        claude_turn_timeout: Duration::from_secs(1),
     }
 }
 
@@ -97,7 +95,6 @@ pub(super) fn capsule_config(storage_root: PathBuf) -> ProductionCapsuleConfig {
         git_program: config.git_program,
         gh_program: config.gh_program,
         process_pool: allocator_process_pool(),
-        claude_turn_timeout: config.claude_turn_timeout,
         operator_diagnostics: std::sync::Arc::new(
             crate::native_v2_target_authority::OperatorDiagnosticStore::default(),
         ),

--- a/zeroshot/src/native_v2_local.rs
+++ b/zeroshot/src/native_v2_local.rs
@@ -9,7 +9,6 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
-use std::time::Duration;
 
 use openengine_cluster_protocol::{
     RunId, RunSubmission, RuntimePlan, SourceBranchId, SourceRepositoryId, SourceRevisionId,
@@ -35,7 +34,6 @@ use crate::native_v2_supervisor::{RunEnvironment, RunEnvironmentError};
 
 const DEFAULT_SEARCH_PATH: &str = "/usr/local/bin:/usr/bin:/bin";
 const MAX_GIT_OUTPUT_BYTES: usize = 16 * 1024;
-const LOCAL_TURN_TIMEOUT: Duration = Duration::from_secs(6 * 60 * 60);
 
 #[derive(Debug, Error)]
 pub enum LocalCompositionError {
@@ -235,7 +233,6 @@ pub fn build_local_process_candidate(
                 runtime_home: runtime_home.clone(),
                 local_user_home: local_home,
                 base_environment: local_claude_environment(&search_path)?,
-                turn_timeout: LOCAL_TURN_TIMEOUT,
                 process_pool,
             })
         }

--- a/zeroshot/src/native_v2_runner.rs
+++ b/zeroshot/src/native_v2_runner.rs
@@ -421,3 +421,5 @@ pub(crate) mod test_support;
 #[cfg(test)]
 #[path = "native_v2_runner/tests.rs"]
 mod tests;
+
+pub(crate) use output::current_timestamp;

--- a/zeroshot/src/native_v2_runner/output.rs
+++ b/zeroshot/src/native_v2_runner/output.rs
@@ -302,7 +302,7 @@ pub(super) fn durable_output_event(output: LiveOutput) -> DurableNodeEvent {
     }
 }
 
-pub(super) fn current_timestamp() -> UnixTimestampMillis {
+pub(crate) fn current_timestamp() -> UnixTimestampMillis {
     let milliseconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .ok()

--- a/zeroshot/src/native_v2_supervisor/controller.rs
+++ b/zeroshot/src/native_v2_supervisor/controller.rs
@@ -163,14 +163,36 @@ impl NativeV2Supervisor {
         reference: ExecutionRef,
         outcome: WorkerOutcome,
     ) -> Result<(), NativeV2SupervisorError> {
-        self.ledger
-            .append(
-                &self.run_id,
-                vec![RunEvent::NodeCompleted {
-                    completion: NodeCompletion { reference, outcome },
-                }],
-            )
-            .await?;
+        self.append_completion(reference, outcome, None).await
+    }
+
+    async fn append_completion(
+        &self,
+        reference: ExecutionRef,
+        outcome: WorkerOutcome,
+        elapsed: Option<Duration>,
+    ) -> Result<(), NativeV2SupervisorError> {
+        let mut events = Vec::new();
+        if let Some(code) = outcome.error_code() {
+            let timing = elapsed.map_or_else(String::new, |duration| {
+                format!(" after {:.1}s", duration.as_secs_f64())
+            });
+            events.push(RunEvent::SafeLog {
+                execution: Some(reference.execution),
+                timestamp: crate::native_v2_runner::current_timestamp(),
+                stream: SafeLogStream::Error,
+                line: SafeLogLine::new(format!(
+                    "Node {} failed: {}{}",
+                    reference.node.as_str(),
+                    code.as_str(),
+                    timing,
+                ))?,
+            });
+        }
+        events.push(RunEvent::NodeCompleted {
+            completion: NodeCompletion { reference, outcome },
+        });
+        self.ledger.append(&self.run_id, events).await?;
         Ok(())
     }
 
@@ -220,18 +242,8 @@ impl NativeV2Supervisor {
         }
         let force = self.snapshot().await?.force_stop_requested;
         let outcome = settled_outcome(&finished.reference, finished.result, force)?;
-        self.ledger
-            .append(
-                &self.run_id,
-                vec![RunEvent::NodeCompleted {
-                    completion: NodeCompletion {
-                        reference: finished.reference,
-                        outcome,
-                    },
-                }],
-            )
-            .await?;
-        Ok(())
+        self.append_completion(finished.reference, outcome, Some(finished.elapsed))
+            .await
     }
 
     pub(super) async fn append_terminal(

--- a/zeroshot/src/native_v2_supervisor/runtime.rs
+++ b/zeroshot/src/native_v2_supervisor/runtime.rs
@@ -28,7 +28,7 @@ pub(super) enum Initialization {
 
 pub(super) struct RunProgram {
     pub(super) admitted: AdmittedRun,
-    pub(super) timeouts: BTreeMap<NodeName, Duration>,
+    pub(super) timeouts: BTreeMap<NodeName, Option<Duration>>,
     pub(super) instructions: BTreeMap<NodeName, Option<NodeInstructions>>,
 }
 
@@ -105,11 +105,12 @@ pub(super) struct FinishedDispatch {
     pub(super) execution: ExecutionId,
     pub(super) reference: ExecutionRef,
     pub(super) result: DispatchResult,
+    pub(super) elapsed: Duration,
 }
 
 pub(super) struct DispatchTask {
     pub(super) handle: NodeHandle,
-    pub(super) timeout: Duration,
+    pub(super) timeout: Option<Duration>,
     pub(super) cancel: oneshot::Receiver<ExecutionInterrupt>,
     pub(super) ledger: Arc<dyn RunLedger>,
     pub(super) run_id: RunId,
@@ -127,12 +128,15 @@ pub(super) async fn run_dispatch(task: DispatchTask) -> FinishedDispatch {
         registration,
         output,
     } = task;
+    let started = tokio::time::Instant::now();
     let reference = handle.reference().clone();
     let execution = reference.execution;
     let events = tokio::spawn(bridge_durable_events(ledger, run_id, execution, output));
     let interrupt = async {
         tokio::select! {
-            _ = tokio::time::sleep(timeout) => DispatchResult::TimedOut,
+            _ = crate::execution::process::wait_for_deadline(
+                timeout.map(|duration| tokio::time::Instant::now() + duration),
+            ) => DispatchResult::TimedOut,
             _ = cancel => DispatchResult::Interrupted,
         }
     };
@@ -154,6 +158,7 @@ pub(super) async fn run_dispatch(task: DispatchTask) -> FinishedDispatch {
         registration.close().await;
     }
     FinishedDispatch {
+        elapsed: started.elapsed(),
         execution,
         reference,
         result,
@@ -287,7 +292,7 @@ pub(super) fn next_execution(
 }
 
 pub(super) struct ExecutionCatalog {
-    pub(super) timeouts: BTreeMap<NodeName, Duration>,
+    pub(super) timeouts: BTreeMap<NodeName, Option<Duration>>,
     pub(super) instructions: BTreeMap<NodeName, Option<NodeInstructions>>,
 }
 
@@ -305,13 +310,13 @@ fn collect_execution_metadata(node: &GraphNode, catalog: &mut ExecutionCatalog) 
         GraphNode::Step(node) => record_execution_metadata(
             catalog,
             &node.name,
-            node.timeout_ms.get(),
+            node.timeout_ms.map(|value| value.get()),
             &node.instructions,
         ),
         GraphNode::Verifier(node) => record_execution_metadata(
             catalog,
             &node.name,
-            node.timeout_ms.get(),
+            node.timeout_ms.map(|value| value.get()),
             &node.instructions,
         ),
         GraphNode::Seq(node) => node
@@ -342,12 +347,12 @@ fn collect_execution_metadata(node: &GraphNode, catalog: &mut ExecutionCatalog) 
 fn record_execution_metadata(
     catalog: &mut ExecutionCatalog,
     name: &NodeName,
-    timeout_ms: u64,
+    timeout_ms: Option<u64>,
     instructions: &Option<NodeInstructions>,
 ) {
     catalog
         .timeouts
-        .insert(name.clone(), Duration::from_millis(timeout_ms));
+        .insert(name.clone(), timeout_ms.map(Duration::from_millis));
     catalog
         .instructions
         .insert(name.clone(), instructions.clone());

--- a/zeroshot/src/native_v2_supervisor/tests/cases_2.rs
+++ b/zeroshot/src/native_v2_supervisor/tests/cases_2.rs
@@ -42,7 +42,7 @@ async fn timeout_cancels_then_acknowledges_cleanup_before_settlement() {
         .assert_value_with("tail");
     assert!(tail.events.iter().any(|event| matches!(
         &event.event,
-        RunEvent::SafeLog { line, .. } if line.as_str() == "worker"
+        RunEvent::SafeLog { line, .. } if line.as_str().starts_with("Node worker failed: timeout after ")
     )));
 }
 
@@ -193,4 +193,66 @@ async fn force_stop_closes_active_work_and_never_dispatches_again() {
         .position(|event| matches!(event.event, RunEvent::Terminal { .. }))
         .assert_value_with("terminal event");
     assert!(log < completed && completed < terminal);
+}
+
+#[tokio::test(start_paused = true)]
+async fn nodes_without_deadlines_finish_after_the_old_worker_limit() {
+    for (mut node, outcome) in [
+        (step("worker", 1), success_for(NodeRole::Worker)),
+        (verifier("worker", 1), verifier_outcome("accepted")),
+    ] {
+        node.as_object_mut().assert_value().remove("timeoutMs");
+        let harness = harness(
+            graph(
+                sequence(vec![node, succeed("done")], null_type()),
+                null_type(),
+            ),
+            Value::Null,
+            FakeDriver::scripted([(
+                "worker",
+                vec![Behavior::Complete {
+                    delay: Duration::from_secs(2 * 60 * 60),
+                    outcome: outcome.clone(),
+                }],
+            )]),
+        )
+        .await;
+        harness.supervisor.drive().await.assert_value();
+        assert_eq!(harness.driver.cancellations("worker"), 0);
+        assert!(
+            stored_run(&harness.ledger)
+                .await
+                .snapshot
+                .executions
+                .values()
+                .any(|execution| execution.outcome() == Some(&outcome))
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn unbounded_worker_survives_seven_hours_and_can_be_stopped() {
+    let mut worker = step("worker", 1);
+    worker.as_object_mut().assert_value().remove("timeoutMs");
+    let harness = harness(
+        graph(
+            sequence(vec![worker, succeed("done")], null_type()),
+            null_type(),
+        ),
+        Value::Null,
+        FakeDriver::scripted([("worker", vec![Behavior::Hang])]),
+    )
+    .await;
+    let supervisor = harness.supervisor.clone();
+    let drive = tokio::spawn(async move { supervisor.drive().await });
+    while harness.driver.starts("worker") == 0 {
+        tokio::task::yield_now().await;
+    }
+    tokio::time::advance(Duration::from_secs(7 * 60 * 60)).await;
+    assert!(!drive.is_finished());
+    assert_eq!(harness.driver.cancellations("worker"), 0);
+    harness.supervisor.force_stop().await.assert_value();
+    drive.await.assert_value().assert_value();
+    assert_eq!(harness.driver.cancellations("worker"), 1);
+    assert_eq!(harness.driver.state().active, 0);
 }

--- a/zeroshot/src/native_v2_templates.rs
+++ b/zeroshot/src/native_v2_templates.rs
@@ -31,7 +31,6 @@ use values::*;
 #[path = "native_v2_templates/tests.rs"]
 mod tests;
 
-const NODE_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
 const CHANGE_ITERATIONS: u64 = 10;
 const TASK_FIELD: &str = "task";
 const ACCEPTANCE_FEEDBACK_FIELD: &str = "acceptanceFeedback";
@@ -111,7 +110,7 @@ fn task_worker(
         output: PayloadType::Null,
         input_bindings: vec![state_input(TASK_FIELD, TASK_FIELD)?],
         write_bindings: Vec::new(),
-        timeout_ms: positive(NODE_TIMEOUT_MS)?,
+        timeout_ms: None,
         attempts: positive(1)?,
     }))
 }
@@ -229,7 +228,7 @@ fn review_verifier(spec: ReviewVerifierSpec<'_>) -> Result<GraphNode, BuiltinTem
             state_input(DELIVERY_FEEDBACK_FIELD, DELIVERY_FEEDBACK_FIELD)?,
         ],
         write_bindings,
-        timeout_ms: positive(NODE_TIMEOUT_MS)?,
+        timeout_ms: None,
         attempts: positive(MAX_AGENT_VERIFIER_ATTEMPTS)?,
         signals,
         diagnostic: diagnostic_type()?,
@@ -278,7 +277,7 @@ fn review_repair() -> Result<GraphNode, BuiltinTemplateError> {
             state_input(DELIVERY_FEEDBACK_FIELD, DELIVERY_FEEDBACK_FIELD)?,
         ],
         write_bindings: Vec::new(),
-        timeout_ms: positive(NODE_TIMEOUT_MS)?,
+        timeout_ms: None,
         attempts: positive(1)?,
     }))
 }
@@ -357,7 +356,7 @@ fn delivery_repair(mode: DeliveryMode) -> Result<GraphNode, BuiltinTemplateError
             state_input(DELIVERY_FEEDBACK_FIELD, DELIVERY_FEEDBACK_FIELD)?,
         ],
         write_bindings: Vec::new(),
-        timeout_ms: positive(NODE_TIMEOUT_MS)?,
+        timeout_ms: None,
         attempts: positive(1)?,
     }))
 }
@@ -377,7 +376,7 @@ fn delivery_node(mode: DeliveryMode) -> Result<GraphNode, BuiltinTemplateError> 
             state_input(ISSUE_NUMBER_FIELD, ISSUE_NUMBER_FIELD)?,
         ],
         write_bindings,
-        timeout_ms: positive(NODE_TIMEOUT_MS)?,
+        timeout_ms: None,
         attempts: positive(1)?,
         signals,
         diagnostic: static_value(delivery_diagnostic_schema())?,

--- a/zeroshot/src/native_v2_templates/tests.rs
+++ b/zeroshot/src/native_v2_templates/tests.rs
@@ -118,6 +118,14 @@ async fn every_supported_materialization_is_admissible() {
 
     for (template, delivery, expected) in cases {
         assert_admissible(template, delivery, &expected).await;
+        let graph = template.materialize(delivery).assert_value();
+        for node in all_nodes(&graph.root) {
+            match node {
+                GraphNode::Step(node) => assert!(node.timeout_ms.is_none()),
+                GraphNode::Verifier(node) => assert!(node.timeout_ms.is_none()),
+                _ => {}
+            }
+        }
     }
 }
 

--- a/zeroshot/tests/native_v2_cli_loopback/fixtures.rs
+++ b/zeroshot/tests/native_v2_cli_loopback/fixtures.rs
@@ -391,7 +391,6 @@ pub(crate) fn live_hosting_config(root: &TempRoot, lane: LiveLane) -> Production
         gh_program: PathBuf::from("/usr/bin/gh"),
         process_pool: HostedProcessPool::new(10_002, 10_002, 20_000, 20_000)
             .assert_value_with("production process pool"),
-        claude_turn_timeout: Duration::from_secs(10 * 60),
     }
 }
 

--- a/zeroshot/tests/native_v2_cli_loopback/retry.rs
+++ b/zeroshot/tests/native_v2_cli_loopback/retry.rs
@@ -149,7 +149,6 @@ impl RetryAllocator {
                 runtime_home: self.runtime_home.clone(),
                 local_user_home: None,
                 base_environment,
-                turn_timeout: Duration::from_secs(10),
                 process_pool: HostedProcessPool::new(10_002, 10_002, 20_000, 20_000)
                     .map_err(|_| CapsuleAllocationUnavailable::Runtime)?,
             })

--- a/zeroshot/tests/streaming_process_runner.rs
+++ b/zeroshot/tests/streaming_process_runner.rs
@@ -34,7 +34,7 @@ fn command(program: &str, argv: Vec<&str>) -> ProcessSessionCommand {
             current_dir: std::env::temp_dir(),
             mode: WorkspaceAccessMode::Exclusive,
         },
-        deadline: Instant::now() + Duration::from_secs(10),
+        deadline: Some(Instant::now() + Duration::from_secs(10)),
     }
 }
 
@@ -169,7 +169,7 @@ async fn cancellation_and_child_exit_races_settle_once() {
 async fn deadline_force_kills_and_reaps_the_session() {
     let (_cancel, cancellation) = cancellation_pair();
     let mut timed = command("/bin/sleep", vec!["30"]);
-    timed.deadline = Instant::now() + Duration::from_millis(50);
+    timed.deadline = Some(Instant::now() + Duration::from_millis(50));
     let mut session = LocalProcessRunner::new()
         .open(timed, cancellation)
         .await
@@ -387,4 +387,29 @@ async fn windows_job_release_reaps_a_descendant() {
     assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
     wait_for_process_exit(child_pid).await;
     let _ = fs::remove_file(pid_file);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unbounded_process_remains_cancellable_and_reaped() {
+    let (cancel, cancellation) = cancellation_pair();
+    let mut request = command("/bin/sleep", vec!["30"]);
+    request.deadline = None;
+    let mut session = LocalProcessRunner::new()
+        .open(request, cancellation)
+        .await
+        .assert_value();
+    assert!(
+        timeout(Duration::from_millis(30), session.wait())
+            .await
+            .is_err()
+    );
+    cancel.send(true).assert_value();
+    let completion = timeout(Duration::from_secs(2), session.wait())
+        .await
+        .assert_value()
+        .assert_value();
+    assert!(completion.cancelled);
+    assert!(!completion.timed_out);
+    assert_eq!(completion.cleanup, ProcessCleanupEvidence::Reaped);
 }


### PR DESCRIPTION
Built-in code-change runs could lose an active worker after one hour, and provider adapters imposed a separate six-hour limit. Omitted node deadlines now mean completion or cancellation; every built-in node omits them and provider sessions impose no additional execution deadline. Custom graphs can still specify positive deadlines.

Node failures now append their error code and elapsed time to durable logs before settlement, so an archived run retains the cause behind a generic terminal reason. The shared target-image smoke also requires the GNU Rust host after hosted build investigation found the musl compiler substantially slower.

Validation: full Rust workspace tests, Clippy with warnings denied, Rust docs, formatting, protocol regeneration/check, 28 tooling tests, lint, and distribution checks passed. Regression tests cover workers/verifiers beyond one hour, cancellation after seven simulated hours, explicit custom deadlines, and process cleanup. Opcore Verify is clean; Sense reports only matching wire fields and short test setup/assertion blocks, reviewed without adding abstractions to these independent contracts.

Related: the-open-engine/zero-cloud#270.
