### PR TITLE
fix(runtime): isolate verifier builds and settle fatal execution failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,13 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
 - Node deadlines are optional: omitted `timeoutMs` means completion or explicit cancellation.
   Built-in graphs have no node deadlines, and provider adapters impose no separate turn timeout.
   The supervisor records node error codes and elapsed time in durable logs before settlement.
+- A failed durable-output bridge cancels and drains its provider immediately. Fatal supervisor
+  errors and task panics close owned work and attempt runtime cleanup before durable failure.
+  If persistence is unavailable, the controller retains a minimal `runtime_failed` status at the
+  last observed durable cursor and records private operator diagnostics, including SQLite error codes.
+  This fallback creates no history events. Readable retained history drains normally; unavailable
+  history closes with `SOURCE_UNAVAILABLE`, never `done`. Compiler/runtime failure reasons
+  `unhandled`, `runtime_failed`, and `runtime_lost` are reserved against authored graph fail nodes.
 - Native-v2 retries only a settled `crash` outcome when the executable has another authored
   attempt. A provider session invalidated by that active execution becomes replaceable for the
   authorized retry; passive session loss and run closure remain permanent, fail-closed loss.
@@ -117,6 +124,11 @@ with `npm i -g @the-open-engine-company/zeroshot` or build `zeroshot` with Cargo
   tools. They expose Rust through the fixed runtime PATH without a shared writable Cargo cache;
   explicit user toolchain settings and installations take precedence. Runtime toolchain smoke
   tests compile native fixtures as an isolated user with a read-only root and fresh home.
+- Hosted verifiers build in disposable writable copies of the current candidate. Copies include
+  dirty files and build artifacts, preserve metadata, and use reflinks or independent file copies;
+  verifier writes are never promoted to the candidate or peers. Provider scratch permits execution.
+  Managed copies and execution-scoped homes are removed only after confirmed process-tree cleanup;
+  node-instance homes survive authorized continuation and loop revisits until session closure.
 
 ## CLI and target contracts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3181,6 +3181,7 @@ dependencies = [
  "clap",
  "dbus",
  "fs2",
+ "futures-util",
  "getrandom 0.3.4",
  "httparse",
  "keyring",

--- a/crates/openengine-cluster-protocol/src/graph.rs
+++ b/crates/openengine-cluster-protocol/src/graph.rs
@@ -376,7 +376,10 @@ pub struct FailReason(EnumLabel);
 
 impl FailReason {
     pub fn new(value: EnumLabel) -> Result<Self, FailReasonError> {
-        if value.as_str() == "unhandled" {
+        if matches!(
+            value.as_str(),
+            "unhandled" | "runtime_failed" | "runtime_lost"
+        ) {
             Err(FailReasonError)
         } else {
             Ok(Self(value))
@@ -390,7 +393,7 @@ impl FailReason {
 }
 
 #[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
-#[error("fail reason 'unhandled' is reserved for the compiler's implicit sink")]
+#[error("fail reason is reserved for the compiler or runtime")]
 pub struct FailReasonError;
 
 impl<'de> Deserialize<'de> for FailReason {
@@ -417,7 +420,7 @@ impl JsonSchema for FailReason {
             "type": "string",
             "minLength": 1,
             "maxLength": 128,
-            "pattern": "^(?!unhandled$)[A-Za-z_][A-Za-z0-9_.-]*$"
+            "pattern": "^(?!(?:unhandled|runtime_failed|runtime_lost)$)[A-Za-z_][A-Za-z0-9_.-]*$"
         })
     }
 }

--- a/crates/openengine-cluster-protocol/src/watch.rs
+++ b/crates/openengine-cluster-protocol/src/watch.rs
@@ -133,6 +133,10 @@ pub enum SubscriptionCloseReason {
     Done,
     #[serde(rename = "SLOW_CONSUMER")]
     SlowConsumer,
+    /// The source could not read the remaining history; delivered events are retained, but the
+    /// stream is incomplete. This is not a successful end or a request to reconnect indefinitely.
+    #[serde(rename = "SOURCE_UNAVAILABLE")]
+    SourceUnavailable,
 }
 
 /// Wire body of the terminal `subscription/closed` server notification.

--- a/crates/openengine-cluster-protocol/tests/graph_wire.rs
+++ b/crates/openengine-cluster-protocol/tests/graph_wire.rs
@@ -319,9 +319,23 @@ fn identifier_keyed_maps_enforce_wire_identifier_bounds_in_rust_and_schema() {
 }
 
 #[test]
-fn authored_fail_nodes_cannot_use_the_reserved_unhandled_reason() {
-    let value = json!({"kind":"fail", "name":"sink", "reason":"unhandled"});
-    assert!(serde_json::from_value::<openengine_cluster_protocol::GraphNode>(value).is_err());
+fn authored_fail_nodes_cannot_use_compiler_or_runtime_reasons() {
+    let schema = schemars::schema_for!(openengine_cluster_protocol::GraphNode);
+    let schema = serde_json::to_value(schema).assert_value();
+    let validator = jsonschema::validator_for(&schema).assert_value();
+    for reason in ["unhandled", "runtime_failed", "runtime_lost", "task_failed"] {
+        let value = json!({"kind":"fail", "name":"sink", "reason":reason});
+        let allowed = reason == "task_failed";
+        assert_eq!(
+            validator.is_valid(&value),
+            allowed,
+            "schema reason {reason}"
+        );
+        assert_eq!(
+            serde_json::from_value::<openengine_cluster_protocol::GraphNode>(value).is_ok(),
+            allowed
+        );
+    }
 }
 
 #[test]

--- a/crates/openengine-cluster-protocol/tests/watch.rs
+++ b/crates/openengine-cluster-protocol/tests/watch.rs
@@ -201,14 +201,21 @@ fn subscription_cancel_params_round_trip_and_are_closed() {
 
 #[test]
 fn subscription_close_reason_uses_mixed_case_wire_values() {
-    assert_eq!(
-        serde_json::to_value(SubscriptionCloseReason::Done).assert_value(),
-        json!("done")
-    );
-    assert_eq!(
-        serde_json::to_value(SubscriptionCloseReason::SlowConsumer).assert_value(),
-        json!("SLOW_CONSUMER")
-    );
+    for (reason, wire) in [
+        (SubscriptionCloseReason::Done, "done"),
+        (SubscriptionCloseReason::SlowConsumer, "SLOW_CONSUMER"),
+        (
+            SubscriptionCloseReason::SourceUnavailable,
+            "SOURCE_UNAVAILABLE",
+        ),
+    ] {
+        let encoded = serde_json::to_value(reason).assert_value();
+        assert_eq!(encoded, json!(wire));
+        assert_eq!(
+            serde_json::from_value::<SubscriptionCloseReason>(encoded).assert_value(),
+            reason
+        );
+    }
     assert!(serde_json::from_value::<SubscriptionCloseReason>(json!("SlowConsumer")).is_err());
 }
 

--- a/protocol/openengine-cluster/v1/compiled-ir.schema.json
+++ b/protocol/openengine-cluster/v1/compiled-ir.schema.json
@@ -582,7 +582,7 @@
             "reason": {
               "maxLength": 128,
               "minLength": 1,
-              "pattern": "^(?!unhandled$)[A-Za-z_][A-Za-z0-9_.-]*$",
+              "pattern": "^(?!(?:unhandled|runtime_failed|runtime_lost)$)[A-Za-z_][A-Za-z0-9_.-]*$",
               "type": "string"
             }
           },

--- a/protocol/openengine-cluster/v1/graph.schema.json
+++ b/protocol/openengine-cluster/v1/graph.schema.json
@@ -804,7 +804,7 @@
             "reason": {
               "maxLength": 128,
               "minLength": 1,
-              "pattern": "^(?!unhandled$)[A-Za-z_][A-Za-z0-9_.-]*$",
+              "pattern": "^(?!(?:unhandled|runtime_failed|runtime_lost)$)[A-Za-z_][A-Za-z0-9_.-]*$",
               "type": "string"
             }
           },

--- a/protocol/openengine-cluster/v1/schema.json
+++ b/protocol/openengine-cluster/v1/schema.json
@@ -1447,7 +1447,7 @@
             "reason": {
               "maxLength": 128,
               "minLength": 1,
-              "pattern": "^(?!unhandled$)[A-Za-z_][A-Za-z0-9_.-]*$",
+              "pattern": "^(?!(?:unhandled|runtime_failed|runtime_lost)$)[A-Za-z_][A-Za-z0-9_.-]*$",
               "type": "string"
             }
           },
@@ -4520,11 +4520,20 @@
       "type": "object"
     },
     "SubscriptionCloseReason": {
-      "enum": [
-        "done",
-        "SLOW_CONSUMER"
-      ],
-      "type": "string"
+      "oneOf": [
+        {
+          "enum": [
+            "done",
+            "SLOW_CONSUMER"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "SOURCE_UNAVAILABLE",
+          "description": "The source could not read the remaining history; delivered events are retained, but the\nstream is incomplete. This is not a successful end or a request to reconnect indefinitely.",
+          "type": "string"
+        }
+      ]
     },
     "SubscriptionClosedNotification": {
       "additionalProperties": false,

--- a/zeroshot/Cargo.toml
+++ b/zeroshot/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 async-trait.workspace = true
 clap.workspace = true
 fs2.workspace = true
+futures-util.workspace = true
 getrandom.workspace = true
 httparse.workspace = true
 libc.workspace = true

--- a/zeroshot/src/execution/process/platform_unix.rs
+++ b/zeroshot/src/execution/process/platform_unix.rs
@@ -163,10 +163,10 @@ fn linux_entry_process_group(entry: std::fs::DirEntry) -> Result<Option<i32>, io
     let Some(pid) = linux_entry_pid(&entry) else {
         return Ok(None);
     };
-    let stat = match std::fs::read_to_string(entry.path().join("stat")) {
-        Ok(stat) => stat,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error),
+    let Some(stat) =
+        resolve_linux_process_read(std::fs::read_to_string(entry.path().join("stat")))?
+    else {
+        return Ok(None);
     };
     linux_process_group(&stat).map(Some).ok_or_else(|| {
         io::Error::new(
@@ -373,10 +373,10 @@ fn linux_uid_processes(worker_uid: u32) -> Result<Vec<i32>, io::Error> {
         let Some(pid) = linux_entry_pid(&entry) else {
             continue;
         };
-        let status = match std::fs::read_to_string(entry.path().join("status")) {
-            Ok(status) => status,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
-            Err(error) => return Err(error),
+        let Some(status) =
+            resolve_linux_process_read(std::fs::read_to_string(entry.path().join("status")))?
+        else {
+            continue;
         };
         let effective_uid = linux_effective_uid(&status).ok_or_else(|| {
             io::Error::new(
@@ -389,6 +389,21 @@ fn linux_uid_processes(worker_uid: u32) -> Result<Vec<i32>, io::Error> {
         }
     }
     Ok(pids)
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_linux_process_read(read: io::Result<String>) -> io::Result<Option<String>> {
+    match read {
+        Ok(contents) => Ok(Some(contents)),
+        // A process may disappear before open (ENOENT) or after open but before read (ESRCH).
+        Err(error)
+            if error.kind() == io::ErrorKind::NotFound
+                || error.raw_os_error() == Some(libc::ESRCH) =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -429,3 +444,7 @@ pub(super) fn process_group_has_live_members(process_group_id: i32) -> Result<bo
         .map(str::trim)
         .any(|state| !state.is_empty()))
 }
+
+#[cfg(all(test, target_os = "linux"))]
+#[path = "platform_unix/tests.rs"]
+mod tests;

--- a/zeroshot/src/execution/process/platform_unix/tests.rs
+++ b/zeroshot/src/execution/process/platform_unix/tests.rs
@@ -1,0 +1,53 @@
+use std::fs::File;
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+use openengine_cluster_testkit::assertions::AssertValue;
+
+use super::*;
+
+#[test]
+fn process_files_opened_before_exit_are_treated_as_absent() {
+    let mut child = Command::new("/bin/sh")
+        .args(["-c", "read line"])
+        .stdin(Stdio::piped())
+        .spawn()
+        .assert_value();
+    let files = ["stat", "status"]
+        .map(|name| File::open(format!("/proc/{}/{name}", child.id())).assert_value());
+    drop(child.stdin.take());
+    child.wait().assert_value();
+
+    for mut file in files {
+        let mut contents = String::new();
+        let read = file.read_to_string(&mut contents);
+        assert_eq!(
+            read.as_ref().err().and_then(io::Error::raw_os_error),
+            Some(libc::ESRCH)
+        );
+        assert!(
+            resolve_linux_process_read(read.map(|_| contents))
+                .assert_value()
+                .is_none()
+        );
+    }
+}
+
+#[test]
+fn process_file_reads_preserve_contents_and_unrelated_errors() {
+    assert_eq!(
+        resolve_linux_process_read(Ok("process metadata".to_owned())).assert_value(),
+        Some("process metadata".to_owned())
+    );
+    assert!(
+        resolve_linux_process_read(Err(io::Error::from_raw_os_error(libc::ENOENT)))
+            .assert_value()
+            .is_none()
+    );
+    for code in [libc::EACCES, libc::EPERM, libc::EIO, libc::EINVAL] {
+        let error = resolve_linux_process_read(Err(io::Error::from_raw_os_error(code)))
+            .err()
+            .assert_value();
+        assert_eq!(error.raw_os_error(), Some(code));
+    }
+}

--- a/zeroshot/src/native_v2_candidate/test_support.rs
+++ b/zeroshot/src/native_v2_candidate/test_support.rs
@@ -246,3 +246,14 @@ impl TestGitRepository {
         }
     }
 }
+
+pub(crate) fn assert_removed_directories(paths: &[&str], expected_count: usize) {
+    let unique = paths.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(unique.len(), expected_count);
+    for path in unique {
+        assert!(
+            !Path::new(path).exists(),
+            "execution directory remains: {path}"
+        );
+    }
+}

--- a/zeroshot/src/native_v2_capsule/provider_process.rs
+++ b/zeroshot/src/native_v2_capsule/provider_process.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
@@ -17,6 +18,12 @@ use crate::native_v2_runner::{
     DriverControl, DriverInvocation, LiveOutput, LiveOutputStream, NodeRole, NodeRunnerError,
 };
 use crate::worker_catalog::ReasoningEffort;
+
+mod contained;
+mod filesystem;
+
+pub(crate) use contained::ProviderProcess;
+pub(crate) use filesystem::{ProviderExecution, ProviderExecutionFiles, ProviderFilesystemConfig};
 
 const CONTINUE_PROMPT: &str = "Continue";
 
@@ -85,7 +92,7 @@ pub(crate) struct ProcessInputFailure<T> {
 /// Cleanup and output draining remain concurrent after an input failure so parsed metadata is
 /// retained without introducing another output buffer.
 pub(crate) async fn exchange_process_io<T>(
-    process: &mut ProcessSession,
+    process: &mut ProviderProcess,
     bytes: &[u8],
     output: impl Future<Output = T>,
 ) -> ProcessExchange<T> {
@@ -127,15 +134,18 @@ pub(crate) async fn exchange_process_io<T>(
 }
 
 pub(crate) async fn open_provider_process(
-    runner: LocalProcessRunner,
+    files: Arc<ProviderExecutionFiles>,
     command: ProcessSessionCommand,
     control: &DriverControl,
-) -> Result<Result<ProcessSession, ProcessRunnerError>, NodeRunnerError> {
-    match runner.open(command, control.cancellation()).await {
-        Ok(process) => Ok(Ok(process)),
+) -> Result<Result<ProviderProcess, ProcessRunnerError>, NodeRunnerError> {
+    files.begin_process();
+    match files.runner.open(command, control.cancellation()).await {
+        Ok(process) => Ok(Ok(ProviderProcess::new(process, files))),
         Err(error) => {
             if error.launch_evidence() == ProcessLaunchEvidence::MayHaveStarted {
                 control.record_token_usage(None).await?;
+            } else {
+                files.process_reaped();
             }
             if control.is_cancelled() {
                 return Err(NodeRunnerError::Cancelled);
@@ -148,6 +158,7 @@ pub(crate) async fn open_provider_process(
 pub(crate) struct ProviderSessionCore {
     live: AtomicBool,
     pub(crate) turn: Mutex<()>,
+    home: Mutex<Option<Arc<filesystem::PrivateDirectory>>>,
 }
 
 macro_rules! impl_provider_node_session {
@@ -163,7 +174,7 @@ macro_rules! impl_provider_node_session {
             }
 
             async fn close(&self) {
-                self.core.close();
+                self.core.close().await;
             }
         }
     };
@@ -191,6 +202,7 @@ impl ProviderSessionCore {
         Self {
             live: AtomicBool::new(true),
             turn: Mutex::new(()),
+            home: Mutex::new(None),
         }
     }
 
@@ -198,8 +210,32 @@ impl ProviderSessionCore {
         self.live.load(Ordering::Acquire)
     }
 
-    pub(crate) fn close(&self) {
+    pub(crate) async fn close(&self) {
         self.live.store(false, Ordering::Release);
+        self.home.lock().await.take();
+    }
+
+    async fn retain_home(
+        &self,
+        path: PathBuf,
+    ) -> Result<Arc<filesystem::PrivateDirectory>, ProcessRunnerError> {
+        let mut home = self.home.lock().await;
+        if !self.is_live() {
+            return Err(ProcessRunnerError::InvalidCommand(
+                "provider session is closed".to_owned(),
+            ));
+        }
+        if let Some(home) = home.as_ref() {
+            if home.path() != path {
+                return Err(ProcessRunnerError::InvalidCommand(
+                    "provider session home changed".to_owned(),
+                ));
+            }
+            return Ok(home.clone());
+        }
+        let directory = Arc::new(filesystem::PrivateDirectory::retained(path));
+        *home = Some(directory.clone());
+        Ok(directory)
     }
 
     pub(crate) fn ensure_live(

--- a/zeroshot/src/native_v2_capsule/provider_process/contained.rs
+++ b/zeroshot/src/native_v2_capsule/provider_process/contained.rs
@@ -1,0 +1,61 @@
+//! Couples filesystem lifetime to confirmed contained-process cleanup.
+
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+use crate::execution::process::{ProcessRunnerError, ProcessSession, ProcessSessionOutput};
+
+use super::filesystem::ProviderExecutionFiles;
+
+pub(crate) struct ProviderProcess {
+    process: ProcessSession,
+    files: Arc<ProviderExecutionFiles>,
+    pending: bool,
+}
+
+impl ProviderProcess {
+    pub(super) fn new(process: ProcessSession, files: Arc<ProviderExecutionFiles>) -> Self {
+        Self {
+            process,
+            files,
+            pending: true,
+        }
+    }
+
+    pub(crate) async fn wait(&mut self) -> Result<ProcessSessionOutput, ProcessRunnerError> {
+        let result = self.process.wait().await;
+        self.record_completion(&result);
+        result
+    }
+
+    pub(crate) async fn release(&mut self) -> Result<ProcessSessionOutput, ProcessRunnerError> {
+        let result = self.process.release().await;
+        self.record_completion(&result);
+        result
+    }
+
+    fn record_completion(&mut self, result: &Result<ProcessSessionOutput, ProcessRunnerError>) {
+        if self.pending
+            && result
+                .as_ref()
+                .is_ok_and(|output| output.cleanup.proves_tree_empty())
+        {
+            self.files.process_reaped();
+            self.pending = false;
+        }
+    }
+}
+
+impl Deref for ProviderProcess {
+    type Target = ProcessSession;
+
+    fn deref(&self) -> &Self::Target {
+        &self.process
+    }
+}
+
+impl DerefMut for ProviderProcess {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.process
+    }
+}

--- a/zeroshot/src/native_v2_capsule/provider_process/filesystem.rs
+++ b/zeroshot/src/native_v2_capsule/provider_process/filesystem.rs
@@ -1,0 +1,401 @@
+//! Disposable build workspaces and session-private homes for provider processes.
+
+use std::fs;
+use std::io;
+#[cfg(target_os = "linux")]
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::sync::Mutex;
+
+use crate::execution::driver::DriverCancellation;
+use crate::execution::process::{HostedProcessIdentity, LocalProcessRunner, ProcessRunnerError};
+use crate::native_v2_runner::{DriverControl, DriverInvocation, NodeRole};
+
+use super::{ProviderProcessRunners, ProviderSessionCore, process_scope};
+
+#[derive(Clone, Copy)]
+pub(crate) struct ProviderFilesystemConfig<'a> {
+    pub(crate) runners: ProviderProcessRunners,
+    pub(crate) root: &'a Path,
+    pub(crate) workspace: &'a Path,
+}
+
+pub(crate) struct ProviderExecution<'a> {
+    config: ProviderFilesystemConfig<'a>,
+    invocation: &'a DriverInvocation,
+    session: &'a ProviderSessionCore,
+    files: Mutex<Option<Arc<ProviderExecutionFiles>>>,
+}
+
+impl<'a> ProviderExecution<'a> {
+    pub(crate) fn new(
+        config: ProviderFilesystemConfig<'a>,
+        invocation: &'a DriverInvocation,
+        session: &'a ProviderSessionCore,
+    ) -> Self {
+        Self {
+            config,
+            invocation,
+            session,
+            files: Mutex::new(None),
+        }
+    }
+
+    pub(crate) async fn prepare(
+        &self,
+        control: &DriverControl,
+    ) -> Result<Arc<ProviderExecutionFiles>, ProcessRunnerError> {
+        let mut files = self.files.lock().await;
+        if let Some(files) = files.as_ref() {
+            files.ensure_idle()?;
+            return Ok(files.clone());
+        }
+        let specification = self.specification(control).await?;
+        let prepared =
+            tokio::task::spawn_blocking(move || ProviderExecutionFiles::prepare(specification))
+                .await
+                .map_err(|_| {
+                    ProcessRunnerError::Launch(
+                        "provider filesystem preparation task failed".to_owned(),
+                    )
+                })??;
+        let prepared = Arc::new(prepared);
+        *files = Some(prepared.clone());
+        Ok(prepared)
+    }
+
+    async fn specification(
+        &self,
+        control: &DriverControl,
+    ) -> Result<ExecutionFilesystemSpec, ProcessRunnerError> {
+        let scope = process_scope(self.invocation).map_err(|_| {
+            ProcessRunnerError::InvalidCommand("provider filesystem scope is invalid".to_owned())
+        })?;
+        let (runner, home) = self.config.runners.turn_process(self.config.root, scope)?;
+        let home = self.session.retain_home(home).await?;
+        let identity = match self.config.runners {
+            ProviderProcessRunners::Hosted(pool) => Some(pool.identity(scope)?),
+            ProviderProcessRunners::Local => None,
+        };
+        Ok(ExecutionFilesystemSpec {
+            runner,
+            home,
+            root: self.config.root.join(format!(
+                "execution-{}",
+                self.invocation.node.reference.execution.get()
+            )),
+            candidate: self.config.workspace.to_owned(),
+            verifier_copy: identity.is_some() && self.invocation.role == NodeRole::Verifier,
+            identity,
+            cancellation: control.cancellation(),
+        })
+    }
+}
+
+pub(super) struct PrivateDirectory {
+    path: PathBuf,
+    processes: AtomicUsize,
+}
+
+impl PrivateDirectory {
+    pub(super) fn retained(path: PathBuf) -> Self {
+        Self {
+            path,
+            processes: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn create(path: PathBuf) -> io::Result<Self> {
+        create_private_directory(&path)?;
+        Ok(Self::retained(path))
+    }
+}
+
+impl Drop for PrivateDirectory {
+    fn drop(&mut self) {
+        // An unproven process exit must leave files intact for whole-run cleanup.
+        if self.processes.load(Ordering::Acquire) != 0 {
+            return;
+        }
+        if fs::symlink_metadata(&self.path).is_ok_and(|metadata| metadata.is_dir()) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+struct ExecutionFilesystemSpec {
+    runner: LocalProcessRunner,
+    home: Arc<PrivateDirectory>,
+    root: PathBuf,
+    candidate: PathBuf,
+    verifier_copy: bool,
+    identity: Option<HostedProcessIdentity>,
+    cancellation: DriverCancellation,
+}
+
+pub(crate) struct ProviderExecutionFiles {
+    pub(crate) runner: LocalProcessRunner,
+    pub(crate) workspace: PathBuf,
+    scratch: PathBuf,
+    pub(crate) isolated_workspace: bool,
+    home: Arc<PrivateDirectory>,
+    root: PrivateDirectory,
+}
+
+impl ProviderExecutionFiles {
+    fn prepare(specification: ExecutionFilesystemSpec) -> Result<Self, ProcessRunnerError> {
+        Self::prepare_io(specification).map_err(|error| {
+            ProcessRunnerError::Launch(format!("provider filesystem preparation failed: {error}"))
+        })
+    }
+
+    fn prepare_io(specification: ExecutionFilesystemSpec) -> io::Result<Self> {
+        check_cancelled(&specification.cancellation)?;
+        let root = PrivateDirectory::create(specification.root.clone())?;
+        let scratch = root.path.join("tmp");
+        create_private_directory(&scratch)?;
+        set_owner(&scratch, specification.identity)?;
+        let workspace = if specification.verifier_copy {
+            let workspace = root.path.join("workspace");
+            copy_candidate(&specification, &workspace)?;
+            workspace
+        } else {
+            specification.candidate
+        };
+        set_owner(&root.path, specification.identity)?;
+        Ok(Self {
+            runner: specification.runner,
+            workspace,
+            scratch,
+            isolated_workspace: specification.verifier_copy,
+            home: specification.home,
+            root,
+        })
+    }
+
+    pub(crate) fn home(&self) -> &Path {
+        self.home.path()
+    }
+
+    pub(crate) fn scratch_text(&self) -> Result<String, ProcessRunnerError> {
+        self.scratch.to_str().map(str::to_owned).ok_or_else(|| {
+            ProcessRunnerError::InvalidCommand(
+                "provider scratch path is not valid UTF-8".to_owned(),
+            )
+        })
+    }
+
+    pub(crate) fn begin_process(&self) {
+        self.root.processes.fetch_add(1, Ordering::AcqRel);
+        self.home.processes.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(crate) fn process_reaped(&self) {
+        self.root.processes.fetch_sub(1, Ordering::AcqRel);
+        self.home.processes.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn ensure_idle(&self) -> Result<(), ProcessRunnerError> {
+        if self.root.processes.load(Ordering::Acquire) != 0 {
+            return Err(ProcessRunnerError::Launch(
+                "previous provider process cleanup was not confirmed".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn create_private_directory(path: &Path) -> io::Result<()> {
+    let mut builder = fs::DirBuilder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+    builder.create(path)
+}
+
+fn check_cancelled(cancellation: &DriverCancellation) -> io::Result<()> {
+    if cancellation.is_cancelled() {
+        return Err(io::Error::other(
+            "provider filesystem preparation cancelled",
+        ));
+    }
+    Ok(())
+}
+
+fn set_owner(path: &Path, identity: Option<HostedProcessIdentity>) -> io::Result<()> {
+    #[cfg(target_os = "linux")]
+    if let Some(identity) = identity {
+        std::os::unix::fs::lchown(path, Some(identity.uid()), Some(identity.gid()))?;
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = (path, identity);
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn copy_candidate(specification: &ExecutionFilesystemSpec, workspace: &Path) -> io::Result<()> {
+    let candidate = fs::canonicalize(&specification.candidate)?;
+    let runtime_root = fs::canonicalize(
+        specification
+            .root
+            .parent()
+            .ok_or_else(|| io::Error::other("missing runtime root"))?,
+    )?;
+    if candidate.starts_with(&runtime_root) || runtime_root.starts_with(&candidate) {
+        return Err(io::Error::other("candidate and runtime roots overlap"));
+    }
+    copy_entry(&candidate, workspace, specification)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn copy_candidate(_specification: &ExecutionFilesystemSpec, _workspace: &Path) -> io::Result<()> {
+    Err(io::Error::other("hosted verifier copies require Linux"))
+}
+
+#[cfg(target_os = "linux")]
+fn copy_entry(
+    source: &Path,
+    destination: &Path,
+    specification: &ExecutionFilesystemSpec,
+) -> io::Result<()> {
+    check_cancelled(&specification.cancellation)?;
+    let metadata = fs::symlink_metadata(source)?;
+    copy_contents(source, destination, &metadata, specification)?;
+    set_owner(destination, specification.identity)?;
+    preserve_times(destination, &metadata)
+}
+
+#[cfg(target_os = "linux")]
+fn copy_contents(
+    source: &Path,
+    destination: &Path,
+    metadata: &fs::Metadata,
+    specification: &ExecutionFilesystemSpec,
+) -> io::Result<()> {
+    if metadata.file_type().is_symlink() {
+        return std::os::unix::fs::symlink(fs::read_link(source)?, destination);
+    }
+    if metadata.is_dir() {
+        return copy_directory(source, destination, metadata, specification);
+    }
+    if !metadata.is_file() {
+        return Err(io::Error::other(
+            "candidate contains an unsupported filesystem entry",
+        ));
+    }
+    copy_file(source, destination, &specification.cancellation)?;
+    fs::set_permissions(destination, metadata.permissions())
+}
+
+#[cfg(target_os = "linux")]
+fn copy_directory(
+    source: &Path,
+    destination: &Path,
+    metadata: &fs::Metadata,
+    specification: &ExecutionFilesystemSpec,
+) -> io::Result<()> {
+    create_private_directory(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        copy_entry(
+            &entry.path(),
+            &destination.join(entry.file_name()),
+            specification,
+        )?;
+    }
+    fs::set_permissions(destination, metadata.permissions())
+}
+
+#[cfg(target_os = "linux")]
+fn copy_file(
+    source: &Path,
+    destination: &Path,
+    cancellation: &DriverCancellation,
+) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let source = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(source)?;
+    if !source.metadata()?.is_file() {
+        return Err(io::Error::other("candidate file changed type"));
+    }
+    let mut destination = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(destination)?;
+    // SAFETY: both descriptors refer to live, independently opened regular files.
+    let cloned =
+        unsafe { libc::ioctl(destination.as_raw_fd(), libc::FICLONE, source.as_raw_fd()) } == 0;
+    if !cloned {
+        io::copy(
+            &mut CancellableReader {
+                source,
+                cancellation,
+            },
+            &mut destination,
+        )?;
+    }
+    check_cancelled(cancellation)
+}
+
+#[cfg(target_os = "linux")]
+struct CancellableReader<'a> {
+    source: fs::File,
+    cancellation: &'a DriverCancellation,
+}
+
+#[cfg(target_os = "linux")]
+impl Read for CancellableReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        check_cancelled(self.cancellation)?;
+        self.source.read(buffer)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn preserve_times(path: &Path, metadata: &fs::Metadata) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| io::Error::other("invalid copied path"))?;
+    let times = [
+        libc::timespec {
+            tv_sec: metadata.atime(),
+            tv_nsec: metadata.atime_nsec(),
+        },
+        libc::timespec {
+            tv_sec: metadata.mtime(),
+            tv_nsec: metadata.mtime_nsec(),
+        },
+    ];
+    // SAFETY: the path and both timestamps remain live; symlink targets are never followed.
+    if unsafe {
+        libc::utimensat(
+            libc::AT_FDCWD,
+            path.as_ptr(),
+            times.as_ptr(),
+            libc::AT_SYMLINK_NOFOLLOW,
+        )
+    } != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests;

--- a/zeroshot/src/native_v2_capsule/provider_process/filesystem/tests.rs
+++ b/zeroshot/src/native_v2_capsule/provider_process/filesystem/tests.rs
@@ -1,0 +1,394 @@
+use std::collections::BTreeMap;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::time::Duration;
+
+use openengine_cluster_testkit::assertions::AssertValue;
+use tokio::sync::watch;
+
+use super::*;
+use crate::execution::WorkspaceAccessMode;
+use crate::execution::driver::WorkspaceCapability;
+use crate::execution::process::{HostedProcessPool, HostedProcessScope, ProcessSessionCommand};
+use crate::native_v2_candidate::test_support::TestDirectory;
+use crate::native_v2_capsule::provider_process::ProviderProcess;
+
+struct Fixture {
+    _directory: TestDirectory,
+    candidate: PathBuf,
+    runtime: PathBuf,
+    cancellation: watch::Sender<bool>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let directory = TestDirectory::new("provider-filesystem");
+        let candidate = directory.child("workspace");
+        let runtime = directory.child("runtime");
+        fs::create_dir(&candidate).assert_value();
+        fs::create_dir(&runtime).assert_value();
+        let (cancellation, _) = watch::channel(false);
+        Self {
+            _directory: directory,
+            candidate,
+            runtime,
+            cancellation,
+        }
+    }
+
+    fn specification(&self, execution: u64) -> ExecutionFilesystemSpec {
+        let home = self.runtime.join(format!("home-{execution}"));
+        create_private_directory(&home).assert_value();
+        ExecutionFilesystemSpec {
+            runner: LocalProcessRunner::new(),
+            home: Arc::new(PrivateDirectory::retained(home)),
+            root: self.runtime.join(format!("execution-{execution}")),
+            candidate: self.candidate.clone(),
+            verifier_copy: true,
+            identity: None,
+            cancellation: DriverCancellation::new(self.cancellation.subscribe()),
+        }
+    }
+
+    fn prepare(&self, execution: u64) -> Arc<ProviderExecutionFiles> {
+        Arc::new(ProviderExecutionFiles::prepare(self.specification(execution)).assert_value())
+    }
+}
+
+#[test]
+fn candidate_copy_preserves_artifacts_metadata_and_symlinks_without_shared_inodes() {
+    let fixture = Fixture::new();
+    fs::create_dir(fixture.candidate.join("target")).assert_value();
+    fs::write(fixture.candidate.join(".gitignore"), "target/\n").assert_value();
+    fs::write(fixture.candidate.join("untracked.rs"), "actual candidate").assert_value();
+    let artifact = fixture.candidate.join("target/build-helper");
+    fs::write(&artifact, "#!/bin/sh\nexit 0\n").assert_value();
+    fs::set_permissions(&artifact, fs::Permissions::from_mode(0o751)).assert_value();
+    let external = fixture.runtime.join("external");
+    fs::write(&external, "outside the candidate").assert_value();
+    std::os::unix::fs::symlink(&external, fixture.candidate.join("external-link")).assert_value();
+    let metadata = fs::metadata(&artifact).assert_value();
+
+    let files = fixture.prepare(1);
+    assert_eq!(
+        fs::read(files.workspace.join("untracked.rs")).assert_value(),
+        b"actual candidate"
+    );
+    let copy = files.workspace.join("target/build-helper");
+    let copied = fs::metadata(&copy).assert_value();
+    assert_ne!(metadata.ino(), copied.ino());
+    assert_eq!(metadata.permissions().mode(), copied.permissions().mode());
+    assert_eq!(
+        (metadata.mtime(), metadata.mtime_nsec()),
+        (copied.mtime(), copied.mtime_nsec())
+    );
+    assert_eq!(
+        fs::read_link(files.workspace.join("external-link")).assert_value(),
+        external
+    );
+    fs::write(copy, "verifier changes").assert_value();
+    assert_eq!(fs::read(&artifact).assert_value(), b"#!/bin/sh\nexit 0\n");
+    let execution = files.root.path.clone();
+    drop(files);
+    assert!(!execution.exists());
+    assert_eq!(fs::read(external).assert_value(), b"outside the candidate");
+}
+
+#[test]
+fn each_execution_observes_the_latest_candidate_without_promoting_verifier_writes() {
+    let fixture = Fixture::new();
+    fs::write(fixture.candidate.join("source"), "version one").assert_value();
+    let first = fixture.prepare(1);
+    fs::write(first.workspace.join("source"), "verifier edit").assert_value();
+    fs::write(first.workspace.join("private-cache"), "private").assert_value();
+    drop(first);
+    fs::write(fixture.candidate.join("source"), "version two").assert_value();
+    let second = fixture.prepare(2);
+    assert_eq!(
+        fs::read(second.workspace.join("source")).assert_value(),
+        b"version two"
+    );
+    assert!(!second.workspace.join("private-cache").exists());
+    assert!(!fixture.candidate.join("private-cache").exists());
+}
+
+#[tokio::test]
+async fn session_home_survives_executions_until_close_and_outstanding_resources_finish() {
+    let fixture = Fixture::new();
+    let core = ProviderSessionCore::new();
+    let mut specification = fixture.specification(1);
+    let home = fixture.runtime.join("session-home");
+    create_private_directory(&home).assert_value();
+    specification.home = core.retain_home(home.clone()).await.assert_value();
+    let files = ProviderExecutionFiles::prepare(specification).assert_value();
+    drop(files);
+    assert!(home.exists());
+    let mut next = fixture.specification(2);
+    next.home = core.retain_home(home.clone()).await.assert_value();
+    let files = ProviderExecutionFiles::prepare(next).assert_value();
+    core.close().await;
+    assert!(home.exists());
+    drop(files);
+    assert!(!home.exists());
+}
+
+#[test]
+fn unconfirmed_process_cleanup_retains_files_and_rejects_another_provider_launch() {
+    let fixture = Fixture::new();
+    let files = fixture.prepare(1);
+    let execution = files.root.path.clone();
+    let home = files.home.path.clone();
+    files.begin_process();
+    assert!(files.ensure_idle().is_err());
+    drop(files);
+    assert!(execution.exists());
+    assert!(home.exists());
+}
+
+#[test]
+fn cancelled_or_unsupported_copy_does_not_leave_partial_execution_resources() {
+    let fixture = Fixture::new();
+    fixture.cancellation.send_replace(true);
+    assert!(ProviderExecutionFiles::prepare(fixture.specification(1)).is_err());
+    assert!(!fixture.runtime.join("execution-1").exists());
+    assert!(!fixture.runtime.join("home-1").exists());
+    fixture.cancellation.send_replace(false);
+    let _socket =
+        std::os::unix::net::UnixListener::bind(fixture.candidate.join("socket")).assert_value();
+    assert!(ProviderExecutionFiles::prepare(fixture.specification(2)).is_err());
+    assert!(!fixture.runtime.join("execution-2").exists());
+    assert!(!fixture.runtime.join("home-2").exists());
+}
+
+fn command(files: &ProviderExecutionFiles, script: &str) -> ProcessSessionCommand {
+    ProcessSessionCommand {
+        program: "/bin/sh".to_owned(),
+        argv: vec!["-c".to_owned(), script.to_owned()],
+        environment: BTreeMap::from([
+            ("PATH".to_owned(), "/usr/bin:/bin".to_owned()),
+            ("HOME".to_owned(), files.home().display().to_string()),
+            ("TMPDIR".to_owned(), files.scratch_text().assert_value()),
+        ]),
+        workspace: WorkspaceCapability {
+            current_dir: files.workspace.clone(),
+            mode: WorkspaceAccessMode::ReadOnly,
+        },
+        deadline: Some(tokio::time::Instant::now() + Duration::from_secs(20)),
+    }
+}
+
+async fn open(
+    files: Arc<ProviderExecutionFiles>,
+    command: ProcessSessionCommand,
+    cancellation: &watch::Sender<bool>,
+) -> ProviderProcess {
+    let process = files
+        .runner
+        .open(command, DriverCancellation::new(cancellation.subscribe()))
+        .await
+        .assert_value();
+    files.begin_process();
+    ProviderProcess::new(process, files)
+}
+
+#[tokio::test]
+async fn nonzero_exit_and_cancelled_process_tree_release_execution_files() {
+    let fixture = Fixture::new();
+    for (execution, script) in [(1, "exit 17"), (2, "sleep 30 & printf ready; wait")] {
+        let files = fixture.prepare(execution);
+        let mut process = open(
+            files.clone(),
+            command(&files, script),
+            &fixture.cancellation,
+        )
+        .await;
+        if execution == 2 {
+            assert!(process.recv_stdout().await.is_some());
+            fixture.cancellation.send_replace(true);
+        }
+        let output = process.wait().await.assert_value();
+        assert!(output.cleanup.proves_tree_empty());
+        assert_eq!(output.cancelled, execution == 2);
+        if execution == 1 {
+            assert_eq!(output.exit_code, Some(17));
+        }
+        drop(process);
+        let home = files.home.path.clone();
+        let execution = files.root.path.clone();
+        drop(files);
+        assert!(!execution.exists());
+        assert!(!home.exists());
+    }
+}
+
+fn hosted_files(fixture: &Fixture, execution: u64) -> Arc<ProviderExecutionFiles> {
+    let pool = HostedProcessPool::new(71_002, 71_002, 72_000, 72_000).assert_value();
+    let identity = pool
+        .identity(HostedProcessScope::VerifierExecution(execution))
+        .assert_value();
+    let mut specification = fixture.specification(execution);
+    specification.runner = identity.runner();
+    specification.identity = Some(identity);
+    set_owner(specification.home.path(), Some(identity)).assert_value();
+    Arc::new(ProviderExecutionFiles::prepare(specification).assert_value())
+}
+
+fn writer_build(fixture: &Fixture) {
+    use std::os::unix::process::CommandExt;
+
+    fs::write(
+        fixture.candidate.join("main.c"),
+        "int main(void) { return 0; }\n",
+    )
+    .assert_value();
+    fs::write(
+        fixture.candidate.join("Makefile"),
+        "target/proof: main.c\n\tmkdir -p target\n\tcc main.c -o target/proof\n",
+    )
+    .assert_value();
+    std::os::unix::fs::chown(&fixture.candidate, Some(71_002), Some(71_002)).assert_value();
+    let output = std::process::Command::new("/usr/bin/make")
+        .current_dir(&fixture.candidate)
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin")
+        .uid(71_002)
+        .gid(71_002)
+        .output()
+        .assert_value();
+    assert!(
+        output.status.success(),
+        "writer build: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Run this exact gate as root to exercise the hosted UID boundary and native build execution.
+#[tokio::test]
+async fn root_writer_artifacts_support_parallel_private_verifier_builds() {
+    // SAFETY: geteuid has no preconditions or side effects.
+    if unsafe { libc::geteuid() } != 0 {
+        eprintln!("root-only verifier build gate skipped outside the capsule identity");
+        return;
+    }
+    let fixture = Fixture::new();
+    writer_build(&fixture);
+    let left = hosted_files(&fixture, 1);
+    let right = hosted_files(&fixture, 2);
+    let script = r#"set -eu
+make -q
+./target/proof
+! touch "$CANDIDATE/forbidden" 2>/dev/null
+! touch "$PEER/forbidden" 2>/dev/null
+rm target/proof
+make >/dev/null
+./target/proof
+printf '#!/bin/sh\nexit 0\n' > "$TMPDIR/executable"
+chmod 700 "$TMPDIR/executable"
+"$TMPDIR/executable"
+printf private > private-cache
+"#;
+    let mut left_command = command(&left, script);
+    left_command.environment.insert(
+        "CANDIDATE".to_owned(),
+        fixture.candidate.display().to_string(),
+    );
+    left_command
+        .environment
+        .insert("PEER".to_owned(), right.workspace.display().to_string());
+    let mut right_command = command(&right, script);
+    right_command.environment.insert(
+        "CANDIDATE".to_owned(),
+        fixture.candidate.display().to_string(),
+    );
+    right_command
+        .environment
+        .insert("PEER".to_owned(), left.workspace.display().to_string());
+    let (mut left_process, mut right_process) = tokio::join!(
+        open(left.clone(), left_command, &fixture.cancellation),
+        open(right.clone(), right_command, &fixture.cancellation)
+    );
+    let (left_output, right_output) = tokio::join!(left_process.wait(), right_process.wait());
+    for output in [left_output, right_output] {
+        let output = output.assert_value();
+        assert_eq!(
+            output.exit_code,
+            Some(0),
+            "{}",
+            String::from_utf8_lossy(&output.stderr_tail)
+        );
+        assert!(output.cleanup.proves_tree_empty());
+    }
+    assert!(!fixture.candidate.join("private-cache").exists());
+    assert!(fixture.candidate.join("target/proof").exists());
+    drop((left_process, left));
+    assert!(!fixture.runtime.join("execution-1").exists());
+    assert!(right.workspace.join("private-cache").exists());
+    drop((right_process, right));
+    assert!(!fixture.runtime.join("execution-2").exists());
+}
+
+#[test]
+fn copied_cargo_target_reuses_compiled_artifacts_and_build_script_outputs() {
+    let fixture = Fixture::new();
+    fs::write(
+        fixture.candidate.join("Cargo.toml"),
+        concat!(
+            "[package]\nname = \"copied-target-fixture\"\n",
+            "version = \"0.0.0\"\nedition = \"2024\"\n[workspace]\n",
+        ),
+    )
+    .assert_value();
+    fs::create_dir(fixture.candidate.join("src")).assert_value();
+    fs::write(
+        fixture.candidate.join("src/main.rs"),
+        concat!(
+            "include!(concat!(env!(\"OUT_DIR\"), \"/generated.rs\"));\n",
+            "fn main() { assert_eq!(answer(), 42); }\n",
+        ),
+    )
+    .assert_value();
+    fs::write(
+        fixture.candidate.join("build.rs"),
+        r#"fn main() {
+        println!("cargo:rerun-if-changed=build.rs");
+        let output = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+        std::fs::write(output.join("generated.rs"), "fn answer() -> u32 { 42 }").unwrap();
+    }"#,
+    )
+    .assert_value();
+    let original = build_cargo_fixture(&fixture.candidate, &fixture.runtime);
+    assert!(String::from_utf8_lossy(&original.stderr).contains("Compiling copied-target-fixture"));
+    let files = fixture.prepare(1);
+    let copied = build_cargo_fixture(&files.workspace, &files.scratch);
+    let diagnostics = String::from_utf8_lossy(&copied.stderr);
+    assert!(
+        diagnostics.contains("Fresh copied-target-fixture"),
+        "{diagnostics}"
+    );
+    assert!(
+        !diagnostics.contains("Compiling copied-target-fixture"),
+        "{diagnostics}"
+    );
+    assert!(
+        std::process::Command::new(files.workspace.join("target/debug/copied-target-fixture"))
+            .status()
+            .assert_value()
+            .success()
+    );
+}
+
+fn build_cargo_fixture(workspace: &Path, scratch: &Path) -> std::process::Output {
+    let output = std::process::Command::new("cargo")
+        .args(["build", "--offline", "--verbose"])
+        .current_dir(workspace)
+        .env("CARGO_TARGET_DIR", workspace.join("target"))
+        .env("CARGO_TERM_COLOR", "never")
+        .env("TMPDIR", scratch)
+        .output()
+        .assert_value();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}

--- a/zeroshot/src/native_v2_capsule/provider_process/tests.rs
+++ b/zeroshot/src/native_v2_capsule/provider_process/tests.rs
@@ -2,10 +2,10 @@ use openengine_cluster_testkit::assertions::AssertValue;
 
 use super::*;
 
-#[test]
-fn closed_session_failure_maps_to_selected_runner_error() {
+#[tokio::test]
+async fn closed_session_failure_maps_to_selected_runner_error() {
     let session = ProviderSessionCore::new();
-    session.close();
+    session.close().await;
 
     assert_eq!(
         session.ensure_live(ClosedSessionFailure::Driver),

--- a/zeroshot/src/native_v2_claude.rs
+++ b/zeroshot/src/native_v2_claude.rs
@@ -19,8 +19,8 @@ use std::path::{Path, PathBuf};
 
 use crate::execution::process::{HostedProcessPool, ProcessSessionCommand, ProcessStdout};
 use crate::native_v2_capsule::provider_process::{
-    ClosedSessionFailure, ProviderProcessRunners, process_scope, redaction_values,
-    with_driver_detail,
+    ClosedSessionFailure, ProviderExecution, ProviderExecutionFiles, ProviderProcessRunners,
+    redaction_values, with_driver_detail,
 };
 use crate::native_v2_contract::{ClaudeProvider, NodeRuntimeBinding};
 use crate::native_v2_runner::{
@@ -173,6 +173,7 @@ impl ClaudeAdapter {
         let argv = claude_arguments(
             self.prefix_arguments.clone(),
             ClaudeTurnArguments {
+                private_workspace: input.files.isolated_workspace,
                 model: model.as_str(),
                 effort: *effort,
                 role: invocation.role,
@@ -193,16 +194,22 @@ impl ClaudeAdapter {
             with_driver_detail(error, "Claude command rejected the selected node role")
         })?;
 
+        let mut environment = self
+            .process_environment(&invocation.environment, input.files.home())
+            .map_err(|error| with_driver_detail(error, "Claude provider environment is invalid"))?;
+        environment.insert(
+            "TMPDIR".to_owned(),
+            input
+                .files
+                .scratch_text()
+                .map_err(|error| NodeRunnerError::DriverDetail(error.to_string()))?,
+        );
         Ok(ProcessSessionCommand {
             program: self.executable.clone(),
             argv,
-            environment: self
-                .process_environment(&invocation.environment, input.runtime_home)
-                .map_err(|error| {
-                    with_driver_detail(error, "Claude provider environment is invalid")
-                })?,
+            environment,
             workspace: crate::execution::driver::WorkspaceCapability {
-                current_dir: self.workspace.clone(),
+                current_dir: input.files.workspace.clone(),
                 mode: workspace_access(invocation.role).map_err(|error| {
                     with_driver_detail(error, "Claude workspace policy rejected the node role")
                 })?,
@@ -314,10 +321,7 @@ impl ClaudeAdapter {
         turn: &ClaudeTurn<'_>,
         resume_id: Option<&str>,
     ) -> Result<ClaudeProcessStart, NodeRunnerError> {
-        let scope = process_scope(turn.invocation).map_err(|error| {
-            with_driver_detail(error, "Claude process scope requires an agent node role")
-        })?;
-        let (runner, runtime_home) = match self.runners.turn_process(&self.runtime_home, scope) {
+        let files = match turn.execution.prepare(turn.control).await {
             Ok(process) => process,
             Err(error) => return turn_process::failed_before_start(error, turn.control),
         };
@@ -325,10 +329,10 @@ impl ClaudeAdapter {
             turn,
             ClaudeCommandInput {
                 resume_id,
-                runtime_home: &runtime_home,
+                files: &files,
             },
         )?;
-        turn_process::open(runner, command, turn.control).await
+        turn_process::open(files, command, turn.control).await
     }
 }
 
@@ -370,6 +374,7 @@ struct ClaudeTurn<'a> {
     invocation: &'a DriverInvocation,
     session: &'a ClaudeSession,
     control: &'a DriverControl,
+    execution: &'a ProviderExecution<'a>,
 }
 
 enum ClaudeTurnAdvance {
@@ -379,7 +384,7 @@ enum ClaudeTurnAdvance {
 
 struct ClaudeCommandInput<'a> {
     resume_id: Option<&'a str>,
-    runtime_home: &'a Path,
+    files: &'a ProviderExecutionFiles,
 }
 
 async fn collect_transcript(

--- a/zeroshot/src/native_v2_claude/command.rs
+++ b/zeroshot/src/native_v2_claude/command.rs
@@ -23,6 +23,7 @@ pub(super) struct ClaudeTurnArguments<'a> {
     pub(super) model: &'a str,
     pub(super) effort: Option<ReasoningEffort>,
     pub(super) role: NodeRole,
+    pub(super) private_workspace: bool,
     pub(super) resume_id: Option<&'a str>,
     pub(super) json_schema: String,
 }
@@ -49,6 +50,9 @@ pub(super) fn claude_arguments(
     }
     match turn.role {
         NodeRole::Worker => argv.push("--dangerously-skip-permissions".to_owned()),
+        NodeRole::Verifier if turn.private_workspace => {
+            argv.push("--dangerously-skip-permissions".to_owned());
+        }
         NodeRole::Verifier => {
             argv.extend(["--permission-mode".to_owned(), "plan".to_owned()]);
         }

--- a/zeroshot/src/native_v2_claude/session.rs
+++ b/zeroshot/src/native_v2_claude/session.rs
@@ -6,8 +6,8 @@ use tokio::sync::Mutex;
 
 use crate::execution::SessionScope;
 use crate::native_v2_capsule::provider_process::{
-    ProviderFailure, ProviderFailureRetry, ProviderSessionCore, impl_provider_node_session,
-    redaction_values,
+    ProviderExecution, ProviderFilesystemConfig, ProviderFailure, ProviderFailureRetry,
+    ProviderSessionCore, impl_provider_node_session, redaction_values,
 };
 use crate::native_v2_contract::{NodeInvocation, NodeRuntimeBinding};
 use crate::native_v2_runner::{
@@ -63,10 +63,20 @@ impl NodeDriver for ClaudeAdapter {
             .downcast_ref::<ClaudeSession>()
             .ok_or(NodeRunnerError::Driver)?;
         let _turn = session.core.turn.lock().await;
+        let execution = ProviderExecution::new(
+            ProviderFilesystemConfig {
+                runners: self.runners,
+                root: &self.runtime_home,
+                workspace: &self.workspace,
+            },
+            &invocation,
+            &session.core,
+        );
         let turn = ClaudeTurn {
             invocation: &invocation,
             session,
             control: &control,
+            execution: &execution,
         };
         let mut state = ClaudeRunState::new(&invocation, session).await?;
         loop {

--- a/zeroshot/src/native_v2_claude/tests.rs
+++ b/zeroshot/src/native_v2_claude/tests.rs
@@ -298,6 +298,21 @@ async fn two_turn_workspace(
     )
     .await;
     complete_two_turns(&runner, &binding).await;
+    let homes = workspace.read("homes.txt");
+    assert!(
+        homes
+            .lines()
+            .all(|home| Path::new(home).exists() == (scope == SessionScope::NodeInstance))
+    );
+    let scratches = workspace.read("scratches.txt");
+    crate::native_v2_candidate::test_support::assert_removed_directories(
+        &scratches.lines().collect::<Vec<_>>(),
+        2,
+    );
+    runner
+        .close_run(&openengine_cluster_protocol::RunId::new("claude-run"))
+        .await;
+    assert!(homes.lines().all(|home| !Path::new(home).exists()));
     workspace
 }
 
@@ -326,6 +341,7 @@ printf '%s\n' "${AWS_REGION-unset}" > aws-region.txt
 printf '%s\n' "${CLAUDE_CODE_USE_BEDROCK-unset}" > use-bedrock.txt
 printf '%s\n' "${UNDECLARED_AMBIENT_SENTINEL-unset}" > ambient.txt
 printf '%s\n' "$HOME" >> homes.txt
+printf '%s\n' "$TMPDIR" >> scratches.txt
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"session-1"}'
 printf '%s%s\n' \
   '{"type":"stream_event","event":{"type":"content_block_delta",' \

--- a/zeroshot/src/native_v2_claude/tests/command.rs
+++ b/zeroshot/src/native_v2_claude/tests/command.rs
@@ -151,3 +151,37 @@ async fn scripted_provider_commands_are_exact_and_ambient_free() {
         assert_provider_environment(&workspace, provider, provider_value);
     }
 }
+
+#[test]
+fn private_verifier_workspaces_allow_noninteractive_build_side_effects() {
+    use crate::native_v2_claude::command::{ClaudeTurnArguments, claude_arguments};
+    use crate::native_v2_runner::NodeRole;
+
+    let arguments = claude_arguments(
+        Vec::new(),
+        ClaudeTurnArguments {
+            model: "provider-owned-model",
+            effort: None,
+            role: NodeRole::Verifier,
+            private_workspace: true,
+            resume_id: Some("same-session"),
+            json_schema: "{}".to_owned(),
+        },
+    )
+    .assert_value();
+    assert!(
+        arguments
+            .iter()
+            .any(|argument| argument == "--dangerously-skip-permissions")
+    );
+    assert!(
+        !arguments
+            .iter()
+            .any(|argument| argument == "--permission-mode")
+    );
+    assert!(
+        arguments
+            .windows(2)
+            .any(|pair| pair == ["--resume", "same-session"])
+    );
+}

--- a/zeroshot/src/native_v2_claude/turn_process.rs
+++ b/zeroshot/src/native_v2_claude/turn_process.rs
@@ -1,10 +1,9 @@
-use crate::execution::process::{
-    LocalProcessRunner, ProcessRunnerError, ProcessSession, ProcessSessionCommand,
-    ProcessSessionOutput,
-};
+use std::sync::Arc;
+
+use crate::execution::process::{ProcessRunnerError, ProcessSessionCommand, ProcessSessionOutput};
 use crate::native_v2_capsule::provider_process::{
-    ProcessExchange, ProcessInputFailure, exchange_process_io, open_provider_process,
-    process_failure_detail,
+    ProcessExchange, ProcessInputFailure, ProviderExecutionFiles, ProviderProcess,
+    exchange_process_io, open_provider_process, process_failure_detail,
 };
 use crate::native_v2_runner::{DriverControl, NodeRunnerError};
 
@@ -12,7 +11,7 @@ use super::transcript::ClaudeTranscript;
 use super::ClaudeAttempt;
 
 pub(super) enum ClaudeProcessStart {
-    Ready(ProcessSession),
+    Ready(ProviderProcess),
     Failed(ClaudeAttempt),
 }
 
@@ -29,11 +28,11 @@ pub(super) fn failed_before_start(
 }
 
 pub(super) async fn open(
-    runner: LocalProcessRunner,
+    files: Arc<ProviderExecutionFiles>,
     command: ProcessSessionCommand,
     control: &DriverControl,
 ) -> Result<ClaudeProcessStart, NodeRunnerError> {
-    let process = match open_provider_process(runner, command, control).await? {
+    let process = match open_provider_process(files, command, control).await? {
         Ok(process) => process,
         Err(error) => return failed_before_start(error, control),
     };
@@ -41,7 +40,7 @@ pub(super) async fn open(
 }
 
 pub(super) async fn finish_process(
-    process: &mut ProcessSession,
+    process: &mut ProviderProcess,
     prompt: &[u8],
     mut transcript: ClaudeTranscript,
     control: &DriverControl,
@@ -99,7 +98,7 @@ fn input_failure_cancelled(
 }
 
 async fn finish_output_failure(
-    process: &mut ProcessSession,
+    process: &mut ProviderProcess,
     transcript: ClaudeTranscript,
     control: &DriverControl,
     error: NodeRunnerError,
@@ -123,7 +122,7 @@ async fn finish_output_failure(
 }
 
 async fn finish_process_completion(
-    process: &mut ProcessSession,
+    process: &mut ProviderProcess,
     transcript: ClaudeTranscript,
     control: &DriverControl,
 ) -> Result<ClaudeAttempt, NodeRunnerError> {
@@ -149,7 +148,7 @@ async fn finish_process_completion(
 }
 
 pub(super) async fn release_failure(
-    process: &mut ProcessSession,
+    process: &mut ProviderProcess,
     mut diagnostic: String,
     control: &DriverControl,
 ) -> Result<ClaudeAttempt, NodeRunnerError> {

--- a/zeroshot/src/native_v2_cli/execution.rs
+++ b/zeroshot/src/native_v2_cli/execution.rs
@@ -474,23 +474,13 @@ fn write_durable_event(
     from_cursor: &mut Option<Cursor>,
     output: &mut impl Write,
 ) -> Result<Option<CliOutcome>, NativeV2CliError> {
-    if event.cursor() == from_cursor.as_ref() {
+    let cursor = event.cursor().cloned();
+    if cursor.is_some() && cursor == *from_cursor {
         return Ok(None);
     }
-    let cursor = event.cursor().cloned();
     let outcome = match event {
         DurableItem::Watch(event) => {
-            let outcome = match &event.status {
-                CliRunStatus::Target(RunStatus::Finished {
-                    terminal_result: TerminalResult::Succeeded { .. },
-                    ..
-                }) => Some(CliOutcome::Finished),
-                CliRunStatus::Target(RunStatus::Finished {
-                    terminal_result: TerminalResult::Failed { .. },
-                    ..
-                }) => Some(CliOutcome::Failed),
-                _ => None,
-            };
+            let outcome = watched_outcome(&event.status);
             write_json(output, &event)?;
             outcome
         }
@@ -498,10 +488,29 @@ fn write_durable_event(
             write_json(output, &event)?;
             None
         }
+        DurableItem::Closed(SubscriptionCloseReason::SourceUnavailable) => {
+            return Err(NativeV2CliError::Protocol(
+                "observation source is unavailable; the stream is incomplete".to_owned(),
+            ));
+        }
         DurableItem::Closed(_) => None,
     };
     *from_cursor = cursor;
     Ok(outcome)
+}
+
+fn watched_outcome(status: &CliRunStatus) -> Option<CliOutcome> {
+    match status {
+        CliRunStatus::Target(RunStatus::Finished {
+            terminal_result: TerminalResult::Succeeded { .. },
+            ..
+        }) => Some(CliOutcome::Finished),
+        CliRunStatus::Target(RunStatus::Finished {
+            terminal_result: TerminalResult::Failed { .. },
+            ..
+        }) => Some(CliOutcome::Failed),
+        _ => None,
+    }
 }
 
 fn write_json(output: &mut impl Write, value: &impl Serialize) -> Result<(), NativeV2CliError> {
@@ -509,4 +518,27 @@ fn write_json(output: &mut impl Write, value: &impl Serialize) -> Result<(), Nat
     output.write_all(b"\n")?;
     output.flush()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod incomplete_stream_tests {
+    use super::*;
+
+    #[test]
+    fn unavailable_history_is_an_error_even_before_the_first_event() {
+        for mut cursor in [None, Some(Cursor::new("v2:3"))] {
+            let before = cursor.clone();
+            let mut output = Vec::new();
+            let result = write_durable_event(
+                DurableItem::Closed(SubscriptionCloseReason::SourceUnavailable),
+                &mut cursor,
+                &mut output,
+            );
+            assert!(
+                matches!(result, Err(NativeV2CliError::Protocol(message)) if message.contains("incomplete"))
+            );
+            assert_eq!(cursor, before);
+            assert!(output.is_empty());
+        }
+    }
 }

--- a/zeroshot/src/native_v2_cli/execution/attach.rs
+++ b/zeroshot/src/native_v2_cli/execution/attach.rs
@@ -57,6 +57,13 @@ where
                 }))
                 | SubscriptionStep::Item(None)
                 | SubscriptionStep::Reconnect => break,
+                SubscriptionStep::Item(Some(CliSubscriptionItem::Closed {
+                    reason: SubscriptionCloseReason::SourceUnavailable,
+                })) => {
+                    return Err(NativeV2CliError::Protocol(
+                        "observation source is unavailable; the stream is incomplete".to_owned(),
+                    ));
+                }
             }
         }
         tokio::select! {

--- a/zeroshot/src/native_v2_cloud.rs
+++ b/zeroshot/src/native_v2_cloud.rs
@@ -89,6 +89,7 @@ pub struct NativeV2CloudController {
     submission_turn: Arc<Mutex<()>>,
     reconstructed_turn: Arc<Mutex<()>>,
     delivery_policy: DeliveryPolicy,
+    operator_diagnostics: Arc<crate::native_v2_target_authority::OperatorDiagnosticStore>,
 }
 
 #[derive(Clone)]
@@ -130,9 +131,18 @@ impl NativeV2CloudController {
             submission_turn: Arc::new(Mutex::new(())),
             reconstructed_turn: Arc::new(Mutex::new(())),
             delivery_policy,
+            operator_diagnostics: Arc::default(),
         };
         controller.reconcile_persisted_runs().await?;
         Ok(controller)
+    }
+
+    pub(crate) fn with_operator_diagnostics(
+        mut self,
+        diagnostics: Arc<crate::native_v2_target_authority::OperatorDiagnosticStore>,
+    ) -> Self {
+        self.operator_diagnostics = diagnostics;
+        self
     }
 
     /// Reconciles durable nonterminal truth before this controller can serve any OECP method.
@@ -262,7 +272,7 @@ impl NativeV2CloudController {
         admitted: AdmittedRun,
         secrets: RunSecretEnvelope,
     ) -> Result<CloudRunReceipt, NativeV2CloudError> {
-        let run_id = stored.snapshot.run_id;
+        let run_id = stored.snapshot.run_id.clone();
         let controller_claim = self.allocator.claim_controller(&run_id).await?;
         let github_token = match source_github_token(&secrets).await {
             Ok(token) => token,
@@ -284,6 +294,7 @@ impl NativeV2CloudController {
                 return Err(error.into());
             }
         };
+        self.observability.track_runtime(&stored.snapshot)?;
         let AllocatedCapsule {
             runner,
             loss,
@@ -297,7 +308,8 @@ impl NativeV2CloudController {
             loss,
             controller_claim,
             delivery_policy: self.delivery_policy,
-            live_output: Arc::new(self.observability.clone()),
+            observability: self.observability.clone(),
+            operator_diagnostics: self.operator_diagnostics.clone(),
         });
         self.runtimes
             .lock()
@@ -313,8 +325,9 @@ impl NativeV2CloudController {
     fn remove_finished_runtime(&self, run_id: RunId, engine: Arc<PortableRunEngine>) {
         let runtimes = self.runtimes.clone();
         tokio::spawn(async move {
-            engine.wait_removable().await;
-            runtimes.lock().await.remove(&run_id);
+            if engine.wait_removable().await {
+                runtimes.lock().await.remove(&run_id);
+            }
         });
     }
 

--- a/zeroshot/src/native_v2_cloud/backend.rs
+++ b/zeroshot/src/native_v2_cloud/backend.rs
@@ -106,12 +106,7 @@ struct WatchSource(RunWatchSubscription);
 #[async_trait]
 impl RunSubscriptionSource<RunWatchEventNotification> for WatchSource {
     async fn next(&mut self) -> Option<RunSubscriptionItem<RunWatchEventNotification>> {
-        match self.0.recv().await {
-            Ok(Some(event)) => Some(RunSubscriptionItem::Event(event)),
-            Ok(None) | Err(_) => Some(RunSubscriptionItem::Closed {
-                reason: SubscriptionCloseReason::Done,
-            }),
-        }
+        Some(durable_item(self.0.recv().await))
     }
 }
 
@@ -120,12 +115,19 @@ struct LogsSource(RunLogsSubscription);
 #[async_trait]
 impl RunSubscriptionSource<RunLogEventNotification> for LogsSource {
     async fn next(&mut self) -> Option<RunSubscriptionItem<RunLogEventNotification>> {
-        match self.0.recv().await {
-            Ok(Some(event)) => Some(RunSubscriptionItem::Event(event)),
-            Ok(None) | Err(_) => Some(RunSubscriptionItem::Closed {
-                reason: SubscriptionCloseReason::Done,
-            }),
-        }
+        Some(durable_item(self.0.recv().await))
+    }
+}
+
+fn durable_item<E>(result: Result<Option<E>, NativeV2ObservationError>) -> RunSubscriptionItem<E> {
+    match result {
+        Ok(Some(event)) => RunSubscriptionItem::Event(event),
+        Ok(None) => RunSubscriptionItem::Closed {
+            reason: SubscriptionCloseReason::Done,
+        },
+        Err(_) => RunSubscriptionItem::Closed {
+            reason: SubscriptionCloseReason::SourceUnavailable,
+        },
     }
 }
 
@@ -176,6 +178,13 @@ fn cloud_backend_error(error: NativeV2CloudError) -> BackendError {
             NativeV2ObservationError::ExecutionNotActive
             | NativeV2ObservationError::ExecutionNotLive,
         ) => BackendError::application(GONE, "execution is no longer active", None),
+        NativeV2CloudError::Observation(NativeV2ObservationError::Ledger(
+            RunLedgerError::Storage | RunLedgerError::SqliteStorage(_) | RunLedgerError::Corrupt,
+        )) => BackendError::application(
+            "SOURCE_UNAVAILABLE",
+            "durable run history is unavailable",
+            None,
+        ),
         _ => BackendError::new(INTERNAL_ERROR_CODE, "native-v2 operation failed"),
     }
 }

--- a/zeroshot/src/native_v2_cloud/tests.rs
+++ b/zeroshot/src/native_v2_cloud/tests.rs
@@ -401,3 +401,6 @@ mod cases_4;
 mod cases_5;
 
 use openengine_cluster_testkit::assertions::{AssertValue};
+
+#[path = "tests/runtime_failure.rs"]
+mod runtime_failure;

--- a/zeroshot/src/native_v2_cloud/tests/cases_5.rs
+++ b/zeroshot/src/native_v2_cloud/tests/cases_5.rs
@@ -65,19 +65,33 @@ async fn concurrent_force_of_reconstructed_run_cleans_up_and_terminalizes_once()
 }
 
 #[tokio::test]
-async fn force_retries_cleanup_after_a_drive_cleanup_failure() {
+async fn drive_cleanup_failure_automatically_retries_and_reports_runtime_failure() {
     let harness = harness(Behavior::Complete).await;
     harness.cleanup.fail_next();
     let receipt = submit_test_request(&harness.controller, request(Value::Null))
         .await
         .assert_value_with("submit");
-    tokio::time::timeout(Duration::from_secs(2), async {
-        while harness.cleanup.exits().is_empty() {
-            tokio::task::yield_now().await;
+    assert_eq!(
+        terminal(&harness.controller, &receipt.run_id).await,
+        TerminalResult::Failed {
+            reason: EnumLabel::new("runtime_failed").assert_value_with("label")
         }
-    })
-    .await
-    .assert_value_with("first cleanup attempted");
+    );
+    assert_eq!(
+        harness.cleanup.exits(),
+        vec![RunRuntimeExit::Completed, RunRuntimeExit::RuntimeLost]
+    );
+    assert_eq!(harness.cleanup.terminal_seen(), vec![false, false]);
+
+    let forced = harness
+        .controller
+        .force(RunForceParams {
+            run_id: receipt.run_id.clone(),
+        })
+        .await
+        .assert_value_with("force after automatic recovery");
+    assert!(matches!(forced.status, RunStatus::Finished { .. }));
+    assert_eq!(harness.cleanup.exits().len(), 2);
     assert!(
         harness
             .ledger
@@ -87,27 +101,8 @@ async fn force_retries_cleanup_after_a_drive_cleanup_failure() {
             .assert_value_with("stored")
             .snapshot
             .terminal
-            .is_none()
+            .is_some()
     );
-
-    harness
-        .controller
-        .force(RunForceParams {
-            run_id: receipt.run_id.clone(),
-        })
-        .await
-        .assert_value_with("force retries cleanup");
-    assert_eq!(
-        terminal(&harness.controller, &receipt.run_id).await,
-        TerminalResult::Failed {
-            reason: EnumLabel::new("force_stopped").assert_value_with("label")
-        }
-    );
-    assert_eq!(
-        harness.cleanup.exits(),
-        vec![RunRuntimeExit::Completed, RunRuntimeExit::ForceStopped]
-    );
-    assert_eq!(harness.cleanup.terminal_seen(), vec![false, false]);
 }
 
 use openengine_cluster_testkit::assertions::{AssertValue};

--- a/zeroshot/src/native_v2_cloud/tests/runtime_failure.rs
+++ b/zeroshot/src/native_v2_cloud/tests/runtime_failure.rs
@@ -1,0 +1,634 @@
+use super::*;
+
+use std::sync::atomic::AtomicBool;
+
+use openengine_cluster_protocol::Cursor;
+use openengine_cluster_testkit::assertions::AssertAt;
+use crate::v2_run_ledger::{AppendResult, SnapshotAndTail};
+
+const RETAINED_OUTPUT: &str = "retained before storage failure";
+const UNPERSISTED_OUTPUT: &str = "output rejected by storage";
+
+#[derive(Clone, Copy)]
+enum FailurePoint {
+    Output,
+    Completion,
+    CompletionPanic,
+    PeerCompletionPanic,
+}
+
+struct FaultLedger {
+    inner: Arc<FakeRunLedger>,
+    point: FailurePoint,
+    permanent: bool,
+    lose_reads: bool,
+    armed: AtomicBool,
+    triggered: AtomicBool,
+    peer: Option<Arc<PeerPanicGate>>,
+}
+
+impl FaultLedger {
+    fn new(
+        inner: Arc<FakeRunLedger>,
+        point: FailurePoint,
+        permanent: bool,
+        lose_reads: bool,
+    ) -> Self {
+        Self {
+            inner,
+            point,
+            permanent,
+            lose_reads,
+            armed: AtomicBool::new(false),
+            triggered: AtomicBool::new(false),
+            peer: None,
+        }
+    }
+
+    fn read_available(&self) -> Result<(), RunLedgerError> {
+        if self.lose_reads && self.triggered.load(Ordering::SeqCst) {
+            Err(sqlite_failure())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn matches(&self, events: &[RunEvent]) -> bool {
+        events.iter().any(|event| match self.point {
+            FailurePoint::Output => matches!(event, RunEvent::SafeLog { .. }),
+            FailurePoint::Completion | FailurePoint::CompletionPanic => {
+                matches!(event, RunEvent::NodeCompleted { .. })
+            }
+            FailurePoint::PeerCompletionPanic => matches!(
+                event, RunEvent::NodeCompleted { completion }
+                    if completion.reference.node.as_str() == "left"
+            ),
+        })
+    }
+}
+
+fn sqlite_failure() -> RunLedgerError {
+    RunLedgerError::SqliteStorage(rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_FULL))
+}
+
+#[async_trait]
+impl RunLedger for FaultLedger {
+    async fn create_or_get(&self, request: CreateRun) -> Result<CreateRunOutcome, RunLedgerError> {
+        self.inner.create_or_get(request).await
+    }
+
+    async fn get(&self, run_id: &RunId) -> Result<Option<StoredRun>, RunLedgerError> {
+        self.read_available()?;
+        self.inner.get(run_id).await
+    }
+
+    async fn get_by_submission_key(
+        &self,
+        key: &IdempotencyKey,
+    ) -> Result<Option<StoredRun>, RunLedgerError> {
+        self.read_available()?;
+        self.inner.get_by_submission_key(key).await
+    }
+
+    async fn list(&self) -> Result<Vec<RunSummary>, RunLedgerError> {
+        self.read_available()?;
+        self.inner.list().await
+    }
+
+    async fn append(
+        &self,
+        run_id: &RunId,
+        events: Vec<RunEvent>,
+    ) -> Result<AppendResult, RunLedgerError> {
+        if let Some(peer) = &self.peer {
+            if events.iter().any(|event| {
+                matches!(
+                    event, RunEvent::SafeLog { line, .. } if line.as_str() == HELD_PEER_OUTPUT
+                )
+            }) {
+                peer.output_started.notify_one();
+                peer.release_output.notified().await;
+            }
+        }
+        if self.permanent && self.triggered.load(Ordering::SeqCst) {
+            return Err(sqlite_failure());
+        }
+        if self.armed.load(Ordering::SeqCst)
+            && self.matches(&events)
+            && !self.triggered.swap(true, Ordering::SeqCst)
+        {
+            assert!(
+                !matches!(
+                    self.point,
+                    FailurePoint::CompletionPanic | FailurePoint::PeerCompletionPanic
+                ),
+                "synthetic private panic payload"
+            );
+            return Err(sqlite_failure());
+        }
+        self.inner.append(run_id, events).await
+    }
+
+    async fn request_force_stop(&self, run_id: &RunId) -> Result<AppendResult, RunLedgerError> {
+        if self.permanent && self.triggered.load(Ordering::SeqCst) {
+            return Err(sqlite_failure());
+        }
+        self.inner.request_force_stop(run_id).await
+    }
+
+    async fn snapshot_and_tail(
+        &self,
+        run_id: &RunId,
+        after: Option<&Cursor>,
+    ) -> Result<SnapshotAndTail, RunLedgerError> {
+        self.read_available()?;
+        self.inner.snapshot_and_tail(run_id, after).await
+    }
+}
+
+struct FaultDriver {
+    point: FailurePoint,
+    release: watch::Sender<bool>,
+    cancelled: AtomicBool,
+    completed: AtomicBool,
+}
+
+impl FaultDriver {
+    fn new(point: FailurePoint) -> Self {
+        let (release, _) = watch::channel(false);
+        Self {
+            point,
+            release,
+            cancelled: AtomicBool::new(false),
+            completed: AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait]
+impl NodeDriver for FaultDriver {
+    async fn run(
+        &self,
+        invocation: DriverInvocation,
+        mut control: DriverControl,
+    ) -> Result<WorkerOutcome, NodeRunnerError> {
+        control
+            .emit(LiveOutput::new(LiveOutputStream::Output, RETAINED_OUTPUT)?)
+            .await?;
+        let mut release = self.release.subscribe();
+        while !*release.borrow_and_update() {
+            release
+                .changed()
+                .await
+                .map_err(|_| NodeRunnerError::Driver)?;
+        }
+        if matches!(self.point, FailurePoint::Output) {
+            control
+                .emit(LiveOutput::new(
+                    LiveOutputStream::Output,
+                    UNPERSISTED_OUTPUT,
+                )?)
+                .await?;
+            // No additional output or natural completion can reveal the bridge error.
+            control.cancelled().await;
+            self.cancelled.store(true, Ordering::SeqCst);
+            Err(NodeRunnerError::Cancelled)
+        } else {
+            self.completed.store(true, Ordering::SeqCst);
+            Ok(fake_worker_outcome(&invocation))
+        }
+    }
+}
+
+struct FailureHarness {
+    controller: NativeV2CloudController,
+    ledger: Arc<FaultLedger>,
+    driver: Arc<FaultDriver>,
+    cleanup: Arc<FakeCleanup>,
+    before: RunStatusResult,
+}
+
+impl FailureHarness {
+    async fn new(point: FailurePoint, permanent: bool, lose_reads: bool) -> Self {
+        let inner = Arc::new(FakeRunLedger::new());
+        let ledger = Arc::new(FaultLedger::new(
+            inner.clone(),
+            point,
+            permanent,
+            lose_reads,
+        ));
+        let driver = Arc::new(FaultDriver::new(point));
+        let cleanup = Arc::new(FakeCleanup::new(inner));
+        let allocator = Arc::new(FakeAllocator::new(driver.clone(), cleanup.clone()));
+        let controller = NativeV2CloudController::new(ledger.clone(), allocator)
+            .await
+            .assert_value_with("fault-injection controller startup");
+        let receipt = submit_test_request(&controller, request(Value::Null))
+            .await
+            .assert_value_with("run admitted before fault");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let tail = ledger
+                    .inner
+                    .snapshot_and_tail(&receipt.run_id, None)
+                    .await
+                    .assert_value_with("retained tail");
+                if tail.events.iter().any(|event| {
+                    matches!(
+                        &event.event,
+                        RunEvent::SafeLog { line, .. } if line.as_str() == RETAINED_OUTPUT
+                    )
+                }) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .assert_value_with("initial output persisted");
+        let before = controller
+            .status(RunStatusParams {
+                run_id: receipt.run_id,
+            })
+            .await
+            .assert_value_with("active status before fault");
+        assert!(matches!(before.status, RunStatus::Running { .. }));
+        Self {
+            controller,
+            ledger,
+            driver,
+            cleanup,
+            before,
+        }
+    }
+
+    fn release_fault(&self) {
+        self.ledger.armed.store(true, Ordering::SeqCst);
+        self.driver.release.send_replace(true);
+    }
+
+    async fn failed(&self) -> RunStatusResult {
+        assert_eq!(
+            terminal(&self.controller, &self.before.run_id).await,
+            TerminalResult::Failed {
+                reason: EnumLabel::new("runtime_failed").assert_value_with("failure reason"),
+            }
+        );
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if !self
+                    .controller
+                    .runtimes
+                    .lock()
+                    .await
+                    .contains_key(&self.before.run_id)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .assert_value_with("runtime removed after explicit failure");
+        assert!(self.ledger.triggered.load(Ordering::SeqCst));
+        self.controller
+            .status(RunStatusParams {
+                run_id: self.before.run_id.clone(),
+            })
+            .await
+            .assert_value_with("failed status survives engine removal")
+    }
+
+    async fn retained(&self) -> SnapshotAndTail {
+        self.ledger
+            .inner
+            .snapshot_and_tail(&self.before.run_id, None)
+            .await
+            .assert_value_with("retained durable history")
+    }
+
+    fn assert_storage_diagnostic(&self) {
+        let diagnostics = self
+            .controller
+            .operator_diagnostics
+            .snapshot(&self.before.run_id);
+        let diagnostic = diagnostics
+            .diagnostics
+            .first()
+            .assert_value_with("operator diagnostic");
+        assert_eq!(diagnostic.code, "runtime_failed");
+        assert!(diagnostic.stderr.contains(&sqlite_failure().to_string()));
+    }
+
+    async fn assert_history_unavailable(&self) {
+        let context = ConnectionContext::default();
+        let watch_error = ClusterBackend::run_watch(
+            &self.controller,
+            &context,
+            RunWatchParams {
+                run_id: self.before.run_id.clone(),
+                from_cursor: None,
+            },
+        )
+        .await
+        .err()
+        .assert_value_with("watch cannot establish with unreadable history");
+        assert_eq!(watch_error.code, "SOURCE_UNAVAILABLE");
+        let logs_error = ClusterBackend::run_logs(
+            &self.controller,
+            &context,
+            RunLogsParams {
+                run_id: self.before.run_id.clone(),
+                from_cursor: None,
+                execution: None,
+            },
+        )
+        .await
+        .err()
+        .assert_value_with("logs cannot establish with unreadable history");
+        assert_eq!(logs_error.code, "SOURCE_UNAVAILABLE");
+    }
+
+    async fn streams(&self) -> (RunWatchEventStream, RunLogEventStream) {
+        let context = ConnectionContext::default();
+        let (_, watch) = ClusterBackend::run_watch(
+            &self.controller,
+            &context,
+            RunWatchParams {
+                run_id: self.before.run_id.clone(),
+                from_cursor: None,
+            },
+        )
+        .await
+        .assert_value_with("watch before fault");
+        let (_, logs) = ClusterBackend::run_logs(
+            &self.controller,
+            &context,
+            RunLogsParams {
+                run_id: self.before.run_id.clone(),
+                from_cursor: None,
+                execution: None,
+            },
+        )
+        .await
+        .assert_value_with("logs before fault");
+        (watch, logs)
+    }
+}
+
+async fn drain<E>(
+    mut stream: RunSubscriptionStream<E>,
+    expected_close: SubscriptionCloseReason,
+) -> Vec<E> {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let mut events = Vec::new();
+        loop {
+            match stream
+                .next()
+                .await
+                .assert_value_with("explicit stream closure")
+            {
+                RunSubscriptionItem::Event(event) => events.push(event),
+                RunSubscriptionItem::Closed { reason } => {
+                    assert_eq!(reason, expected_close);
+                    break;
+                }
+            }
+        }
+        assert!(stream.next().await.is_none());
+        events
+    })
+    .await
+    .assert_value_with("durable stream terminates")
+}
+
+#[tokio::test]
+async fn output_append_failure_cancels_a_still_running_handle_and_persists_failure_after_cleanup() {
+    let harness = FailureHarness::new(FailurePoint::Output, false, false).await;
+    harness.release_fault();
+    harness.failed().await;
+    assert!(harness.driver.cancelled.load(Ordering::SeqCst));
+    assert!(!harness.driver.completed.load(Ordering::SeqCst));
+    assert_eq!(harness.cleanup.exits(), vec![RunRuntimeExit::RuntimeLost]);
+    assert_eq!(harness.cleanup.terminal_seen(), vec![false]);
+    let tail = harness.retained().await;
+    assert!(tail.snapshot.active_executions().next().is_none());
+    assert!(matches!(
+        tail.events.last().map(|event| &event.event),
+        Some(RunEvent::Terminal { .. })
+    ));
+    assert!(!tail.events.iter().any(|event| matches!(
+        &event.event, RunEvent::SafeLog { line, .. } if line.as_str() == UNPERSISTED_OUTPUT
+    )));
+    harness.assert_storage_diagnostic();
+}
+
+#[tokio::test]
+async fn completion_append_failure_after_normal_driver_exit_is_observable_and_durable() {
+    let harness = FailureHarness::new(FailurePoint::Completion, false, false).await;
+    harness.release_fault();
+    let status = harness.failed().await;
+    assert!(harness.driver.completed.load(Ordering::SeqCst));
+    assert_eq!(harness.cleanup.terminal_seen(), vec![false]);
+    let stored = harness.retained().await;
+    assert_eq!(stored.snapshot.cursor, status.at_cursor);
+    assert_eq!(
+        stored.snapshot.terminal,
+        Some(TerminalResult::Failed {
+            reason: EnumLabel::new("runtime_failed").assert_value_with("failure reason"),
+        })
+    );
+    harness.assert_storage_diagnostic();
+}
+
+#[tokio::test]
+async fn permanent_storage_failure_preserves_status_and_reports_stream_completeness() {
+    for (lose_reads, close) in [
+        (false, SubscriptionCloseReason::Done),
+        (true, SubscriptionCloseReason::SourceUnavailable),
+    ] {
+        let harness = FailureHarness::new(FailurePoint::Output, true, lose_reads).await;
+        let (watch, logs) = harness.streams().await;
+        harness.release_fault();
+        let status = harness.failed().await;
+        assert!(harness.driver.cancelled.load(Ordering::SeqCst));
+        assert_eq!(
+            harness.ledger.get(&harness.before.run_id).await.is_err(),
+            lose_reads
+        );
+        assert_eq!(
+            status,
+            RunStatusResult {
+                status: status.status.clone(),
+                ..harness.before.clone()
+            }
+        );
+        let retained = harness.retained().await;
+        assert_eq!(retained.snapshot.cursor, harness.before.at_cursor);
+        assert!(retained.snapshot.terminal.is_none());
+        let watch = drain(watch, close).await;
+        assert!(!watch.is_empty());
+        assert!(
+            watch
+                .iter()
+                .all(|event| !matches!(event.status, RunStatus::Finished { .. }))
+        );
+        let logs = drain(logs, close).await;
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs.assert_at(0).cursor, harness.before.at_cursor);
+        assert_eq!(logs.assert_at(0).record.message.as_str(), RETAINED_OUTPUT);
+        harness.assert_storage_diagnostic();
+        if lose_reads {
+            harness.assert_history_unavailable().await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn supervisor_panic_reports_failure_without_rendering_the_panic_payload() {
+    let harness = FailureHarness::new(FailurePoint::CompletionPanic, false, false).await;
+    harness.release_fault();
+    harness.failed().await;
+    assert!(harness.driver.completed.load(Ordering::SeqCst));
+    assert_eq!(harness.cleanup.terminal_seen(), vec![false]);
+    let diagnostics = harness
+        .controller
+        .operator_diagnostics
+        .snapshot(&harness.before.run_id);
+    let diagnostic = diagnostics
+        .diagnostics
+        .first()
+        .assert_value_with("panic diagnostic");
+    assert_eq!(diagnostic.code, "runtime_failed");
+    assert!(diagnostic.stderr.contains("supervisor task panicked"));
+    assert!(
+        !diagnostic
+            .stderr
+            .contains("synthetic private panic payload")
+    );
+}
+
+#[tokio::test]
+async fn failed_cleanup_keeps_failure_visible_without_claiming_a_durable_terminal() {
+    let harness = FailureHarness::new(FailurePoint::Completion, false, false).await;
+    harness.cleanup.fail_next();
+    harness.release_fault();
+    harness.failed().await;
+    assert_eq!(harness.cleanup.exits(), vec![RunRuntimeExit::RuntimeLost]);
+    assert_eq!(harness.cleanup.terminal_seen(), vec![false]);
+    let stored = harness.retained().await;
+    assert!(stored.snapshot.terminal.is_none());
+    harness.assert_storage_diagnostic();
+}
+
+const HELD_PEER_OUTPUT: &str = "peer output held during supervisor panic";
+
+#[derive(Default)]
+struct PeerPanicGate {
+    output_started: tokio::sync::Notify,
+    release_output: tokio::sync::Notify,
+    cancelled: tokio::sync::Notify,
+}
+
+struct PeerPanicDriver {
+    graph: GraphDriver,
+    gate: Arc<PeerPanicGate>,
+}
+
+#[async_trait]
+impl NodeDriver for PeerPanicDriver {
+    async fn run(
+        &self,
+        invocation: DriverInvocation,
+        mut control: DriverControl,
+    ) -> Result<WorkerOutcome, NodeRunnerError> {
+        match invocation.node.reference.node.as_str() {
+            "left" => self.gate.output_started.notified().await,
+            "right" => {
+                control
+                    .emit(LiveOutput::new(LiveOutputStream::Output, HELD_PEER_OUTPUT)?)
+                    .await?;
+                control.cancelled().await;
+                self.gate.cancelled.notify_one();
+                return Err(NodeRunnerError::Cancelled);
+            }
+            _ => {}
+        }
+        self.graph.run(invocation, control).await
+    }
+}
+
+#[tokio::test]
+async fn supervisor_panic_waits_for_peer_output_before_cleanup_and_durable_failure() {
+    let inner = Arc::new(FakeRunLedger::new());
+    let gate = Arc::new(PeerPanicGate::default());
+    let mut ledger = FaultLedger::new(
+        inner.clone(),
+        FailurePoint::PeerCompletionPanic,
+        false,
+        false,
+    );
+    ledger.peer = Some(gate.clone());
+    ledger.armed.store(true, Ordering::SeqCst);
+    let ledger = Arc::new(ledger);
+    let cleanup = Arc::new(FakeCleanup::new(inner.clone()));
+    let driver = Arc::new(PeerPanicDriver {
+        graph: GraphDriver::default(),
+        gate: gate.clone(),
+    });
+    let allocator = Arc::new(FakeAllocator::new(driver, cleanup.clone()));
+    let controller = NativeV2CloudController::new(ledger.clone(), allocator)
+        .await
+        .assert_value_with("peer panic controller startup");
+    let receipt = submit_test_request(&controller, complex_request())
+        .await
+        .assert_value_with("parallel graph admitted");
+
+    tokio::time::timeout(Duration::from_secs(2), gate.cancelled.notified())
+        .await
+        .assert_value_with("panic cancels the still-running peer");
+    assert!(ledger.triggered.load(Ordering::SeqCst));
+    // Provider cancellation is acknowledged, but its durable write remains deliberately held.
+    // A detached bridge would allow cleanup to race ahead of this write.
+    let premature_cleanup = tokio::time::timeout(Duration::from_millis(25), async {
+        while cleanup.exits().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        premature_cleanup.is_err(),
+        "cleanup must await owned output"
+    );
+    gate.release_output.notify_one();
+
+    assert_eq!(
+        terminal(&controller, &receipt.run_id).await,
+        TerminalResult::Failed {
+            reason: EnumLabel::new("runtime_failed").assert_value_with("failure reason"),
+        }
+    );
+    assert_eq!(cleanup.exits(), vec![RunRuntimeExit::RuntimeLost]);
+    assert_eq!(cleanup.terminal_seen(), vec![false]);
+    let retained = inner
+        .snapshot_and_tail(&receipt.run_id, None)
+        .await
+        .assert_value_with("peer output and failure persisted");
+    let peer_output = retained
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                &event.event, RunEvent::SafeLog { line, .. } if line.as_str() == HELD_PEER_OUTPUT
+            )
+        })
+        .assert_value_with("held peer output drained");
+    let terminal_event = retained
+        .events
+        .iter()
+        .position(|event| matches!(event.event, RunEvent::Terminal { .. }))
+        .assert_value_with("durable terminal follows drained output");
+    assert!(peer_output < terminal_event);
+    assert_eq!(terminal_event + 1, retained.events.len());
+    assert!(retained.snapshot.active_executions().next().is_none());
+}

--- a/zeroshot/src/native_v2_codex.rs
+++ b/zeroshot/src/native_v2_codex.rs
@@ -18,12 +18,10 @@ use std::path::{Path, PathBuf};
 use openengine_cluster_protocol::WorkerOutcome;
 
 use crate::execution::driver::WorkspaceCapability;
-use crate::execution::process::{
-    HostedProcessPool, LocalProcessRunner, ProcessRunnerError, ProcessSessionCommand,
-};
+use crate::execution::process::{HostedProcessPool, ProcessSessionCommand};
 use crate::native_v2_capsule::provider_process::{
     ClosedSessionFailure, ProviderFailure, ProviderFailureRetry, ProviderProcessRunners,
-    process_scope, redaction_values, with_driver_detail,
+    ProviderExecution, ProviderFilesystemConfig, redaction_values, with_driver_detail,
 };
 use crate::native_v2_contract::CodexProvider;
 use crate::native_v2_runner::{
@@ -110,16 +108,6 @@ impl NativeV2CodexAdapter {
         }
     }
 
-    fn turn_process(
-        &self,
-        invocation: &DriverInvocation,
-    ) -> Result<Result<(LocalProcessRunner, PathBuf), ProcessRunnerError>, NodeRunnerError> {
-        let scope = process_scope(invocation).map_err(|error| {
-            with_driver_detail(error, "Codex process scope requires an agent node role")
-        })?;
-        Ok(self.runners.turn_process(&self.config.runtime_home, scope))
-    }
-
     fn command(
         &self,
         turn: &CodexTurn<'_>,
@@ -135,7 +123,7 @@ impl NativeV2CodexAdapter {
         let executable = path_text(&self.config.executable).map_err(|error| {
             with_driver_detail(error, "Codex executable path is not valid on this platform")
         })?;
-        let workspace = self.config.workspace.clone();
+        let workspace = input.files.workspace.clone();
         let mut argv = vec!["exec".to_owned()];
         self.add_execution_policy(&mut argv, sandbox);
         add_resume_command(&mut argv, input.resume);
@@ -153,14 +141,19 @@ impl NativeV2CodexAdapter {
         ]);
         add_session_target(&mut argv, input.resume);
 
+        let mut environment = self
+            .provider_environment(&invocation.environment, input.files.home())
+            .map_err(|error| with_driver_detail(error, "Codex provider environment is invalid"))?;
+        environment.entry("TMPDIR".to_owned()).or_insert(
+            input
+                .files
+                .scratch_text()
+                .map_err(|error| NodeRunnerError::DriverDetail(error.to_string()))?,
+        );
         Ok(ProcessSessionCommand {
             program: executable,
             argv,
-            environment: self
-                .provider_environment(&invocation.environment, input.runtime_home)
-                .map_err(|error| {
-                    with_driver_detail(error, "Codex provider environment is invalid")
-                })?,
+            environment,
             workspace: WorkspaceCapability {
                 current_dir: workspace,
                 mode: access,
@@ -233,10 +226,20 @@ impl NativeV2CodexAdapter {
         control: DriverControl,
     ) -> Result<WorkerOutcome, NodeRunnerError> {
         let _turn = session.core.turn.lock().await;
+        let execution = ProviderExecution::new(
+            ProviderFilesystemConfig {
+                runners: self.runners,
+                root: &self.config.runtime_home,
+                workspace: &self.config.workspace,
+            },
+            invocation,
+            &session.core,
+        );
         let turn = CodexTurn {
             invocation,
             session,
             control: &control,
+            execution: &execution,
         };
         let prompt = render_agent_prompt(
             invocation.agent_instructions()?,
@@ -317,7 +320,7 @@ impl NativeV2CodexAdapter {
         turn: &CodexTurn<'_>,
         resume: Option<&str>,
     ) -> Result<CodexTurnProcessOpen, NodeRunnerError> {
-        let (runner, runtime_home) = match self.turn_process(turn.invocation)? {
+        let files = match turn.execution.prepare(turn.control).await {
             Ok(resources) => resources,
             Err(error) => {
                 return Ok(CodexTurnProcessOpen::ProviderFailure(format!(
@@ -326,7 +329,7 @@ impl NativeV2CodexAdapter {
             }
         };
         let schema = match CodexSchemaFile::create(
-            &runtime_home,
+            files.home(),
             &turn
                 .invocation
                 .response
@@ -341,11 +344,11 @@ impl NativeV2CodexAdapter {
             turn,
             CodexCommandInput {
                 resume,
-                runtime_home: &runtime_home,
+                files: &files,
                 schema_path: schema.path(),
             },
         )?;
-        let process = match open_process(runner, command, turn.control).await? {
+        let process = match open_process(files, command, turn.control).await? {
             ProcessOpen::Ready(process) => process,
             ProcessOpen::ProviderFailure(detail) => {
                 return Ok(CodexTurnProcessOpen::ProviderFailure(detail));
@@ -362,6 +365,7 @@ struct CodexTurn<'a> {
     invocation: &'a DriverInvocation,
     session: &'a CodexSession,
     control: &'a DriverControl,
+    execution: &'a ProviderExecution<'a>,
 }
 
 struct CodexRunState {

--- a/zeroshot/src/native_v2_codex/process.rs
+++ b/zeroshot/src/native_v2_codex/process.rs
@@ -1,10 +1,11 @@
+use std::sync::Arc;
+
 use crate::execution::process::{
-    LocalProcessRunner, ProcessRunnerError, ProcessSession, ProcessSessionCommand,
-    ProcessSessionOutput, ProcessStdout,
+    ProcessRunnerError, ProcessSessionCommand, ProcessSessionOutput, ProcessStdout,
 };
 use crate::native_v2_capsule::provider_process::{
-    ProcessExchange, ProcessInputFailure, exchange_process_io, open_provider_process,
-    process_failure_detail, safe_provider_text,
+    ProcessExchange, ProcessInputFailure, ProviderExecutionFiles, ProviderProcess,
+    exchange_process_io, open_provider_process, process_failure_detail, safe_provider_text,
 };
 use crate::native_v2_contract::TokenUsageDelta;
 use crate::native_v2_runner::{DriverControl, LiveOutput, LiveOutputStream, NodeRunnerError};
@@ -12,7 +13,7 @@ use crate::native_v2_runner::{DriverControl, LiveOutput, LiveOutputStream, NodeR
 use super::output::{CodexOutput, CodexOutputDecoder};
 
 pub(super) enum ProcessOpen {
-    Ready(ProcessSession),
+    Ready(ProviderProcess),
     ProviderFailure(String),
 }
 
@@ -23,11 +24,11 @@ struct CollectedOutput {
 }
 
 pub(super) async fn open_process(
-    runner: LocalProcessRunner,
+    files: Arc<ProviderExecutionFiles>,
     command: ProcessSessionCommand,
     control: &DriverControl,
 ) -> Result<ProcessOpen, NodeRunnerError> {
-    let process = match open_provider_process(runner, command, control).await? {
+    let process = match open_provider_process(files, command, control).await? {
         Ok(process) => process,
         Err(error) => {
             return Ok(ProcessOpen::ProviderFailure(format!(
@@ -60,7 +61,7 @@ async fn collect_output(
 }
 
 pub(super) async fn exchange_turn(
-    process: &mut ProcessSession,
+    process: &mut ProviderProcess,
     prompt: &str,
     control: &DriverControl,
     redactions: &[String],
@@ -126,7 +127,7 @@ fn retain_delivery_evidence(
 }
 
 pub(super) async fn finish_process(
-    process: &mut ProcessSession,
+    process: &mut ProviderProcess,
     output_complete: bool,
 ) -> Result<ProcessSessionOutput, ProcessRunnerError> {
     if output_complete {

--- a/zeroshot/src/native_v2_codex/tests.rs
+++ b/zeroshot/src/native_v2_codex/tests.rs
@@ -60,6 +60,7 @@ prompt=$(/usr/bin/cat)
   /usr/bin/printf 'aws_region=%s\n' "${AWS_REGION-unset}"
   /usr/bin/printf 'path=%s\n' "${PATH-unset}"
   /usr/bin/printf 'home=%s\n' "${HOME-unset}"
+  /usr/bin/printf 'scratch=%s\n' "$TMPDIR"
   /usr/bin/printf 'ambient=%s\n' "${AMBIENT_SENTINEL-unset}"
 } >> "$CAPTURE_PATH"
 
@@ -491,4 +492,14 @@ async fn openai_node_instance_session_resumes_the_exact_thread() {
             .iter()
             .all(|home| home.ends_with("writer-node-instance-1"))
     );
+    assert!(homes.iter().all(|home| Path::new(home).is_dir()));
+    let scratches = capture
+        .lines()
+        .filter_map(|line| line.strip_prefix("scratch="))
+        .collect::<Vec<_>>();
+    crate::native_v2_candidate::test_support::assert_removed_directories(&scratches, 2);
+    runtime
+        .close_run(&openengine_cluster_protocol::RunId::new("run-codex"))
+        .await;
+    assert!(homes.iter().all(|home| !Path::new(home).exists()));
 }

--- a/zeroshot/src/native_v2_codex/tests/correction.rs
+++ b/zeroshot/src/native_v2_codex/tests/correction.rs
@@ -3,7 +3,7 @@ use super::*;
 async fn corrected_output(
     directory: &TestDirectory,
     provider: CodexProvider,
-) -> (WorkerOutcome, String) {
+) -> (WorkerOutcome, String, String) {
     let capture = directory.child("capture");
     let configuration = match provider {
         CodexProvider::OpenAi => Some(("OPENAI_API_KEY", "fake-openai-key", "gpt-5.6-sol")),
@@ -27,7 +27,7 @@ async fn corrected_output(
     )
     .await;
     let runtime = runner(&admitted, adapter);
-    let mut handle = start(
+    let handle = start(
         &runtime,
         &admitted,
         1,
@@ -38,14 +38,18 @@ async fn corrected_output(
         ],
     )
     .await;
-    let outcome = handle.completion().await.assert_value().outcome;
-    (outcome, fs::read_to_string(capture).assert_value())
+    let (logs, outcome) = complete_with_logs(handle).await;
+    (
+        outcome.assert_value(),
+        fs::read_to_string(capture).assert_value(),
+        logs,
+    )
 }
 
 #[tokio::test]
 async fn invalid_output_is_corrected_in_the_same_codex_session() {
     let directory = TestDirectory::new("codex-correction");
-    let (outcome, capture) = corrected_output(&directory, CodexProvider::OpenAi).await;
+    let (outcome, capture, logs) = corrected_output(&directory, CodexProvider::OpenAi).await;
 
     assert!(matches!(
         outcome,
@@ -53,14 +57,17 @@ async fn invalid_output_is_corrected_in_the_same_codex_session() {
     ));
     assert_eq!(capture.matches("arg=resume").count(), 1);
     assert_eq!(capture.matches("arg=thread-123").count(), 1);
-    assert!(capture.contains("Your previous final response was rejected mechanically"));
+    assert!(
+        capture.contains("Your previous final response was rejected mechanically"),
+        "missing correction prompt; fixture capture:\n{capture}\nprovider logs:\n{logs}"
+    );
     assert!(capture.contains("output $.answer must be a integer"));
 }
 
 #[tokio::test]
 async fn openrouter_correction_scopes_configuration_to_the_resume_command() {
     let directory = TestDirectory::new("codex-openrouter-correction");
-    let (outcome, capture) = corrected_output(&directory, CodexProvider::OpenRouter).await;
+    let (outcome, capture, _logs) = corrected_output(&directory, CodexProvider::OpenRouter).await;
 
     assert!(matches!(
         outcome,

--- a/zeroshot/src/native_v2_codex/tests/retry.rs
+++ b/zeroshot/src/native_v2_codex/tests/retry.rs
@@ -3,6 +3,7 @@ use super::*;
 const RETRY_SCRIPT_PREFIX: &str = r#"#!/bin/sh
 set -eu
 prompt=$(/usr/bin/cat)
+/usr/bin/printf '%s\n' "$HOME" "$TMPDIR" "$PWD" >> "$STATE_PATH.files"
 if [ -e "$STATE_PATH" ]; then attempt=2; else attempt=1; : > "$STATE_PATH"; fi
 /usr/bin/printf '%s' "$prompt" > "$STATE_PATH.prompt.$attempt"
 {
@@ -142,6 +143,12 @@ async fn terminal_error_continues_once_in_the_same_session() {
     assert!(rendered.contains("Codex provider failed; continuing once"));
     assert!(rendered.contains("Codex file change completed: update src/lib.rs"));
     assert!(!rendered.contains("sentinel-secret"));
+    let paths = fs::read_to_string(state.with_extension("files")).assert_value();
+    let paths = paths.lines().collect::<Vec<_>>();
+    assert_eq!(&paths[..3], &paths[3..]);
+    assert!(!Path::new(paths[0]).exists());
+    assert!(!Path::new(paths[1]).exists());
+    assert!(Path::new(paths[2]).exists());
 }
 
 #[tokio::test]

--- a/zeroshot/src/native_v2_codex/turn.rs
+++ b/zeroshot/src/native_v2_codex/turn.rs
@@ -1,17 +1,17 @@
 use std::path::Path;
 
-use crate::execution::process::ProcessSession;
+use crate::native_v2_capsule::provider_process::{ProviderExecutionFiles, ProviderProcess};
 
 use super::schema_file::CodexSchemaFile;
 
 pub(super) struct CodexCommandInput<'a> {
     pub(super) resume: Option<&'a str>,
-    pub(super) runtime_home: &'a Path,
+    pub(super) files: &'a ProviderExecutionFiles,
     pub(super) schema_path: &'a Path,
 }
 
 pub(super) struct CodexTurnProcess {
-    pub(super) process: ProcessSession,
+    pub(super) process: ProviderProcess,
     pub(super) _schema: CodexSchemaFile,
 }
 

--- a/zeroshot/src/native_v2_hosting.rs
+++ b/zeroshot/src/native_v2_hosting.rs
@@ -119,7 +119,8 @@ impl ProductionTargetControllerFactory {
             DeliveryPolicy::Optional,
         )
         .await
-        .map_err(|_| ProductionHostingError::Controller)?;
+        .map_err(|_| ProductionHostingError::Controller)?
+        .with_operator_diagnostics(self.operator_diagnostics.clone());
         Ok(Arc::new(controller))
     }
 }

--- a/zeroshot/src/native_v2_hosting/tests.rs
+++ b/zeroshot/src/native_v2_hosting/tests.rs
@@ -318,8 +318,19 @@ async fn hosted_workspace_replacement_signals_runtime_loss() {
     .assert_value_with("workspace loss timeout");
 }
 
+const CLAUDE_HOME_SCRIPT: &str = r#"set -eu
+cat >/dev/null
+printf '%s' "$HOME" > observed-home
+: > "$HOME/created-by-provider"
+printf '%s%s\n' \
+  '{"type":"stream_event","event":{"type":"content_block_delta",' \
+  '"delta":{"type":"text_delta","text":"home-ready"}}}'
+while [ ! -e release-provider ]; do sleep 0.01; done
+exit 17
+"#;
+
 #[tokio::test]
-async fn default_claude_environment_prepares_capsule_session_home() {
+async fn default_claude_environment_owns_private_session_home_until_completion() {
     let repository = RepositoryFixture::new();
     let root = TestDirectory::new("hosting-claude-environment");
     prepare_storage_root(&root.path().to_owned()).assert_value_with("storage root");
@@ -332,6 +343,8 @@ async fn default_claude_environment_prepares_capsule_session_home() {
     .await;
     let mut config = capsule_config(root.path().to_owned());
     config.claude_process_environment = ClaudeProcessEnvironment::default();
+    config.claude_executable = "/bin/sh".to_owned();
+    config.claude_prefix_arguments = vec!["-c".to_owned(), CLAUDE_HOME_SCRIPT.to_owned()];
     let allocator = ProductionCapsuleAllocator::new(config)
         .assert_value_with("allocator")
         .with_test_filesystem_and_source(repository.remote, portable_filesystem);
@@ -373,13 +386,15 @@ async fn default_claude_environment_prepares_capsule_session_home() {
         })
         .await
         .assert_value_with("start Claude node");
+    let mut output = handle.take_initial_output().assert_value();
+    assert_running_claude_home_if_root(&mut output, &run_path).await;
+    let private_home = run_path.join("runtime/writer-execution-1");
     assert!(matches!(
         handle.completion().await,
         Err(crate::native_v2_runner::NodeRunnerError::Driver)
     ));
-
-    let private_home = run_path.join("runtime/writer-execution-1");
-    assert!(private_home.is_dir());
+    assert!(!private_home.exists());
+    assert!(!run_path.join("runtime/execution-1").exists());
 
     capsule
         .cleanup
@@ -389,3 +404,33 @@ async fn default_claude_environment_prepares_capsule_session_home() {
 }
 
 use openengine_cluster_testkit::assertions::{AssertError, AssertValue};
+
+async fn assert_running_claude_home_if_root(
+    output: &mut crate::native_v2_runner::DurableOutput,
+    run_path: &Path,
+) {
+    // Hosted process containment requires Linux and a root supervisor.
+    if !cfg!(target_os = "linux") || unsafe { libc::geteuid() } != 0 {
+        return;
+    }
+    let ready = tokio::time::timeout(Duration::from_secs(3), output.recv_output())
+        .await
+        .assert_value_with("provider prepared HOME")
+        .assert_value();
+    assert_eq!(ready.text, "home-ready");
+    let private_home = run_path.join("runtime/writer-execution-1");
+    assert!(private_home.join("created-by-provider").is_file());
+    assert_eq!(
+        fs::metadata(&private_home)
+            .assert_value()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o700
+    );
+    assert_eq!(
+        fs::read_to_string(run_path.join("workspace/observed-home")).assert_value(),
+        private_home.to_string_lossy()
+    );
+    fs::write(run_path.join("workspace/release-provider"), "").assert_value();
+}

--- a/zeroshot/src/native_v2_observability.rs
+++ b/zeroshot/src/native_v2_observability.rs
@@ -1,6 +1,7 @@
 //! Ledger-backed native-v2 status, watch, logs, and live read-only attach.
 //!
-//! Durable observation is reconstructed exclusively from the lean run ledger. Live attach is a
+//! Durable history is reconstructed from the lean run ledger. A stopped runtime retains a minimal
+//! in-memory failure status when persistence fails, without fabricating history. Live attach is a
 //! deliberately separate, active-execution-only stream: it has no cursor, stores no history, and
 //! cannot signal or cancel an execution when a viewer disconnects.
 
@@ -10,6 +11,7 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures_util::FutureExt;
 use openengine_cluster_protocol::{
     ActiveExecution, AgentAttachEvent, BoundedAssistantOutput, BoundedLogMessage, BoundedLogTarget,
     Cursor, ExecutionRef as PublicExecutionRef, LogLevel, LogRecord, RunAttachEventNotification,
@@ -32,6 +34,9 @@ use crate::v2_run_ledger::{
 const POLL_INTERVAL: Duration = Duration::from_millis(25);
 const LOG_TARGET: &str = "agent";
 
+mod runtime;
+use runtime::RuntimeObservation;
+
 mod projection;
 use projection::{
     bounded_attach_output, changes_public_status, log_notification, opaque_execution,
@@ -46,6 +51,7 @@ mod tests;
 pub struct NativeV2Observability {
     ledger: Arc<dyn RunLedger>,
     live: LiveRegistry,
+    runtime: RuntimeObservation,
     next_subscription: Arc<AtomicU64>,
 }
 
@@ -55,6 +61,7 @@ impl NativeV2Observability {
         Self {
             ledger,
             live: LiveRegistry::default(),
+            runtime: RuntimeObservation::default(),
             next_subscription: Arc::new(AtomicU64::new(1)),
         }
     }
@@ -63,12 +70,15 @@ impl NativeV2Observability {
         &self,
         params: RunStatusParams,
     ) -> Result<RunStatusResult, NativeV2ObservationError> {
-        let stored = self
-            .ledger
-            .get(&params.run_id)
-            .await?
-            .ok_or(NativeV2ObservationError::RunNotFound)?;
-        status_result(&stored.snapshot)
+        if let Some(failure) = self.runtime.failure(&params.run_id) {
+            return Ok(failure);
+        }
+        let result = match self.ledger.get(&params.run_id).await {
+            Ok(Some(stored)) => self.runtime.observe(&stored.snapshot),
+            Ok(None) => Err(NativeV2ObservationError::RunNotFound),
+            Err(error) => Err(error.into()),
+        };
+        result.or_else(|error| self.runtime.failure(&params.run_id).ok_or(error))
     }
 
     pub async fn watch(
@@ -78,6 +88,7 @@ impl NativeV2Observability {
         let start = params.from_cursor.unwrap_or_else(initial_cursor);
         let subscription_id = self.subscription_id("watch");
         let complete = self.ledger.snapshot_and_tail(&params.run_id, None).await?;
+        self.runtime.observe(&complete.snapshot)?;
         let start_sequence = cursor_sequence(&start)?;
         if start_sequence > cursor_sequence(&complete.snapshot.cursor)? {
             return Err(RunLedgerError::CursorAhead.into());
@@ -98,6 +109,7 @@ impl NativeV2Observability {
         };
         let subscription = RunWatchSubscription {
             ledger: self.ledger.clone(),
+            runtime: self.runtime.clone(),
             subscription_id,
             run_id: params.run_id,
             scanned_through: complete.snapshot.cursor,
@@ -116,6 +128,7 @@ impl NativeV2Observability {
             .ledger
             .snapshot_and_tail(&params.run_id, Some(&start))
             .await?;
+        self.runtime.observe(&tail.snapshot)?;
         let execution = params
             .execution
             .as_ref()
@@ -136,6 +149,7 @@ impl NativeV2Observability {
             .collect::<Result<VecDeque<_>, _>>()?;
         let subscription = RunLogsSubscription {
             ledger: self.ledger.clone(),
+            runtime: self.runtime.clone(),
             subscription_id,
             run_id: params.run_id,
             execution,
@@ -159,6 +173,7 @@ impl NativeV2Observability {
             .get(&reference.run_id)
             .await?
             .ok_or(NativeV2ObservationError::RunNotFound)?;
+        self.runtime.observe(&stored.snapshot)?;
         require_active_reference(&stored.snapshot, reference)?;
         let public_execution = opaque_execution(reference)?;
         let key = self
@@ -210,6 +225,27 @@ impl NativeV2Observability {
             receiver,
         };
         Ok((result, subscription))
+    }
+
+    pub(crate) fn track_runtime(
+        &self,
+        snapshot: &RunSnapshot,
+    ) -> Result<(), NativeV2ObservationError> {
+        self.runtime.track(snapshot)
+    }
+
+    pub(crate) async fn runtime_failed(&self, run_id: &RunId) {
+        let refreshed = std::panic::AssertUnwindSafe(self.ledger.get(run_id))
+            .catch_unwind()
+            .await;
+        if let Ok(Ok(Some(stored))) = refreshed {
+            let _ = self.runtime.observe(&stored.snapshot);
+        }
+        self.runtime.fail(run_id);
+    }
+
+    pub(crate) fn runtime_finished(&self, run_id: &RunId) {
+        self.runtime.finish(run_id);
     }
 
     fn subscription_id(&self, kind: &str) -> SubscriptionId {

--- a/zeroshot/src/native_v2_observability/runtime.rs
+++ b/zeroshot/src/native_v2_observability/runtime.rs
@@ -1,0 +1,92 @@
+//! Minimal status fallback for a controller-owned runtime that cannot persist its own failure.
+//! It never creates a durable event or advances a cursor. Only active runtime identities are seeded;
+//! normal completion removes them, while a failed runtime remains observable for this controller.
+
+use super::*;
+use openengine_cluster_protocol::{EnumLabel, TerminalResult};
+
+#[derive(Clone, Default)]
+pub(super) struct RuntimeObservation {
+    entries: Arc<Mutex<BTreeMap<RunId, RuntimeStatus>>>,
+}
+
+struct RuntimeStatus {
+    last: RunStatusResult,
+    metadata: RunMetadata,
+    failed: bool,
+}
+
+impl RuntimeObservation {
+    pub(super) fn track(&self, snapshot: &RunSnapshot) -> Result<(), NativeV2ObservationError> {
+        let last = status_result(snapshot)?;
+        self.entries().insert(
+            last.run_id.clone(),
+            RuntimeStatus {
+                last,
+                metadata: RunMetadata {
+                    token_usage: snapshot.token_usage.clone(),
+                },
+                failed: false,
+            },
+        );
+        Ok(())
+    }
+
+    pub(super) fn observe(
+        &self,
+        snapshot: &RunSnapshot,
+    ) -> Result<RunStatusResult, NativeV2ObservationError> {
+        let current = status_result(snapshot)?;
+        let mut entries = self.entries();
+        let Some(runtime) = entries.get_mut(&current.run_id) else {
+            return Ok(current);
+        };
+        if cursor_sequence(&current.at_cursor)? >= cursor_sequence(&runtime.last.at_cursor)? {
+            let failure = runtime.failed.then(|| runtime.last.status.clone());
+            runtime.last = current;
+            runtime.metadata.token_usage = snapshot.token_usage.clone();
+            if let Some(failure) = failure {
+                runtime.last.status = failure;
+            }
+        }
+        Ok(runtime.last.clone())
+    }
+
+    pub(super) fn fail(&self, run_id: &RunId) {
+        if let Some(runtime) = self.entries().get_mut(run_id) {
+            runtime.failed = true;
+            if !matches!(runtime.last.status, RunStatus::Finished { .. }) {
+                runtime.last.status = RunStatus::Finished {
+                    metadata: runtime.metadata.clone(),
+                    terminal_result: TerminalResult::Failed {
+                        reason: EnumLabel::new("runtime_failed")
+                            .expect("static runtime failure reason"),
+                    },
+                };
+            }
+        }
+    }
+
+    pub(super) fn failure(&self, run_id: &RunId) -> Option<RunStatusResult> {
+        self.entries()
+            .get(run_id)
+            .filter(|runtime| runtime.failed)
+            .map(|runtime| runtime.last.clone())
+    }
+
+    pub(super) fn observe_finished(
+        &self,
+        snapshot: &RunSnapshot,
+    ) -> Result<bool, NativeV2ObservationError> {
+        self.observe(snapshot)?;
+        Ok(snapshot.terminal.is_some() || self.failure(&snapshot.run_id).is_some())
+    }
+
+    pub(super) fn finish(&self, run_id: &RunId) {
+        self.entries().remove(run_id);
+    }
+
+    fn entries(&self) -> MutexGuard<'_, BTreeMap<RunId, RuntimeStatus>> {
+        self.entries.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}

--- a/zeroshot/src/native_v2_observability/subscriptions.rs
+++ b/zeroshot/src/native_v2_observability/subscriptions.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub struct RunWatchSubscription {
     pub(super) ledger: Arc<dyn RunLedger>,
+    pub(super) runtime: RuntimeObservation,
     pub(super) subscription_id: SubscriptionId,
     pub(super) run_id: RunId,
     pub(super) scanned_through: Cursor,
@@ -37,13 +38,15 @@ impl RunWatchSubscription {
             pending: &mut self.pending,
         }
         .apply(&tail.events)?;
+        let finished = self.runtime.observe_finished(&tail.snapshot)?;
         self.scanned_through = tail.snapshot.cursor;
-        Ok(tail.snapshot.terminal.is_some())
+        Ok(finished)
     }
 }
 
 pub struct RunLogsSubscription {
     pub(super) ledger: Arc<dyn RunLedger>,
+    pub(super) runtime: RuntimeObservation,
     pub(super) subscription_id: SubscriptionId,
     pub(super) run_id: RunId,
     pub(super) execution: Option<ExecutionId>,
@@ -81,8 +84,9 @@ impl RunLogsSubscription {
                 self.pending.push_back(notification);
             }
         }
+        let finished = self.runtime.observe_finished(&tail.snapshot)?;
         self.scanned_through = tail.snapshot.cursor;
-        Ok(tail.snapshot.terminal.is_some())
+        Ok(finished)
     }
 }
 

--- a/zeroshot/src/native_v2_portable_controller/engine.rs
+++ b/zeroshot/src/native_v2_portable_controller/engine.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::io::Write;
 
 use async_trait::async_trait;
 use openengine_cluster_protocol::RunId;
@@ -9,6 +10,8 @@ use crate::native_v2_cloud::{
     CapsuleCleanup, CapsuleCleanupUnavailable, CapsuleDestroyed, ExclusiveControllerClaim,
 };
 use crate::native_v2_runner::NodeRunner;
+use crate::native_v2_observability::NativeV2Observability;
+use crate::native_v2_target_authority::{NewOperatorDiagnostic, OperatorDiagnosticStore};
 use crate::native_v2_supervisor::{RunEnvironment, RunRuntimeExit};
 use crate::v2_run_ledger::RunLedger;
 
@@ -31,7 +34,8 @@ pub struct PortableRunEngineBootstrap {
     pub loss: watch::Receiver<bool>,
     pub controller_claim: Arc<dyn ExclusiveControllerClaim>,
     pub delivery_policy: DeliveryPolicy,
-    pub live_output: Arc<dyn crate::native_v2_supervisor::LiveOutputRegistrar>,
+    pub observability: NativeV2Observability,
+    pub(crate) operator_diagnostics: Arc<OperatorDiagnosticStore>,
 }
 
 impl PortableRunEngine {
@@ -45,17 +49,18 @@ impl PortableRunEngine {
             mut loss,
             controller_claim,
             delivery_policy,
-            live_output,
+            observability,
+            operator_diagnostics,
         } = bootstrap;
         let supervisor = Arc::new(
             crate::native_v2_supervisor::NativeV2Supervisor::new(
-                run_id,
+                run_id.clone(),
                 ledger,
                 runtime.runner,
                 Arc::new(environment),
             )
             .with_delivery_policy(delivery_policy)
-            .with_live_output(live_output)
+            .with_live_output(Arc::new(observability.clone()))
             .with_runtime_cleanup(Arc::new(PortableRuntimeCleanup(runtime.cleanup))),
         );
         let (removable_sender, removable) = watch::channel(false);
@@ -66,17 +71,50 @@ impl PortableRunEngine {
         tokio::spawn(async move {
             let _controller_claim = controller_claim;
             let drive_supervisor = supervisor.clone();
-            let mut drive = Box::pin(async move { drive_supervisor.drive().await });
-            let result = tokio::select! {
-                result = &mut drive => result,
-                () = wait_for_runtime_loss(&mut loss) => {
-                    supervisor.runtime_lost().await;
-                    drive.await
+            let result = tokio::spawn(async move {
+                let drive = drive_supervisor.drive();
+                tokio::pin!(drive);
+                tokio::select! {
+                    result = &mut drive => result,
+                    () = wait_for_runtime_loss(&mut loss) => {
+                        drive_supervisor.runtime_lost().await;
+                        drive.await
+                    }
                 }
-            };
-            if result.is_ok() {
-                removable_sender.send_replace(true);
+            })
+            .await;
+            match task_result(result) {
+                Ok(_) => observability.runtime_finished(&run_id),
+                Err(cause) => {
+                    let recovery = task_result(
+                        tokio::spawn(async move { supervisor.fail_runtime().await }).await,
+                    );
+                    let mut details = format!("supervisor.drive: {cause}");
+                    if let Err(error) = recovery {
+                        details.push_str(&format!("\nFailure cleanup/persistence: {error}"));
+                    }
+                    // These are typed platform errors. Never render a panic payload, provider
+                    // response, environment value, or arbitrary SQLite query/trigger text here.
+                    let _ = writeln!(
+                        std::io::stderr(),
+                        "run {} runtime_failed: {details}",
+                        run_id.as_str()
+                    );
+                    operator_diagnostics.record(NewOperatorDiagnostic {
+                        run_id: run_id.clone(),
+                        code: "runtime_failed",
+                        operation: "supervisor.drive",
+                        exit_status: None,
+                        stdout: String::new(),
+                        stderr: details,
+                        stdout_truncated: false,
+                        stderr_truncated: false,
+                    });
+                    observability.runtime_failed(&run_id).await;
+                }
             }
+            // Removal follows an explicit observed outcome, never a dropped false sender.
+            removable_sender.send_replace(true);
         });
         engine
     }
@@ -88,9 +126,26 @@ impl PortableRunEngine {
         self.supervisor.drive().await.map(|_| ())
     }
 
-    pub async fn wait_removable(&self) {
-        let mut removable = self.removable.clone();
-        while !*removable.borrow_and_update() && removable.changed().await.is_ok() {}
+    pub async fn wait_removable(&self) -> bool {
+        wait_for_removability(self.removable.clone()).await
+    }
+}
+
+async fn wait_for_removability(mut removable: watch::Receiver<bool>) -> bool {
+    while !*removable.borrow_and_update() && removable.changed().await.is_ok() {}
+    *removable.borrow()
+}
+
+fn task_result<T>(
+    result: Result<
+        Result<T, crate::native_v2_supervisor::NativeV2SupervisorError>,
+        tokio::task::JoinError,
+    >,
+) -> Result<T, String> {
+    match result {
+        Ok(result) => result.map_err(|error| error.to_string()),
+        Err(error) if error.is_panic() => Err("supervisor task panicked".to_owned()),
+        Err(_) => Err("supervisor task was cancelled".to_owned()),
     }
 }
 
@@ -142,5 +197,34 @@ impl CapsuleCleanup for ConfirmedCleanup {
         _exit: RunRuntimeExit,
     ) -> Result<CapsuleDestroyed, CapsuleCleanupUnavailable> {
         Ok(CapsuleDestroyed::confirmed())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn removal_requires_explicit_completion_even_when_the_sender_disappears() {
+        for completed in [false, true] {
+            let (sender, receiver) = watch::channel(false);
+            if completed {
+                sender.send_replace(true);
+            }
+            drop(sender);
+            assert_eq!(wait_for_removability(receiver).await, completed);
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_supervisor_task_is_an_explicit_failure() {
+        let task = tokio::spawn(std::future::pending::<
+            Result<(), crate::native_v2_supervisor::NativeV2SupervisorError>,
+        >());
+        task.abort();
+        assert_eq!(
+            task_result(task.await),
+            Err("supervisor task was cancelled".to_owned())
+        );
     }
 }

--- a/zeroshot/src/native_v2_supervisor.rs
+++ b/zeroshot/src/native_v2_supervisor.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures_util::FutureExt;
 use openengine_cluster_protocol::{
     EnumLabel, GraphNode, NodeInstructions, NodeName, RunId, TerminalResult, WorkerErrorCode,
     WorkerOutcome,
@@ -94,6 +95,8 @@ pub enum NativeV2SupervisorError {
     InvalidState,
     #[error("a supervisor task failed")]
     Task,
+    #[error("supervisor task panicked")]
+    TaskPanicked,
     #[error(transparent)]
     RuntimeCleanup(#[from] RuntimeCleanupUnavailable),
     #[error(transparent)]
@@ -205,6 +208,25 @@ impl NativeV2Supervisor {
         program: Box<RunProgram>,
     ) -> Result<TerminalResult, NativeV2SupervisorError> {
         let mut active = ActiveDispatches::default();
+        // Retain task ownership across unwinding so peer output drains before failure is settled.
+        // No provider values or panic payloads are copied into diagnostics.
+        let result = std::panic::AssertUnwindSafe(self.drive_active_program(&program, &mut active))
+            .catch_unwind()
+            .await
+            .unwrap_or(Err(NativeV2SupervisorError::TaskPanicked));
+        if result.is_err() {
+            self.runner.close_run(&self.run_id).await;
+            // Keep ownership until every task has stopped, even when another output append failed.
+            while active.tasks.join_next().await.is_some() {}
+        }
+        result
+    }
+
+    async fn drive_active_program(
+        &self,
+        program: &RunProgram,
+        active: &mut ActiveDispatches,
+    ) -> Result<TerminalResult, NativeV2SupervisorError> {
         loop {
             let snapshot = self.snapshot().await?;
             if let Some(terminal) = snapshot.terminal {
@@ -217,7 +239,7 @@ impl NativeV2Supervisor {
             if snapshot.force_stop_requested {
                 return self.terminalize_force(&mut active.tasks).await;
             }
-            if let Some(terminal) = self.advance(&program, &snapshot, &mut active).await? {
+            if let Some(terminal) = self.advance(program, &snapshot, active).await? {
                 return Ok(terminal);
             }
         }
@@ -283,7 +305,7 @@ impl NativeV2Supervisor {
             .join_next()
             .await
             .ok_or(NativeV2SupervisorError::InvalidState)?
-            .map_err(|_| NativeV2SupervisorError::Task)?;
+            .map_err(supervisor_task_error)?;
         active.cancellations.remove(&finished.execution);
         Ok(finished)
     }
@@ -301,6 +323,17 @@ impl NativeV2Supervisor {
     pub async fn runtime_lost(&self) {
         self.runtime_lost.store(true, Ordering::Release);
         self.runner.close_run(&self.run_id).await;
+    }
+
+    /// Stops owned work without depending on a readable or writable ledger. Durable failure is
+    /// attempted only after runtime cleanup has been acknowledged; the engine retains status if it fails.
+    pub(crate) async fn fail_runtime(&self) -> Result<(), NativeV2SupervisorError> {
+        let _turn = self.drive_turn.lock().await;
+        self.runner.close_run(&self.run_id).await;
+        self.cleanup_runtime(RunRuntimeExit::RuntimeLost).await?;
+        self.append_runtime_failure("runtime_failed")
+            .await
+            .map(|_| ())
     }
 
     async fn cleanup_runtime(&self, exit: RunRuntimeExit) -> Result<(), RuntimeCleanupUnavailable> {
@@ -322,6 +355,14 @@ impl NativeV2Supervisor {
     }
 
     // Dispatch and terminalization are kept in the controller companion module.
+}
+
+fn supervisor_task_error(error: tokio::task::JoinError) -> NativeV2SupervisorError {
+    if error.is_panic() {
+        NativeV2SupervisorError::TaskPanicked
+    } else {
+        NativeV2SupervisorError::Task
+    }
 }
 
 fn enforce_delivery_terminal(

--- a/zeroshot/src/native_v2_supervisor/controller.rs
+++ b/zeroshot/src/native_v2_supervisor/controller.rs
@@ -30,8 +30,9 @@ impl NativeV2Supervisor {
             })
             .collect();
         if let Err(error) = self.ledger.append(&self.run_id, events).await {
-            let snapshot = self.snapshot().await?;
-            if snapshot.force_stop_requested || snapshot.terminal.is_some() {
+            if let Ok(snapshot) = self.snapshot().await
+                && (snapshot.force_stop_requested || snapshot.terminal.is_some())
+            {
                 return Ok(false);
             }
             return Err(error.into());
@@ -290,15 +291,21 @@ impl NativeV2Supervisor {
     ) -> Result<TerminalResult, NativeV2SupervisorError> {
         self.runner.close_run(&self.run_id).await;
         drain_terminalizing_tasks(tasks).await?;
+        self.cleanup_runtime(RunRuntimeExit::RuntimeLost).await?;
+        self.append_runtime_failure("runtime_lost").await
+    }
+
+    pub(super) async fn append_runtime_failure(
+        &self,
+        reason: &str,
+    ) -> Result<TerminalResult, NativeV2SupervisorError> {
         let snapshot = self.snapshot().await?;
         if let Some(terminal) = snapshot.terminal {
             return Ok(terminal);
         }
         let terminal = TerminalResult::Failed {
-            reason: EnumLabel::new("runtime_lost")
-                .map_err(|_| NativeV2SupervisorError::InvalidState)?,
+            reason: EnumLabel::new(reason).map_err(|_| NativeV2SupervisorError::InvalidState)?,
         };
-        self.cleanup_runtime(RunRuntimeExit::RuntimeLost).await?;
         let mut events = snapshot
             .active_executions()
             .map(|node| RunEvent::NodeCompleted {

--- a/zeroshot/src/native_v2_supervisor/runtime.rs
+++ b/zeroshot/src/native_v2_supervisor/runtime.rs
@@ -4,10 +4,9 @@ pub(super) async fn drain_terminalizing_tasks(
     tasks: &mut JoinSet<FinishedDispatch>,
 ) -> Result<(), NativeV2SupervisorError> {
     while let Some(finished) = tasks.join_next().await {
-        let finished = finished.map_err(|_| NativeV2SupervisorError::Task)?;
+        let finished = finished.map_err(supervisor_task_error)?;
         match finished.result {
             DispatchResult::DurableEventFailure(error) => return Err(error.into()),
-            DispatchResult::DurableEventTaskFailed => return Err(NativeV2SupervisorError::Task),
             DispatchResult::Completed(_)
             | DispatchResult::TimedOut
             | DispatchResult::Interrupted => {}
@@ -98,7 +97,6 @@ pub(super) enum DispatchResult {
     TimedOut,
     Interrupted,
     DurableEventFailure(RunLedgerError),
-    DurableEventTaskFailed,
 }
 
 pub(super) struct FinishedDispatch {
@@ -131,29 +129,8 @@ pub(super) async fn run_dispatch(task: DispatchTask) -> FinishedDispatch {
     let started = tokio::time::Instant::now();
     let reference = handle.reference().clone();
     let execution = reference.execution;
-    let events = tokio::spawn(bridge_durable_events(ledger, run_id, execution, output));
-    let interrupt = async {
-        tokio::select! {
-            _ = crate::execution::process::wait_for_deadline(
-                timeout.map(|duration| tokio::time::Instant::now() + duration),
-            ) => DispatchResult::TimedOut,
-            _ = cancel => DispatchResult::Interrupted,
-        }
-    };
-    tokio::pin!(interrupt);
-    let result = tokio::select! {
-        completion = handle.completion() => DispatchResult::Completed(completion),
-        interrupt = &mut interrupt => {
-            handle.cancel();
-            let _ = handle.completion().await;
-            interrupt
-        }
-    };
-    let result = match events.await {
-        Ok(Ok(())) => result,
-        Ok(Err(error)) => DispatchResult::DurableEventFailure(error),
-        Err(_) => DispatchResult::DurableEventTaskFailed,
-    };
+    let events = bridge_durable_events(ledger, run_id, execution, output);
+    let result = observe_dispatch(&mut handle, events, timeout, cancel).await;
     if let Some(registration) = registration {
         registration.close().await;
     }
@@ -162,6 +139,52 @@ pub(super) async fn run_dispatch(task: DispatchTask) -> FinishedDispatch {
         execution,
         reference,
         result,
+    }
+}
+
+async fn observe_dispatch(
+    handle: &mut NodeHandle,
+    events: impl std::future::Future<Output = Result<(), RunLedgerError>>,
+    timeout: Option<Duration>,
+    cancel: oneshot::Receiver<ExecutionInterrupt>,
+) -> DispatchResult {
+    let interrupt = async {
+        tokio::select! {
+            _ = crate::execution::process::wait_for_deadline(
+                timeout.map(|duration| tokio::time::Instant::now() + duration),
+            ) => DispatchResult::TimedOut,
+            _ = cancel => DispatchResult::Interrupted,
+        }
+    };
+    tokio::pin!(interrupt, events);
+    let mut interrupted = None;
+    let mut output_result = None;
+    let result = loop {
+        tokio::select! {
+            completion = handle.completion() => break DispatchResult::Completed(completion),
+            interrupt = &mut interrupt, if interrupted.is_none() => {
+                handle.cancel();
+                interrupted = Some(interrupt);
+            }
+            persisted = &mut events, if output_result.is_none() => {
+                let failed = persisted.is_err();
+                output_result = Some(persisted);
+                if failed {
+                    // Persistence owns failure now. A silent provider may never emit again, so
+                    // cancel immediately. Keep polling completion and output together so cancellation
+                    // cannot deadlock a provider that emits final usage through a bounded queue.
+                    handle.cancel();
+                }
+            }
+        }
+    };
+    let output_result = match output_result {
+        Some(result) => result,
+        None => events.await,
+    };
+    match output_result {
+        Ok(()) => interrupted.unwrap_or(result),
+        Err(error) => DispatchResult::DurableEventFailure(error),
     }
 }
 
@@ -392,7 +415,6 @@ pub(super) fn settled_outcome(
         DispatchResult::TimedOut => Ok(WorkerOutcome::declared_failure(WorkerErrorCode::Timeout)),
         DispatchResult::Interrupted => Ok(WorkerOutcome::declared_failure(WorkerErrorCode::Crash)),
         DispatchResult::DurableEventFailure(error) => Err(error.into()),
-        DispatchResult::DurableEventTaskFailed => Err(NativeV2SupervisorError::Task),
     }
 }
 

--- a/zeroshot/src/v2_run_ledger.rs
+++ b/zeroshot/src/v2_run_ledger.rs
@@ -331,6 +331,8 @@ pub enum RunLedgerError {
     InvalidEvent(&'static str),
     #[error("run ledger storage is unavailable")]
     Storage,
+    #[error("run ledger SQLite storage failed: {0}")]
+    SqliteStorage(rusqlite::ffi::Error),
     #[error("run ledger storage is corrupt")]
     Corrupt,
 }

--- a/zeroshot/src/v2_run_ledger/sqlite.rs
+++ b/zeroshot/src/v2_run_ledger/sqlite.rs
@@ -38,19 +38,17 @@ pub struct SqliteRunLedger {
 
 impl SqliteRunLedger {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, RunLedgerError> {
-        let connection = Connection::open(path).map_err(|_| RunLedgerError::Storage)?;
+        let connection = Connection::open(path).map_err(sqlite_error)?;
         Self::from_connection(connection)
     }
 
     pub fn open_in_memory() -> Result<Self, RunLedgerError> {
-        let connection = Connection::open_in_memory().map_err(|_| RunLedgerError::Storage)?;
+        let connection = Connection::open_in_memory().map_err(sqlite_error)?;
         Self::from_connection(connection)
     }
 
     fn from_connection(connection: Connection) -> Result<Self, RunLedgerError> {
-        connection
-            .execute_batch(SCHEMA)
-            .map_err(|_| RunLedgerError::Storage)?;
+        connection.execute_batch(SCHEMA).map_err(sqlite_error)?;
         Ok(Self {
             connection: Arc::new(Mutex::new(connection)),
         })
@@ -70,12 +68,12 @@ impl RunLedger for SqliteRunLedger {
         let mut connection = self.connection();
         let transaction = connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
-            .map_err(|_| RunLedgerError::Storage)?;
+            .map_err(sqlite_error)?;
         let outcome = match existing_submission(&transaction, &request)? {
             Some(existing) => CreateRunOutcome::Existing(existing),
             None => CreateRunOutcome::Created(insert_new_run(&transaction, request)?),
         };
-        transaction.commit().map_err(|_| RunLedgerError::Storage)?;
+        transaction.commit().map_err(sqlite_error)?;
         Ok(outcome)
     }
 
@@ -95,14 +93,13 @@ impl RunLedger for SqliteRunLedger {
         let connection = self.connection();
         let mut statement = connection
             .prepare("SELECT stored_json FROM v2_runs ORDER BY rowid")
-            .map_err(|_| RunLedgerError::Storage)?;
+            .map_err(sqlite_error)?;
         let rows = statement
             .query_map([], |row| row.get::<_, String>(0))
-            .map_err(|_| RunLedgerError::Storage)?;
+            .map_err(sqlite_error)?;
         rows.map(|row| {
-            let stored: StoredRun =
-                serde_json::from_str(&row.map_err(|_| RunLedgerError::Storage)?)
-                    .map_err(|_| RunLedgerError::Corrupt)?;
+            let stored: StoredRun = serde_json::from_str(&row.map_err(sqlite_error)?)
+                .map_err(|_| RunLedgerError::Corrupt)?;
             Ok(RunSummary::from(&stored.snapshot))
         })
         .collect()
@@ -116,9 +113,9 @@ impl RunLedger for SqliteRunLedger {
         let mut connection = self.connection();
         let transaction = connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
-            .map_err(|_| RunLedgerError::Storage)?;
+            .map_err(sqlite_error)?;
         let result = append_transaction(&transaction, run_id, events)?;
-        transaction.commit().map_err(|_| RunLedgerError::Storage)?;
+        transaction.commit().map_err(sqlite_error)?;
         Ok(result)
     }
 
@@ -126,7 +123,7 @@ impl RunLedger for SqliteRunLedger {
         let mut connection = self.connection();
         let transaction = connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
-            .map_err(|_| RunLedgerError::Storage)?;
+            .map_err(sqlite_error)?;
         let stored = load_by_id(&transaction, run_id)?.ok_or(RunLedgerError::RunNotFound)?;
         let result = if stored.snapshot.force_stop_requested || stored.snapshot.terminal.is_some() {
             AppendResult {
@@ -136,7 +133,7 @@ impl RunLedger for SqliteRunLedger {
         } else {
             append_transaction(&transaction, run_id, vec![RunEvent::ForceStopRequested])?
         };
-        transaction.commit().map_err(|_| RunLedgerError::Storage)?;
+        transaction.commit().map_err(sqlite_error)?;
         Ok(result)
     }
 
@@ -160,15 +157,15 @@ impl RunLedger for SqliteRunLedger {
                 "SELECT sequence, event_json FROM v2_run_events
                  WHERE run_id = ?1 AND sequence > ?2 ORDER BY sequence",
             )
-            .map_err(|_| RunLedgerError::Storage)?;
+            .map_err(sqlite_error)?;
         let rows = statement
             .query_map(params![run_id.as_str(), after], |row| {
                 Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
             })
-            .map_err(|_| RunLedgerError::Storage)?;
+            .map_err(sqlite_error)?;
         let events = rows
             .map(|row| {
-                let (sequence, json) = row.map_err(|_| RunLedgerError::Storage)?;
+                let (sequence, json) = row.map_err(sqlite_error)?;
                 let sequence = u64::try_from(sequence).map_err(|_| RunLedgerError::Corrupt)?;
                 let event = serde_json::from_str(&json).map_err(|_| RunLedgerError::Corrupt)?;
                 Ok(StoredRunEvent {
@@ -259,7 +256,7 @@ fn insert_event(
             "INSERT INTO v2_run_events (run_id, sequence, event_json) VALUES (?1, ?2, ?3)",
             params![run_id.as_str(), sequence as i64, event_json],
         )
-        .map_err(|_| RunLedgerError::Storage)?;
+        .map_err(sqlite_error)?;
     Ok(())
 }
 
@@ -275,7 +272,7 @@ fn update_stored_run(
             "UPDATE v2_runs SET cursor = ?2, stored_json = ?3 WHERE run_id = ?1",
             params![run_id.as_str(), sequence as i64, stored_json],
         )
-        .map_err(|_| RunLedgerError::Storage)?;
+        .map_err(sqlite_error)?;
     if changed != 1 {
         return Err(RunLedgerError::Corrupt);
     }
@@ -336,7 +333,7 @@ fn insert_new_run(
                 stored_json,
             ],
         )
-        .map_err(|_| RunLedgerError::Storage)?;
+        .map_err(sqlite_error)?;
     Ok(stored)
 }
 
@@ -351,7 +348,7 @@ fn load_by_id(
             |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
         )
         .optional()
-        .map_err(|_| RunLedgerError::Storage)?;
+        .map_err(sqlite_error)?;
     row.map(|(cursor, json)| decode_stored(run_id, cursor, &json))
         .transpose()
 }
@@ -375,7 +372,7 @@ fn load_by_submission(
             },
         )
         .optional()
-        .map_err(|_| RunLedgerError::Storage)?;
+        .map_err(sqlite_error)?;
     row.map(|(run_id, digest, cursor, json)| {
         let stored = decode_stored(&RunId::new(run_id.clone()), cursor, &json)?;
         Ok((run_id, digest, stored))
@@ -396,4 +393,48 @@ fn decode_stored(
         return Err(RunLedgerError::Corrupt);
     }
     Ok(stored)
+}
+
+fn sqlite_error(error: rusqlite::Error) -> RunLedgerError {
+    match error {
+        rusqlite::Error::SqliteFailure(code, _) => RunLedgerError::SqliteStorage(code),
+        _ => RunLedgerError::Storage,
+    }
+}
+
+#[cfg(test)]
+mod storage_failure_tests {
+    use super::*;
+    use openengine_cluster_testkit::assertions::AssertValue;
+
+    #[test]
+    fn a_full_sqlite_database_retains_its_machine_error() {
+        let connection = Connection::open_in_memory().assert_value();
+        connection
+            .pragma_update(None, "max_page_count", 1)
+            .assert_value();
+        let result = SqliteRunLedger::from_connection(connection);
+        let Err(RunLedgerError::SqliteStorage(code)) = result else {
+            panic!("expected SQLite capacity failure");
+        };
+        assert_eq!(code.extended_code, rusqlite::ffi::SQLITE_FULL);
+        assert!(
+            RunLedgerError::SqliteStorage(code)
+                .to_string()
+                .contains("database is full")
+        );
+    }
+
+    #[test]
+    fn sqlite_diagnostics_exclude_arbitrary_input_text() {
+        let error = sqlite_error(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_IOERR_WRITE),
+            Some("secret trigger input".to_owned()),
+        ));
+        let message = error.to_string();
+        assert!(message.contains(&rusqlite::ffi::SQLITE_IOERR_WRITE.to_string()));
+        assert!(!message.contains("secret"));
+        assert!(matches!(error, RunLedgerError::SqliteStorage(code)
+            if code.extended_code == rusqlite::ffi::SQLITE_IOERR_WRITE));
+    }
 }


### PR DESCRIPTION
Hosted verification can fail to compile in the candidate workspace and leave execution homes behind. A supervisor or ledger error can then leave the run showing as active after its provider has gone away.

Give each hosted verifier a writable disposable copy of the candidate, including existing build artifacts, and executable scratch. Remove managed execution files after confirmed process cleanup while preserving homes for authorized session reuse.

Catch fatal supervisor errors and task panics, cancel and drain owned work, and retain a failed status when the ledger cannot write it. Keep the original failure in private diagnostics, including SQLite error codes; unavailable history reports `SOURCE_UNAVAILABLE` without inventing events or cursors.

When a process exits during `/proc` inspection, treat its vanished metadata as absent so a successful provider turn does not trigger a false cleanup failure. Permission and unrelated I/O errors remain failures.

Validation passed: 1,177 workspace tests; three privileged Linux checks for UID isolation, local-fixture build reuse and HOME cleanup; strict workspace Clippy/rustdoc; formatting and protocol generation checks; Python SDK checks (38 tests); strict MkDocs; and repository tooling (28 tests). The Codex correction regression also passed 400 parallel repetitions after the procfs fix. Five existing manual stress/live-provider tests remain ignored.

A separate registry-dependency probe found that fresh `CARGO_HOME` paths still force Cargo rebuilds (`PathToSourceChanged`), even with intact copied artifacts. The filesystem fix enables writable verification and cleanup; registry-cache reuse remains a measured limitation for follow-up discussion.

Opcore Verify passed. Sense reported no findings with partial language coverage; compiler checks, tests and independent source review also passed.
